### PR TITLE
hardening/374_hdfs_parameters

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+OrionHDFSSink parameters are now called as "hdfs_*" instead of "cosmos_*" (#374)

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The body simply contains a byte representation of the HTTP payload that will be 
 
 [HDFS organizes](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html#The_File_System_Namespace) the data in folders containinig big data files. Such organization is exploited by [`OrionHDFSSink`](doc/design/OrionHDFSSink.md) each time a Flume event is taken from its channel.
 
-Assuming `cosmos_default_username=myuser`, `service_as_namespace=false` and `attr_persistence=row` as configuration parameters, then the data within the body will be persisted as:
+Assuming `hdfs_username=myuser`, `service_as_namespace=false` and `attr_persistence=row` as configuration parameters, then the data within the body will be persisted as:
 
     $ hadoop fs -cat /user/myuser/vehicles/4wheels/car1_car/car1_car.txt
     {"recvTimeTs":"1429535775","recvTime":"2015-04-20T12:13:22.41.124Z","entityId":"car1","entityType":"car","attrName":"speed","attrType":"float","attrValue":"112.9","attrMd":[]}
@@ -716,16 +716,16 @@ cygnusagent.sources.http-source.interceptors.de.matching_table = /usr/cygnus/con
 cygnusagent.sinks.hdfs-sink.channel = hdfs-channel
 # sink class, must not be changed
 cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.OrionHDFSSink
-# Comma-separated list of FQDN/IP address regarding the Cosmos Namenode endpoints
+# Comma-separated list of FQDN/IP address regarding the HDFS Namenode endpoints
 # If you are using Kerberos authentication, then the usage of FQDNs instead of IP addresses is mandatory
-cygnusagent.sinks.hdfs-sink.cosmos_host = x1.y1.z1.w1,x2.y2.z2.w2
-# port of the Cosmos service listening for persistence operations; 14000 for httpfs, 50070 for webhdfs and free choice for inifinty
-cygnusagent.sinks.hdfs-sink.cosmos_port = 14000
-# default username allowed to write in HDFS
-cygnusagent.sinks.hdfs-sink.cosmos_default_username = cosmos_username
-# default password for the default username
-cygnusagent.sinks.hdfs-sink.cosmos_default_password = xxxxxxxxxxxxx
-# HDFS backend type (webhdfs, httpfs or infinity)
+cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
+# port of the HDFS service listening for persistence operations; 14000 for httpfs, 50070 for webhdfs
+cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
+# username allowed to write in HDFS
+cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
+# password for the username
+cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
+# HDFS backend type (webhdfs or httpfs)
 cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
 # how the attributes are stored, either per row either per column (row, column)
 cygnusagent.sinks.hdfs-sink.attr_persistence = column

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -64,15 +64,15 @@ cygnusagent.sources.http-source.interceptors.de.matching_table = /usr/cygnus/con
 cygnusagent.sinks.hdfs-sink.channel = hdfs-channel
 # sink class, must not be changed
 cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.OrionHDFSSink
-# Comma-separated list of FQDN/IP address regarding the Cosmos Namenode endpoints
+# Comma-separated list of FQDN/IP address regarding the HDFS Namenode endpoints
 # If you are using Kerberos authentication, then the usage of FQDNs instead of IP addresses is mandatory
-cygnusagent.sinks.hdfs-sink.cosmos_host = x1.y1.z1.w1,x2.y2.z2.w2
-# port of the Cosmos service listening for persistence operations; 14000 for httpfs, 50070 for webhdfs and free choice for inifinty
-cygnusagent.sinks.hdfs-sink.cosmos_port = 14000
-# default username allowed to write in HDFS
-cygnusagent.sinks.hdfs-sink.cosmos_default_username = cosmos_username
-# default password for the default username
-cygnusagent.sinks.hdfs-sink.cosmos_default_password = xxxxxxxxxxxxx
+cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
+# port of the HDFS service listening for persistence operations; 14000 for httpfs, 50070 for webhdfs
+cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
+# username allowed to write in HDFS
+cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
+# password for the username
+cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
 # HDFS backend type (webhdfs, httpfs or infinity)
 cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
 # how the attributes are stored, either per row either per column (row, column)

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -8,7 +8,7 @@ Independently of the data generator, NGSI context data is always [transformed](f
 [HDFS organizes](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html#The_File_System_Namespace) the data in folders containinig big data files. Such organization is exploited by `OrionHDFSSink` each time a Flume event is taken, by performing the following workflow:
 
 1. The bytes within the event's body are parsed and a `NotifyContextRequest` object container is created.
-2. According to the [naming conventions](naming_convetions.md), a folder called `/user/<cosmos_default_userame>/<fiware-service>/<fiware-servicePath>/<destination>` is created (if not existing yet), where `<cosmos_default_username>` is a configuration parameter, and `<fiware_service>`, `<fiware-servicePath>` and `<destination>` values are got from the event headers.
+2. According to the [naming conventions](naming_convetions.md), a folder called `/user/<hdfs_userame>/<fiware-service>/<fiware-servicePath>/<destination>` is created (if not existing yet), where `<hdfs_username>` is a configuration parameter, and `<fiware_service>`, `<fiware-servicePath>` and `<destination>` values are got from the event headers.
 3. The context responses/entities within the container are iterated, and a file called `<destination>.txt` is created (if not yet existing), where `<destination>` value is got from the event headers.
 4. The context attributes within each context response/entity are iterated, and a new Json line (or lines) is appended to the current file. The format for this append depends on the configured persistence mode:
     * `row`: A Json line is added for each notified context attribute. This kind of line will always contain 8 fields:
@@ -61,7 +61,7 @@ Assuming the following Flume event is created from a notified NGSI context data 
 	    }
     }
 
-Assuming `cosmos_default_username=myuser`, `service_as_namespace=false` and `attr_persistence=row` as configuration parameters, then `OrionHDFSSink` will persist the data within the body as:
+Assuming `hdfs_username=myuser`, `service_as_namespace=false` and `attr_persistence=row` as configuration parameters, then `OrionHDFSSink` will persist the data within the body as:
 
     $ hadoop fs -cat /user/myuser/vehicles/4wheels/car1_car/car1_car.txt
     {"recvTimeTs":"1429535775","recvTime":"2015-04-20T12:13:22.41.124Z","entityId":"car1","entityType":"car","attrName":"speed","attrType":"float","attrValue":"112.9","attrMd":[]}
@@ -95,11 +95,15 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 |---|---|---|---|
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.OrionHDFSSink</i> |
 | channel | yes | N/A |
-| cosmos_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run |
-| cosmos_port | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS |
-| cosmos\_default\_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
-| cosmos\_default\_password | yes | N/A |
-| service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `cosmos_default_username`, which in this case must be a HDFS superuser |
+| hdfs_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run |
+| cosmos_host<br>(**deprecated**)| no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run |
+| hdfs_port | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS |
+| cosmos_port<br>(**deprecated**) | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS |
+| hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
+| cosmos\_default\_username<br>(**deprecated**) | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
+| hdfs_password | yes | N/A |
+| cosmos\_default\_password<br>(**deprecated**) | yes | N/A |
+| service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
 | hdfs_api | no | httpfs | <i>httpfs</i> if using the HttpFS gateway or <i>webhdfs</i> if using the standard WebHDFS |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>
 | hive_host | no | localhost |
@@ -117,10 +121,10 @@ A configuration example could be:
     ...
     cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.OrionHDFSSink
     cygnusagent.sinks.hdfs-sink.channel = hdfs-channel
-    cygnusagent.sinks.hdfs-sink.cosmos_host = 192.168.80.34
-    cygnusagent.sinks.hdfs-sink.cosmos_port = 14000
-    cygnusagent.sinks.hdfs-sink.cosmos_default_username = myuser
-    cygnusagent.sinks.hdfs-sink.cosmos_default_password = mypassword
+    cygnusagent.sinks.hdfs-sink.hdfs_host = 192.168.80.34
+    cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
+    cygnusagent.sinks.hdfsƒsink.hdfs_username = myuser
+    cygnusagent.sinks.hdfs-sink.hdfs_password = mypassword
     cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
     cygnusagent.sinks.hdfs-sink.attr_persistence = column
     cygnusagent.sinks.hdfs-sink.hive_host = 192.168.80.35

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -96,23 +96,23 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.OrionHDFSSink</i> |
 | channel | yes | N/A |
 | hdfs_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run |
-| cosmos_host<br>(**deprecated**)| no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run |
+| cosmos_host<br>(**deprecated**)| no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run.<br>Still usable; if both are configured, `hdfs_host` is preferred |
 | hdfs_port | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS |
-| cosmos_port<br>(**deprecated**) | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS |
+| cosmos_port<br>(**deprecated**) | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS.<br>Still usable; if both are configured, `hdfs_port` is preferred |
 | hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
-| cosmos\_default\_username<br>(**deprecated**) | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
+| cosmos\_default\_username<br>(**deprecated**) | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser.<br>Still usable; if both are configured, `hdfs_username` is preferred |
 | hdfs_password | yes | N/A |
-| cosmos\_default\_password<br>(**deprecated**) | yes | N/A |
+| cosmos\_default\_password<br>(**deprecated**) | yes | N/A | Still usable; if both are configured, `hdfs_password` is preferred |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
 | hdfs_api | no | httpfs | <i>httpfs</i> if using the HttpFS gateway or <i>webhdfs</i> if using the standard WebHDFS |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>
 | hive_host | no | localhost |
 | hive_port | no | 10000 |
 | krb5_auth | no | false |
-| krb5_user | yes | <i>empty</i> | Ignored if <i>krb5_auth=false</i>, mandatory otherwise |
-| krb5_password | yes | <i>empty</i> | Ignored if <i>krb5_auth=false</i>, mandatory otherwise |
-| krb5\_login\_conf\_file | no | /usr/cygnus/conf/krb5_login.conf | Ignored if <i>krb5_auth=false</i> |
-| krb5\_conf\_file | no | /usr/cygnus/conf/krb5.conf | Ignored if <i>krb5_auth=false</i> |
+| krb5_user | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise |
+| krb5_password | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise |
+| krb5\_login\_conf\_file | no | /usr/cygnus/conf/krb5_login.conf | Ignored if `krb5_auth=false` |
+| krb5\_conf\_file | no | /usr/cygnus/conf/krb5.conf | Ignored if `krb5_auth=false` |
 
 A configuration example could be:
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -76,10 +76,10 @@ import org.apache.flume.Context;
 public class OrionHDFSSink extends OrionSink {
 
     private static final CygnusLogger LOGGER = new CygnusLogger(OrionHDFSSink.class);
-    private String[] cosmosHost;
-    private String cosmosPort;
-    private String cosmosDefaultUsername;
-    private String cosmosDefaultPassword;
+    private String[] host;
+    private String port;
+    private String username;
+    private String password;
     private String hdfsAPI;
     private boolean rowAttrPersistence;
     private String hiveHost;
@@ -104,7 +104,7 @@ public class OrionHDFSSink extends OrionSink {
      * @return The Cosmos host
      */
     protected String[] getCosmosHost() {
-        return cosmosHost;
+        return host;
     } // getCosmosHost
     
     /**
@@ -112,7 +112,7 @@ public class OrionHDFSSink extends OrionSink {
      * @return The Cosmos port
      */
     protected String getCosmosPort() {
-        return cosmosPort;
+        return port;
     } // getCosmosPort
 
     /**
@@ -120,7 +120,7 @@ public class OrionHDFSSink extends OrionSink {
      * @return The default Cosmos username
      */
     protected String getCosmosDefaultUsername() {
-        return cosmosDefaultUsername;
+        return username;
     } // getCosmosDefaultUsername
     
     /**
@@ -129,7 +129,7 @@ public class OrionHDFSSink extends OrionSink {
      * @return The Cosmos password for the detault Cosmos username
      */
     protected String getCosmosDefaultPassword() {
-        return cosmosDefaultPassword;
+        return password;
     } // getCosmosDefaultPassword
     
     /**
@@ -166,18 +166,65 @@ public class OrionHDFSSink extends OrionSink {
        
     @Override
     public void configure(Context context) {
-        cosmosHost = context.getString("cosmos_host", "localhost").split(",");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_host=" + Arrays.toString(cosmosHost)
-                + ")");
-        cosmosPort = context.getString("cosmos_port", "14000");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + cosmosPort + ")");
-        cosmosDefaultUsername = context.getString("cosmos_default_username", "defaultCygnus");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_default_username="
-                + cosmosDefaultUsername + ")");
+        String cosmosHost = context.getString("cosmos_host");
+        String hdfsHost = context.getString("hdfs_host");
+        
+        if (hdfsHost != null && hdfsHost.length() > 0) {
+            host = hdfsHost.split(",");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_host=" + Arrays.toString(host)
+                    + ")");
+        } else if (cosmosHost != null && cosmosHost.length() > 0) {
+            host = cosmosHost.split(",");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_host=" + Arrays.toString(host)
+                    + ")");
+        } else {
+            host = new String[]{"localhost"};
+            LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_host=localhost");
+        } // if else
+        
+        String cosmosPort = context.getString("cosmos_port");
+        String hdfsPort = context.getString("hdfs_port");
+        
+        if (hdfsPort != null && hdfsPort.length() > 0) {
+            port = hdfsPort;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_port=" + port + ")");
+        } else if (cosmosPort != null && cosmosPort.length() > 0) {
+            port = cosmosPort;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + port + ")");
+        } else {
+            port = "14000";
+            LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_port=14000");
+        }
+        
+        String cosmosDefaultUsername = context.getString("cosmos_default_username");
+        String hdfsUsername = context.getString("hdfs_username");
+        
+        if (hdfsUsername != null && hdfsUsername.length() > 0) {
+            username = hdfsUsername;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_username=" + username + ")");
+        } else if (cosmosDefaultUsername != null && cosmosDefaultUsername.length() > 0) {
+            username = cosmosDefaultUsername;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_default_username=" + username + ")");
+        } else {
+            LOGGER.error("[" + this.getName() + "] No username provided. Cygnus can continue, but HDFS sink will not "
+                    + "properly work!");
+        } // if else
+        
         // FIXME: cosmosPassword should be read as a SHA1 and decoded here
-        cosmosDefaultPassword = context.getString("cosmos_default_password", "");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_default_password="
-                + cosmosDefaultPassword + ")");
+        String cosmosDefaultPassword = context.getString("cosmos_default_password");
+        String hdfsPassword = context.getString("hdfs_password");
+        
+        if (hdfsPassword != null && hdfsPassword.length() > 0) {
+            password = hdfsPassword;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_password=" + password + ")");
+        } else if (cosmosDefaultPassword != null && cosmosDefaultPassword.length() > 0) {
+            password = cosmosDefaultPassword;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_default_password=" + password + ")");
+        } else {
+            LOGGER.error("[" + this.getName() + "] No password provided. Cygnus can continue, but HDFS sink will not "
+                    + "properly work!");
+        } // if else
+        
         hdfsAPI = context.getString("hdfs_api", "httpfs");
         
         if (!hdfsAPI.equals("webhdfs") && !hdfsAPI.equals("httpfs")) {
@@ -217,14 +264,12 @@ public class OrionHDFSSink extends OrionSink {
         try {
             // create the persistence backend
             if (hdfsAPI.equals("httpfs")) {
-                persistenceBackend = new HDFSBackendImpl(cosmosHost, cosmosPort, cosmosDefaultUsername,
-                        cosmosDefaultPassword, hiveHost, hivePort, krb5, krb5User, krb5Password, krb5LoginConfFile,
-                        krb5ConfFile, serviceAsNamespace);
+                persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
+                        krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
                 LOGGER.debug("[" + this.getName() + "] HttpFS persistence backend created");
             } else if (hdfsAPI.equals("webhdfs")) {
-                persistenceBackend = new HDFSBackendImpl(cosmosHost, cosmosPort, cosmosDefaultUsername,
-                        cosmosDefaultPassword, hiveHost, hivePort, krb5, krb5User, krb5Password, krb5LoginConfFile,
-                        krb5ConfFile, serviceAsNamespace);
+                persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
+                        krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
                 LOGGER.debug("[" + this.getName() + "] WebHDFS persistence backend created");
             } else {
                 // this point should never be reached since the HDFS API has been checked while configuring the sink
@@ -274,7 +319,7 @@ public class OrionHDFSSink extends OrionSink {
             // check if the fileName exists in HDFS right now, i.e. when its attrName has been got
             boolean fileExists = false;
             
-            if (persistenceBackend.exists(cosmosDefaultUsername, hdfsFile)) {
+            if (persistenceBackend.exists(username, hdfsFile)) {
                 fileExists = true;
             } // if
             
@@ -324,11 +369,11 @@ public class OrionHDFSSink extends OrionSink {
                     // and mark as existing (this avoids checking if the fileName exists each time a Json document is
                     // going to be persisted)
                     if (fileExists) {
-                        persistenceBackend.append(cosmosDefaultUsername, hdfsFile, rowLine);
+                        persistenceBackend.append(username, hdfsFile, rowLine);
                     } else {
-                        persistenceBackend.createDir(cosmosDefaultUsername, hdfsFolder);
-                        persistenceBackend.createFile(cosmosDefaultUsername, hdfsFile, rowLine);
-                        persistenceBackend.provisionHiveTable(cosmosDefaultUsername, hdfsFolder);
+                        persistenceBackend.createDir(username, hdfsFolder);
+                        persistenceBackend.createFile(username, hdfsFile, rowLine);
+                        persistenceBackend.provisionHiveTable(username, hdfsFolder);
                         fileExists = true;
                     } // if else
                 } else {
@@ -347,11 +392,11 @@ public class OrionHDFSSink extends OrionSink {
                         + "), Data (" + columnLine + ")");
                 
                 if (fileExists) {
-                    persistenceBackend.append(cosmosDefaultUsername, hdfsFile, columnLine);
+                    persistenceBackend.append(username, hdfsFile, columnLine);
                 } else {
-                    persistenceBackend.createDir(cosmosDefaultUsername, hdfsFolder);
-                    persistenceBackend.createFile(cosmosDefaultUsername, hdfsFile, columnLine);
-                    persistenceBackend.provisionHiveTable(cosmosDefaultUsername, hdfsFolder, hiveFields);
+                    persistenceBackend.createDir(username, hdfsFolder);
+                    persistenceBackend.createFile(username, hdfsFile, columnLine);
+                    persistenceBackend.provisionHiveTable(username, hdfsFolder, hiveFields);
                     fileExists = true;
                 } // if else
             } // if


### PR DESCRIPTION
* Fixes issue #374 
* 100% unit tests passed:
```
Results :
Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
2015-05-11T10:29:10.711CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[174] : [hdfs-sink] Reading configuration (hdfs_host=[130.206.80.46])
2015-05-11T10:29:10.711CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[190] : [hdfs-sink] Reading configuration (hdfs_port=14000)
2015-05-11T10:29:10.711CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[204] : [hdfs-sink] Reading configuration (hdfs_username=hdfs)
2015-05-11T10:29:10.711CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[219] : [hdfs-sink] Reading configuration (hdfs_password=xxxxxxxxxxxxx)
```
* Assignee @iariasleon 