### PR TITLE
feature/483_oauth2_hdfssink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - [HARDENING] Link the Quick Start Guide from the README (#454)
 - [BUG] Fix the grouping rules validator, now empty fields and non-numeric ids are not allowed (#460)
 - [HARDENING] Add detailed explanation about the syntax of the grouping rules (#459)
+- [FEATURE] OAuth2 support for OrionHDFSSink (#483)

--- a/README.md
+++ b/README.md
@@ -726,8 +726,8 @@ cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
 cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 # username allowed to write in HDFS
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
-# password for the username
-cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
+# OAuth2 token
+cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxxxxxxx
 # how the attributes are stored, either per row either per column (row, column)
 cygnusagent.sinks.hdfs-sink.attr_persistence = column
 # Hive FQDN/IP address of the Hive server
@@ -903,11 +903,11 @@ Cygnus implements its own startup script, `cygnus-flume-ng` which replaces the s
 
 In foreground (with logging):
 
-    $ APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,console [-p <mgmt-if-port>] [-t <polling-interval>]
+    $ APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/agent_<id>.conf -n cygnusagent -Dflume.root.logger=INFO,console [-p <mgmt-if-port>] [-t <polling-interval>]
 
 In background:
 
-    $ nohup APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,LOGFILE [-p <mgmt-if-port>] [-t <polling-interval>] &
+    $ nohup APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/agent_<id>.conf -n cygnusagent -Dflume.root.logger=INFO,LOGFILE [-p <mgmt-if-port>] [-t <polling-interval>] &
 
 The parameters used in these commands are:
 

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -71,8 +71,8 @@ cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
 cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 # username allowed to write in HDFS
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
-# password for the username
-cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxxxxxxx
+# OAuth2 token
+cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxx
 # how the attributes are stored, either per row either per column (row, column)
 cygnusagent.sinks.hdfs-sink.attr_persistence = column
 # Hive FQDN/IP address of the Hive server

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -120,8 +120,7 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | cosmos_port<br>(**deprecated**) | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS.<br>Still usable; if both are configured, `hdfs_port` is preferred |
 | hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
 | cosmos\_default\_username<br>(**deprecated**) | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser.<br>Still usable; if both are configured, `hdfs_username` is preferred |
-| hdfs_password | yes | N/A |
-| cosmos\_default\_password<br>(**deprecated**) | yes | N/A | Still usable; if both are configured, `hdfs_password` is preferred |
+| oauth2_token | yes | N/A |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>
 | hive_host | no | localhost |
@@ -142,7 +141,7 @@ A configuration example could be:
     cygnusagent.sinks.hdfs-sink.hdfs_host = 192.168.80.34
     cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
     cygnusagent.sinks.hdfsƒsink.hdfs_username = myuser
-    cygnusagent.sinks.hdfs-sink.hdfs_password = mypassword
+    cygnusagent.sinks.hdfs-sink.oauth2_token = mytoken
     cygnusagent.sinks.hdfs-sink.attr_persistence = column
     cygnusagent.sinks.hdfs-sink.hive_host = 192.168.80.35
     cygnusagent.sinks.hdfs-sink.hive_port = 10000

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -203,8 +203,6 @@ Provisions a Hive table with data stores in column-like mode within the given HD
 [Top](#top)
 
 ###<a name="section4.3"></a>Authentication and authorization
-The sink for HDFS accepts  tokens as authentication and authorization mechanism. This can be configured through , as seen before.
-
 [OAuth2](http://oauth.net/2/) is the evolution of the OAuth protocol, an open standard for authorization. Using OAuth, client applications can access in a secure way certain server resources on behalf of the resource owner, and the best, without sharing their credentials with the service. This works because of a trusted authorization service in charge of emitting some pieces of security information: the access tokens. Once requested, the access token is attached to the service request in order the server may ask the authorization service for the validity of the user requesting the access (authentication) and the availability of the resource itself for this user (authorization).
 
 A detailed architecture of OAuth2 can be found [here](http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/PEP_Proxy_-_Wilma_-_Installation_and_Administration_Guide), but in a nutshell, FIWARE implements the above concept through the Identity Manager GE ([Keyrock](http://catalogue.fiware.org/enablers/identity-management-keyrock) implementation) and the Access Control ([AuthZForce](http://catalogue.fiware.org/enablers/authorization-pdp-authzforce) implementation); the join of this two enablers conform the OAuth2-based authorization service in FIWARE:
@@ -214,12 +212,12 @@ A detailed architecture of OAuth2 can be found [here](http://forge.fiware.org/pl
 
 This is important for Cygnus since HDFS (big) data can be accessed through the native [WebHDFS](http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html) RESTful API. And it may be protected with the above mentioned mechanism. If that's the case, simply ask for an access token and add it to the configuration through `cygnusagent.sinks.hdfs-sink.oauth2_token` parameter.
 
-In order to get an access token, do the following request to a global instance of the Identity Manager; in FIWARE Lab this is `account.lab.fiware.org`:
+In order to get an access token, do the following request to your OAuth2 tokens provider; in FIWARE Lab this is `cosmos.lab.fi-ware.org:13000`:
 
-    $ curl -X POST "https://account.lab.fiware.org/oauth2/token" -H "Authorization: Basic NGQxYWYyZWVjMzc1NDA5OWE0ZjhkYzg2YmY3MzUwNjg6Nzc5YTZlODY5MzdmNDljNzg0OTYzOGZhNTY1YmE0OGQ=" -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&username=frb@tid.es&password=xxxxxxxx”
+    $ curl -X POST "http://cosmos.lab.fi-ware.org:13000/cosmos-auth/v1/token" -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&username=frb@tid.es&password=xxxxxxxx”
     {"access_token": "qjHPUcnW6leYAqr3Xw34DWLQlja0Ix", "token_type": "Bearer", "expires_in": 3600, "refresh_token": “V2Wlk7aFCnElKlW9BOmRzGhBtqgR2z"}
 
-As you can see, your FIWARE Lab credentials are required in the payload, in the form of a password-based grant type (this will be the only time you have to give them). Another important thing is the value of the authorization header; this is the same for all the users, since it identifies the WebHDFS application in the Identity Manager (this registration step is something to be done by the HDFS administrator, not by you).
+As you can see, your FIWARE Lab credentials are required in the payload, in the form of a password-based grant type (this will be the only time you have to give them).
 
 [Top](#top)
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -123,13 +123,13 @@ public class OrionHDFSSink extends OrionSink {
     } // getCosmosDefaultUsername
     
     /**
-     * Gets the Cosmos oauth2Token for the default username. It is protected due to it is only required for testing
-     * purposes.
+     * Gets the OAuth2 token used for authentication and authorization. It is protected due to it is only required
+     * for testing purposes.
      * @return The Cosmos oauth2Token for the detault Cosmos username
      */
-    protected String getCosmosDefaultPassword() {
+    protected String getOAuth2Token() {
         return oauth2Token;
-    } // getCosmosDefaultPassword
+    } // getOAuth2Token
     
     /**
      * Gets the Hive port. It is protected due to it is only required for testing purposes.

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -79,7 +79,7 @@ public class OrionHDFSSink extends OrionSink {
     private String[] host;
     private String port;
     private String username;
-    private String password;
+    private String oauth2Token;
     private boolean rowAttrPersistence;
     private String hiveHost;
     private String hivePort;
@@ -123,12 +123,12 @@ public class OrionHDFSSink extends OrionSink {
     } // getCosmosDefaultUsername
     
     /**
-     * Gets the Cosmos password for the default username. It is protected due to it is only required for testing
+     * Gets the Cosmos oauth2Token for the default username. It is protected due to it is only required for testing
      * purposes.
-     * @return The Cosmos password for the detault Cosmos username
+     * @return The Cosmos oauth2Token for the detault Cosmos username
      */
     protected String getCosmosDefaultPassword() {
-        return password;
+        return oauth2Token;
     } // getCosmosDefaultPassword
     
     /**
@@ -202,20 +202,14 @@ public class OrionHDFSSink extends OrionSink {
                     + "properly work!");
         } // if else
         
-        // FIXME: cosmosPassword should be read as a SHA1 and decoded here
-        String cosmosDefaultPassword = context.getString("cosmos_default_password");
-        String hdfsPassword = context.getString("hdfs_password");
+        oauth2Token = context.getString("oauth2_token");
         
-        if (hdfsPassword != null && hdfsPassword.length() > 0) {
-            password = hdfsPassword;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_password=" + password + ")");
-        } else if (cosmosDefaultPassword != null && cosmosDefaultPassword.length() > 0) {
-            password = cosmosDefaultPassword;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_default_password=" + password + ")"
-                    + " -- DEPRECATED, use hdfs_password instead");
+        if (oauth2Token != null && oauth2Token.length() > 0) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (oauth2_token=" + this.oauth2Token + ")");
         } else {
-            LOGGER.error("[" + this.getName() + "] No password provided. Cygnus can continue, but HDFS sink will not "
-                    + "properly work!");
+            LOGGER.error("[" + this.getName() + "] No OAuth2 token provided. Cygnus can continue, but HDFS sink may "
+                    + "not properly work if WebHDFS service is protected with such an authentication and "
+                    + "authorization mechanism!");
         } // if else
         
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
@@ -246,7 +240,7 @@ public class OrionHDFSSink extends OrionSink {
     public void start() {
         try {
             // create the persistence backend
-            persistenceBackend = new HDFSBackendImpl(host, port, username, password, hiveHost, hivePort, krb5,
+            persistenceBackend = new HDFSBackendImpl(host, port, username, oauth2Token, hiveHost, hivePort, krb5,
                     krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
             LOGGER.debug("[" + this.getName() + "] HDFS persistence backend created");
         } catch (Exception e) {

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -60,7 +60,7 @@ public class OrionHDFSSinkTest {
     private final String[] cosmosHost = {"localhost"};
     private final String cosmosPort = "14000";
     private final String cosmosDefaultUsername = "user1";
-    private final String cosmosDefaultPassword = "pass1234";
+    private final String oauth2Token = "tokenabcdefghijk";
     private final String hivePort = "10000";
     private final long recvTimeTs = 123456789;
     private final String normalServiceName = "vehicles";
@@ -162,7 +162,7 @@ public class OrionHDFSSinkTest {
         context.put("cosmos_host", cosmosHost[0]);
         context.put("cosmos_port", cosmosPort);
         context.put("cosmos_default_username", cosmosDefaultUsername);
-        context.put("cosmos_default_password", cosmosDefaultPassword);
+        context.put("oauth2_token", oauth2Token);
         context.put("hive_port", hivePort);
         singleNotifyContextRequest = TestUtils.createJsonNotifyContextRequest(singleContextElementNotification);
         multipleNotifyContextRequest = TestUtils.createJsonNotifyContextRequest(multipleContextElementNotification);
@@ -186,7 +186,7 @@ public class OrionHDFSSinkTest {
         assertEquals(cosmosHost[0], sink.getCosmosHost()[0]);
         assertEquals(cosmosPort, sink.getCosmosPort());
         assertEquals(cosmosDefaultUsername, sink.getCosmosDefaultUsername());
-        assertEquals(cosmosDefaultPassword, sink.getCosmosDefaultPassword());
+        assertEquals(oauth2Token, sink.getOAuth2Token());
         assertEquals(hivePort, sink.getHivePort());
     } // testConfigure
 


### PR DESCRIPTION
* Implements issue #483 
* 100% unit tests passed:
```
Results :
Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
15/07/06 15:33:50 INFO handlers.OrionRestHandler: Starting transaction (1436189604-627-0000000000)
15/07/06 15:33:50 INFO handlers.OrionRestHandler: Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
15/07/06 15:33:50 INFO handlers.OrionRestHandler: Event put in the channel (id=1657304731, ttl=10)
15/07/06 15:33:50 INFO sinks.OrionSink: Event got from the channel (id=1657304731, headers={timestamp=1436189630739, content-type=application/json, transactionId=1436189604-627-0000000000, fiware-service=def_serv, fiware-servicepath=def_serv_path, ttl=10, destination=room1_room}, bodyLength=460)
15/07/06 15:33:51 INFO sinks.OrionHDFSSink: [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv/def_serv_path/room1_room/room1_room.txt), Data ({"recvTime":"2015-07-06T13:33:50.739Z","temperature":"26.5", "temperature_md":[]})
15/07/06 15:33:51 INFO hdfs.HDFSBackendImpl: Creating Hive external table=frb_def_serv_def_serv_path_room1_room_column
15/07/06 15:33:52 INFO sinks.OrionSink: Finishing transaction (1436189604-627-0000000000)
...
$ hadoop fs -cat def_serv/def_serv_path/room1_room/room1_room.txt
{"recvTime":"2015-07-06T13:33:50.739Z","temperature":"26.5", "temperature_md":[]}
...
$ node server.js 
express deprecated app.configure: Check app.get('env') in an if statement server.js:35:5
Starting PEP proxy in port 41000. Keystone authentication ...
Success authenticating PEP proxy. Proxy Auth-token:  cd2a78b282b24cf18922a9ff74d19d08
[TOKEN] Checking token with IDM...
webhdfs/v1/user/frb/def_serv/def_serv_path/room1_room/room1_room.txt?op=getfilestatus&user.name=frb
[ROOT] Access-token OK. Redirecting to app...
[TOKEN] Token in cache, checking timestamp...
webhdfs/v1/user/frb/def_serv/def_serv_path/room1_room?op=mkdirs&user.name=frb
[ROOT] Access-token OK. Redirecting to app...
Refused to set unsafe header "content-length"
[TOKEN] Token in cache, checking timestamp...
webhdfs/v1/user/frb/def_serv/def_serv_path/room1_room/room1_room.txt?op=create&user.name=frb
[ROOT] Access-token OK. Redirecting to app...
Refused to set unsafe header "content-length"
Refused to set unsafe header "cookie"
Refused to set unsafe header "cookie2"
```
* Assignee @fgalan