### PR TITLE
bug/449_mongo_sink_in_sth_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-[BUG] Fix MySQL connections, adding a permanent connection to each database/fiware-service (#445)
+- [BUG] Fix MySQL connections, adding a permanent connection to each database/fiware-service (#445)
+- [BUG] Fix mongo-sink appearance in sth-sink configuration (both template and README) (#449)

--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ cygnusagent.sinks.sth-sink.db_prefix = sth_
 # prefix for the MongoDB collections
 cygnusagent.sinks.sth-sink.collection_prefix = sth_
 # true is collection names are based on a hash, false for human redable collections
-cygnusagent.sinks.mongo-sink.should_hash = false
+cygnusagent.sinks.sth-sink.should_hash = false
 
 #=============================================
 # hdfs-channel configuration

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -162,7 +162,7 @@ cygnusagent.sinks.sth-sink.db_prefix = sth_
 # prefix for the MongoDB collections
 cygnusagent.sinks.sth-sink.collection_prefix = sth_
 # true is collection names are based on a hash, false for human redable collections
-cygnusagent.sinks.mongo-sink.should_hash = false
+cygnusagent.sinks.sth-sink.should_hash = false
 
 #=============================================
 # hdfs-channel configuration


### PR DESCRIPTION
* Fixes issue #449 
* No unit tests nor (unofficial) e2e tests are required.
* Assignee @iariasleon 