### PR TITLE
bug/441_mysql_time_zone

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-[BUG] Fix MySQL connections, adding a permanent connection to each database/fiware-service (#445)
+- [BUG] Fix MySQL connections, adding a permanent connection to each database/fiware-service (#445)
+- [BUG] Fix OrionMySQLSink, time zone is not added to the timestamp fields (#441)

--- a/README.md
+++ b/README.md
@@ -393,12 +393,12 @@ Assuming `mysql_username=myuser` and `attr_persistence=row` as configuration par
     1 row in set (0.00 sec)
 
     mysql> select * from 4wheels_car1_car;
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
-    | recvTimeTs | recvTime                    | entityId | entityType | attrName    | attrType  | attrValue | attrMd |
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
-    | 1429535775 | 2015-04-20T12:13:22.41.124Z | car1     | car        |  speed      | float     | 112.9     | []     |
-    | 1429535775 | 2015-04-20T12:13:22.41.124Z | car1     | car        |  oil_level  | float     | 74.6      | []     |
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    | recvTimeTs | recvTime                   | entityId | entityType | attrName    | attrType  | attrValue | attrMd |
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | car1     | car        |  speed      | float     | 112.9     | []     |
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | car1     | car        |  oil_level  | float     | 74.6      | []     |
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
     2 row in set (0.00 sec)
     
 If `attr_persistence=colum` then `OrionHDFSSink` will persist the data within the body as:
@@ -430,14 +430,17 @@ If `attr_persistence=colum` then `OrionHDFSSink` will persist the data within th
     1 row in set (0.00 sec)
 
     mysql> select * from 4wheels_car1_car;
-    +-----------------------------+-------+----------+-----------+--------------+
-    | recvTime                    | speed | speed_md | oil_level | oil_level_md |
-    +-----------------------------+-------+----------+-----------+--------------+
-    | 2015-04-20T12:13:22.41.124Z | 112.9 | []       |  74.6     | []           |
-    +-----------------------------+-------+----------+-----------+--------------+
+    +----------------------------+-------+----------+-----------+--------------+
+    | recvTime                   | speed | speed_md | oil_level | oil_level_md |
+    +----------------------------+-------+----------+-----------+--------------+
+    | 2015-04-20T12:13:22.41.124 | 112.9 | []       |  74.6     | []           |
+    +----------------------------+-------+----------+-----------+--------------+
     1 row in set (0.00 sec)
 
-NOTE: `mysql` is the MySQL CLI for querying the data.
+NOTES:
+
+* `mysql` is the MySQL CLI for querying the data.
+* Time zone information is not added in MySQL timestamps since MySQL stores that information as a environment variable. MySQL timestamps are stored in UTC time.
 
 [Top](#top)
 

--- a/doc/design/OrionMySQLSink.md
+++ b/doc/design/OrionMySQLSink.md
@@ -103,12 +103,12 @@ Assuming `mysql_username=myuser` and `attr_persistence=row` as configuration par
     1 row in set (0.00 sec)
 
     mysql> select * from 4wheels_car1_car;
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
-    | recvTimeTs | recvTime                    | entityId | entityType | attrName    | attrType  | attrValue | attrMd |
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
-    | 1429535775 | 2015-04-20T12:13:22.41.124Z | car1     | car        |  speed      | float     | 112.9     | []     |
-    | 1429535775 | 2015-04-20T12:13:22.41.124Z | car1     | car        |  oil_level  | float     | 74.6      | []     |
-    +------------+-----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    | recvTimeTs | recvTime                   | entityId | entityType | attrName    | attrType  | attrValue | attrMd |
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | car1     | car        |  speed      | float     | 112.9     | []     |
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | car1     | car        |  oil_level  | float     | 74.6      | []     |
+    +------------+----------------------------+----------+------------+-------------+-----------+-----------+--------+
     2 row in set (0.00 sec)
 
 If `attr_persistence=colum` then `OrionHDFSSink` will persist the data within the body as:
@@ -140,14 +140,17 @@ If `attr_persistence=colum` then `OrionHDFSSink` will persist the data within th
     1 row in set (0.00 sec)
 
     mysql> select * from 4wheels_car1_car;
-    +-----------------------------+-------+----------+-----------+--------------+
-    | recvTime                    | speed | speed_md | oil_level | oil_level_md |
-    +-----------------------------+-------+----------+-----------+--------------+
-    | 2015-04-20T12:13:22.41.124Z | 112.9 | []       |  74.6     | []           |
-    +-----------------------------+-------+----------+-----------+--------------+
+    +----------------------------+-------+----------+-----------+--------------+
+    | recvTime                   | speed | speed_md | oil_level | oil_level_md |
+    +----------------------------+-------+----------+-----------+--------------+
+    | 2015-04-20T12:13:22.41.124 | 112.9 | []       |  74.6     | []           |
+    +----------------------------+-------+----------+-----------+--------------+
     1 row in set (0.00 sec)
     
-NOTE: `mysql` is the MySQL CLI for querying the data.
+NOTES:
+
+* `mysql` is the MySQL CLI for querying the data.
+* Time zone information is not added in MySQL timestamps since MySQL stores that information as a environment variable. MySQL timestamps are stored in UTC time.
 
 [Top](#top)
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -146,7 +146,7 @@ public class OrionCKANSink extends OrionSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
         
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, true);
 
         // build the organization
         String orgName = buildOrgName(fiwareService);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -266,7 +266,7 @@ public class OrionHDFSSink extends OrionSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
         
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, true);
         
         // iterate on the contextResponses
         ArrayList contextResponses = notification.getContextResponses();

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -60,7 +60,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
 
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, true);
 
         // create the database for this fiwareService if not yet existing... the cost of trying to create it is the same
         // than checking if it exits and then creating it

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -158,7 +158,7 @@ public class OrionMySQLSink extends OrionSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
 
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, false);
 
         // create the database for this fiwareService if not yet existing... the cost of trying to create it is the same
         // than checking if it exits and then creating it

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -51,7 +51,7 @@ public class OrionSTHSink extends OrionMongoBaseSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
 
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, true);
 
         // create the database for this fiwareService if not yet existing... the cost of trying to create it is the same
         // than checking if it exits and then creating it

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionTestSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionTestSink.java
@@ -70,7 +70,7 @@ public class OrionTestSink extends OrionSink {
         String[] destinations = eventHeaders.get(Constants.DESTINATION).split(",");
 
         // human readable version of the reception time
-        String recvTime = Utils.getHumanReadable(recvTimeTs);
+        String recvTime = Utils.getHumanReadable(recvTimeTs, true);
         
         // log about the event headers with deliberated INFO level
         LOGGER.info("[" + this.getName() + "] Processing headers (recvTimeTs=" + recvTimeTs + " (" + recvTime

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -165,16 +165,17 @@ public final class Utils {
     /**
      * Gets the human redable version of timestamp expressed in miliseconds.
      * @param ts
+     * @param addUTC
      * @return
      */
-    public static String getHumanReadable(long ts) {
+    public static String getHumanReadable(long ts, boolean addUTC) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         String humanRedable = sdf.format(new Date(ts));
         humanRedable += "T";
         sdf = new SimpleDateFormat("HH:mm:ss.S");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        humanRedable += sdf.format(new Date(ts)) + "Z";
+        humanRedable += sdf.format(new Date(ts)) + (addUTC ? "Z" : "");
         return humanRedable;
     } // getHumanRedable
     


### PR DESCRIPTION
* Fix issue #441 
* 100% unit tests passed:
```
Results :
Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
2015-06-02T14:59:15.766CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1433249951-164-0000000000)
2015-06-02T14:59:15.769CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[236] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
2015-06-02T14:59:15.769CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[241] : Adding flume event header (name=content-type, value=application/json)
2015-06-02T14:59:15.769CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[244] : Adding flume event header (name=fiware-service, value=ccc_serv)
2015-06-02T14:59:15.770CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[247] : Adding flume event header (name=fiware-servicepath, value=ccc_serv_path)
2015-06-02T14:59:15.770CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[250] : Adding flume event header (name=transactionId, value=1433249951-164-0000000000)
2015-06-02T14:59:15.770CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[252] : Adding flume event header (name=ttl, value=2)
2015-06-02T14:59:15.772CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[258] : Event put in the channel (id=785063028, ttl=2)
2015-06-02T14:59:15.838CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=785063028, headers={fiware-servicepath=rooms, destination=test_rooms, content-type=application/json, fiware-service=ccc_serv, ttl=2, transactionId=1433249951-164-0000000000, timestamp=1433249955772}, bodyLength=460)
2015-06-02T14:59:15.841CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=persist | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[182] : [mysql-sink] Processing context element (id=Room1, type= Room)
2015-06-02T14:59:15.843CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=persist | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[221] : [mysql-sink] Processing context attribute (name=temperature, type=centigrade)
2015-06-02T14:59:15.843CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=persist | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[240] : [mysql-sink] Persisting data at OrionMySQLSink. Database: ccc_serv, Table: rooms_test_rooms, Timestamp: 2015-06-02T12:59:15.772, Data (attrs): {temperature=26.5}, (metadata): {temperature_md=[]}
2015-06-02T14:59:15.861CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=getConnection | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackend$MySQLDriver[322] : Connecting to jdbc:mysql://130.206.81.225:3306/ccc_serv?user=cb&password=XXXXXXXXXX
2015-06-02T14:59:16.669CEST | lvl=DEBUG | trans=1433249951-164-0000000000 | function=insertContextData | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackend[235] : Executing MySQL query 'insert into `rooms_test_rooms` (recvTime,temperature,temperature_md) values ('2015-06-02T12:59:15.772','26.5','[]')'
2015-06-02T14:59:16.741CEST | lvl=INFO | trans=1433249951-164-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1433249951-164-0000000000)
...
...
mysql> describe rooms_test_rooms;
+-------------+-----------+------+-----+-------------------+-----------------------------+
| Field       | Type      | Null | Key | Default           | Extra                       |
+-------------+-----------+------+-----+-------------------+-----------------------------+
| recvTime    | timestamp | NO   |     | CURRENT_TIMESTAMP | on update CURRENT_TIMESTAMP |
| temperature | double    | YES  |     | NULL              |                             |
+-------------+-----------+------+-----+-------------------+-----------------------------+
2 rows in set (0.00 sec)
mysql> select * from rooms_test_rooms;
+---------------------+-------------+----------------+
| recvTime            | temperature | temperature_md |
+---------------------+-------------+----------------+
| 2015-06-02 12:59:15 |        26.5 | []             |
+---------------------+-------------+----------------+
1 row in set (0.00 sec)
```
* Assignee @iariasleon 
