### PR TITLE
hardening/415_hdfs_api_parameter

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 [FEATURE] Add a permament connection to the MySQL Backend (#364)
 [BUG] Add the original (and removed by OrionRESTHandler) slash character to fiware-servicePath (#403)
 [BUG] Set the Fiware-Service and Fiware-ServicePath maximum lenght to 50 characters (previously, it was 32 characters) (#406)
+[HARDENING] Remove unnecessary hfds_api parameter in OrionHDFSSink (#415)

--- a/README.md
+++ b/README.md
@@ -725,8 +725,6 @@ cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
 # password for the username
 cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
-# HDFS backend type (webhdfs or httpfs)
-cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
 # how the attributes are stored, either per row either per column (row, column)
 cygnusagent.sinks.hdfs-sink.attr_persistence = column
 # Hive FQDN/IP address of the Hive server

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -73,8 +73,6 @@ cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
 # password for the username
 cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
-# HDFS backend type (webhdfs, httpfs or infinity)
-cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
 # how the attributes are stored, either per row either per column (row, column)
 cygnusagent.sinks.hdfs-sink.attr_persistence = column
 # Hive FQDN/IP address of the Hive server

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -104,7 +104,6 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | hdfs_password | yes | N/A |
 | cosmos\_default\_password<br>(**deprecated**) | yes | N/A | Still usable; if both are configured, `hdfs_password` is preferred |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
-| hdfs_api | no | httpfs | <i>httpfs</i> if using the HttpFS gateway or <i>webhdfs</i> if using the standard WebHDFS |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>
 | hive_host | no | localhost |
 | hive_port | no | 10000 |
@@ -125,7 +124,6 @@ A configuration example could be:
     cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
     cygnusagent.sinks.hdfsƒsink.hdfs_username = myuser
     cygnusagent.sinks.hdfs-sink.hdfs_password = mypassword
-    cygnusagent.sinks.hdfs-sink.hdfs_api = httpfs
     cygnusagent.sinks.hdfs-sink.attr_persistence = column
     cygnusagent.sinks.hdfs-sink.hive_host = 192.168.80.35
     cygnusagent.sinks.hdfs-sink.hive_port = 10000

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -80,7 +80,6 @@ public class OrionHDFSSink extends OrionSink {
     private String port;
     private String username;
     private String password;
-    private String hdfsAPI;
     private boolean rowAttrPersistence;
     private String hiveHost;
     private String hivePort;
@@ -131,14 +130,6 @@ public class OrionHDFSSink extends OrionSink {
     protected String getCosmosDefaultPassword() {
         return password;
     } // getCosmosDefaultPassword
-    
-    /**
-     * Gets the HDFS API. It is protected due to it is only required for testing purposes.
-     * @return The HDFS API
-     */
-    protected String getHDFSAPI() {
-        return hdfsAPI;
-    } // getHDFSAPI
     
     /**
      * Gets the Hive port. It is protected due to it is only required for testing purposes.
@@ -227,16 +218,6 @@ public class OrionHDFSSink extends OrionSink {
                     + "properly work!");
         } // if else
         
-        hdfsAPI = context.getString("hdfs_api", "httpfs");
-        
-        if (!hdfsAPI.equals("webhdfs") && !hdfsAPI.equals("httpfs")) {
-            LOGGER.error("[" + this.getName() + "] Bad configuration (Unrecognized HDFS API " + hdfsAPI + ")");
-            LOGGER.info("[" + this.getName() + "] Exiting Cygnus");
-            System.exit(-1);
-        } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_api=" + hdfsAPI + ")");
-        } // if else
-        
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + (rowAttrPersistence ? "row" : "column") + ")");
@@ -265,21 +246,9 @@ public class OrionHDFSSink extends OrionSink {
     public void start() {
         try {
             // create the persistence backend
-            if (hdfsAPI.equals("httpfs")) {
-                persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
-                        krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
-                LOGGER.debug("[" + this.getName() + "] HttpFS persistence backend created");
-            } else if (hdfsAPI.equals("webhdfs")) {
-                persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
-                        krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
-                LOGGER.debug("[" + this.getName() + "] WebHDFS persistence backend created");
-            } else {
-                // this point should never be reached since the HDFS API has been checked while configuring the sink
-                LOGGER.error("[" + this.getName() + "] Bad configuration (Unrecognized HDFS API " + hdfsAPI
-                        + ")");
-                LOGGER.info("[" + this.getName() + "] Exiting Cygnus");
-                System.exit(-1);
-            } // if else if
+            persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
+                    krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
+            LOGGER.debug("[" + this.getName() + "] HDFS persistence backend created");
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         } // try catch // try catch

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -18,7 +18,6 @@
 
 package com.telefonica.iot.cygnus.sinks;
 
-import com.telefonica.iot.cygnus.sinks.OrionHDFSSink;
 import com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl;
 import static org.junit.Assert.*; // this is required by "fail" like assertions
 import static org.mockito.Mockito.*; // this is required by "when" like functions
@@ -61,7 +60,6 @@ public class OrionHDFSSinkTest {
     private final String cosmosPort = "14000";
     private final String cosmosDefaultUsername = "user1";
     private final String cosmosDefaultPassword = "pass1234";
-    private final String hdfsAPI = "httpfs";
     private final String hivePort = "10000";
     private final long recvTimeTs = 123456789;
     private final String normalServiceName = "rooms";
@@ -119,7 +117,6 @@ public class OrionHDFSSinkTest {
         context.put("cosmos_port", cosmosPort);
         context.put("cosmos_default_username", cosmosDefaultUsername);
         context.put("cosmos_default_password", cosmosDefaultPassword);
-        context.put("hdfs_api", hdfsAPI);
         context.put("hive_port", hivePort);
         notifyContextRequest = TestUtils.createXMLNotifyContextRequest(notifyXMLSimple);
         
@@ -143,7 +140,6 @@ public class OrionHDFSSinkTest {
         assertEquals(cosmosPort, sink.getCosmosPort());
         assertEquals(cosmosDefaultUsername, sink.getCosmosDefaultUsername());
         assertEquals(cosmosDefaultPassword, sink.getCosmosDefaultPassword());
-        assertEquals(hdfsAPI, sink.getHDFSAPI());
         assertEquals(hivePort, sink.getHivePort());
     } // testConfigure
 
@@ -162,6 +158,7 @@ public class OrionHDFSSinkTest {
 
     /**
      * Test of persist method, of class OrionHDFSSink.
+     * @throws java.lang.Exception
      */
     @Test
     public void testProcessContextResponses() throws Exception {
@@ -186,7 +183,7 @@ public class OrionHDFSSinkTest {
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
         headers = new HashMap<String, String>();
-        headers.put("timestamp", new Long(recvTimeTs).toString());
+        headers.put("timestamp", Long.toString(recvTimeTs));
         headers.put(Constants.HEADER_SERVICE, abnormalServiceName);
         headers.put(Constants.HEADER_SERVICE_PATH, normalServicePathName);
         headers.put(Constants.DESTINATION, normalDestinationName);
@@ -202,7 +199,7 @@ public class OrionHDFSSinkTest {
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
         headers = new HashMap<String, String>();
-        headers.put("timestamp", new Long(recvTimeTs).toString());
+        headers.put("timestamp", Long.toString(recvTimeTs));
         headers.put(Constants.HEADER_SERVICE, normalServiceName);
         headers.put(Constants.HEADER_SERVICE_PATH, abnormalServicePathName);
         headers.put(Constants.DESTINATION, normalDestinationName);
@@ -218,7 +215,7 @@ public class OrionHDFSSinkTest {
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
         headers = new HashMap<String, String>();
-        headers.put("timestamp", new Long(recvTimeTs).toString());
+        headers.put("timestamp", Long.toString(recvTimeTs));
         headers.put(Constants.HEADER_SERVICE, normalServiceName);
         headers.put(Constants.HEADER_SERVICE_PATH, normalServicePathName);
         headers.put(Constants.DESTINATION, abnormalDestinationName);
@@ -234,7 +231,7 @@ public class OrionHDFSSinkTest {
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
         headers = new HashMap<String, String>();
-        headers.put("timestamp", new Long(recvTimeTs).toString());
+        headers.put("timestamp", Long.toString(recvTimeTs));
         headers.put(Constants.HEADER_SERVICE, normalServiceName);
         headers.put(Constants.HEADER_SERVICE_PATH, rootServicePathName);
         headers.put(Constants.DESTINATION, normalDestinationName);


### PR DESCRIPTION
* Fixes issue #415 
* 100% unit tests passed:
```
Results :
Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
2015-05-19T07:45:51.564CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[168] : [hdfs-sink] Reading configuration (cosmos_host=[130.206.80.46]) -- DEPRECATED, use hdfs_host instead
2015-05-19T07:45:51.564CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[183] : [hdfs-sink] Reading configuration (cosmos_port=14000) -- DEPRECATED, use hdfs_port instead
2015-05-19T07:45:51.565CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[198] : [hdfs-sink] Reading configuration (cosmos_default_username=frb) -- DEPRECATED, use hdfs_username instead
2015-05-19T07:45:51.565CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[214] : [hdfs-sink] Reading configuration (cosmos_default_password=xxxxxxxxxxxxx) -- DEPRECATED, use hdfs_password instead
2015-05-19T07:45:51.565CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[222] : [hdfs-sink] Reading configuration (attr_persistence=row)
2015-05-19T07:45:51.565CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[225] : [hdfs-sink] Reading configuration (hive_host=130.206.80.46)
2015-05-19T07:45:51.565CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[227] : [hdfs-sink] Reading configuration (hive_port=10000)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[229] : [hdfs-sink] Reading configuration (krb5_auth=false)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[232] : [hdfs-sink] Reading configuration (krb5_user=krb5_username)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[234] : [hdfs-sink] Reading configuration (krb5_password=xxxxxxxxxxxxx)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[236] : [hdfs-sink] Reading configuration (krb5_login_conf_file=)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[239] : [hdfs-sink] Reading configuration (krb5_conf_file=/usr/cygnus/conf/krb5.conf)
2015-05-19T07:45:51.566CEST | lvl=DEBUG | trans= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[241] : [hdfs-sink] Reading configuration (service_as_namespace=false)
...
$ curl -X GET "http://130.206.80.46:14000/webhdfs/v1/user/frb/zzz_serv/zzz_serv_path/room1_room/room1_room.txt?op=open&user.name=frb"
{"recvTimeTs":"1432014378","recvTime":"2015-05-19T05:46:18.361Z","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```
* Assignee @fgalan 