### PR TITLE
feature/493_remove_user_agent_check

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - [FEATURE] Add support for multiple file formats in HDFS; JSON is maintained and CSV is added (#303) 
-- [FEATURE] The notified user agent is not controlled anymore (#493)
+- [FEATURE] The notified user agent is not checked anymore (#493)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - [FEATURE] Add support for multiple file formats in HDFS; JSON is maintained and CSV is added (#303) 
+- [FEATURE] The notified user agent is not controlled anymore (#493)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Let's supose the 'speed' of the 'car1' entity changes to '112.9'; then the follo
     ngsi-event={
         http-headers={
             Content-Length: 492
-            User-Agent: orion/0.9.0
             Host: localhost:1028
             Accept: application/xml, application/json
             Content-Type: application/json

--- a/doc/design/from_ngsi_events_to_flume_events.md
+++ b/doc/design/from_ngsi_events_to_flume_events.md
@@ -6,7 +6,6 @@ A NGSI-like event example could be (the code below is an <i>object representatio
     ngsi-event={
         http-headers={
             Content-Length: 492
-            User-Agent: orion/0.9.0
             Host: localhost:1028
             Accept: application/xml, application/json
             Content-Type: application/json

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -175,12 +175,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
             String headerName = ((String) headerNames.nextElement()).toLowerCase(Locale.ENGLISH);
             String headerValue = request.getHeader(headerName).toLowerCase(Locale.ENGLISH);
             
-            if (headerName.equals(Constants.HEADER_USER_AGENT)) {
-                if (!headerValue.startsWith("orion")) {
-                    LOGGER.warn("Bad HTTP notification (" + headerValue + " user agent not supported)");
-                    throw new HTTPBadRequestException(headerValue + " user agent not supported");
-                } // if
-            } else if (headerName.equals(Constants.HEADER_CONTENT_TYPE)) {
+            if (headerName.equals(Constants.HEADER_CONTENT_TYPE)) {
                 if (!headerValue.contains("application/json") && !headerValue.contains("application/xml")) {
                     LOGGER.warn("Bad HTTP notification (" + headerValue + " content type not supported)");
                     throw new HTTPBadRequestException(headerValue + " content type not supported");

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -18,7 +18,6 @@
 
 package com.telefonica.iot.cygnus.handlers;
 
-import com.telefonica.iot.cygnus.handlers.OrionRestHandler;
 import com.telefonica.iot.cygnus.utils.TestConstants;
 import com.telefonica.iot.cygnus.utils.TestUtils;
 import java.io.BufferedReader;
@@ -68,7 +67,7 @@ public class OrionRestHandlerTest {
     private final String notificationNotificationTarget = "/notify";
     private final String notificationContentType = "application/json";
     private final String notificationRequestMethod = "POST";
-    private final String notificationUserAgent = "orion/0.9.0";
+    private final String notificationUserAgent = "whatever/0.12.7";
     private final String notificationService = "a.SERV_with-rare chars%@";
     private final String notificationServicePath = "a.SERVPATH_with-rare chars%@";
     
@@ -124,41 +123,52 @@ public class OrionRestHandlerTest {
      * Test of getEvents method, of class OrionRestHandler.
      */
     @Test
-    public void testGetEvents() throws Exception {
+    public void testGetEvents() {
         System.out.println("Testing 'getEvents' method from class 'OrionRestHandler' (invalid characters");
-        handler.configure(context);
-        List result = handler.getEvents(mockRequest);
-        assertTrue(result.size() == 1);
-        Event event = (Event) result.get(0);
-        Map<String, String> eventHeaders = event.getHeaders();
-        byte[] eventMessage = event.getBody();
-        assertTrue(eventHeaders.size() == 5);
-        assertTrue(eventHeaders.containsKey("content-type"));
-        assertTrue(eventHeaders.get("content-type").equals("application/json")
-                || eventHeaders.get("content-type").equals("application/xml"));
-        assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE));
-        assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE), TestUtils.encode(notificationService));
-        assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE_PATH));
-        assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE_PATH), TestUtils.encode(notificationServicePath));
-        assertTrue(eventMessage.length != 0);
         
+        try {
+            handler.configure(context);
+            List result = handler.getEvents(mockRequest);
+            assertTrue(result.size() == 1);
+            Event event = (Event) result.get(0);
+            Map<String, String> eventHeaders = event.getHeaders();
+            byte[] eventMessage = event.getBody();
+            assertTrue(eventHeaders.size() == 5);
+            assertTrue(eventHeaders.containsKey("content-type"));
+            assertTrue(eventHeaders.get("content-type").equals("application/json")
+                    || eventHeaders.get("content-type").equals("application/xml"));
+            assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE), TestUtils.encode(notificationService));
+            assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE_PATH));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE_PATH),
+                    TestUtils.encode(notificationServicePath));
+            assertTrue(eventMessage.length != 0);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        } // try catch
+ 
         System.out.println("Testing 'getEvents' method from class 'OrionRestHandler' (\"root\" servicePath name");
-        context.put(TestConstants.PARAM_DEFAULT_SERVICE_PATH, rootServicePath);
-        handler.configure(context);
-        result = handler.getEvents(mockRequest);
-        assertTrue(result.size() == 1);
-        event = (Event) result.get(0);
-        eventHeaders = event.getHeaders();
-        eventMessage = event.getBody();
-        assertTrue(eventHeaders.size() == 5);
-        assertTrue(eventHeaders.containsKey("content-type"));
-        assertTrue(eventHeaders.get("content-type").equals("application/json")
-                || eventHeaders.get("content-type").equals("application/xml"));
-        assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE));
-        assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE), TestUtils.encode(notificationService));
-        assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE_PATH));
-        assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE_PATH), TestUtils.encode(rootServicePath));
-        assertTrue(eventMessage.length != 0);
+        
+        try {
+            context.put(TestConstants.PARAM_DEFAULT_SERVICE_PATH, rootServicePath);
+            handler.configure(context);
+            List result = handler.getEvents(mockRequest);
+            assertTrue(result.size() == 1);
+            Event event = (Event) result.get(0);
+            Map<String, String> eventHeaders = event.getHeaders();
+            byte[] eventMessage = event.getBody();
+            assertTrue(eventHeaders.size() == 5);
+            assertTrue(eventHeaders.containsKey("content-type"));
+            assertTrue(eventHeaders.get("content-type").equals("application/json")
+                    || eventHeaders.get("content-type").equals("application/xml"));
+            assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE), TestUtils.encode(notificationService));
+            assertTrue(eventHeaders.containsKey(TestConstants.HEADER_SERVICE_PATH));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_SERVICE_PATH), TestUtils.encode(rootServicePath));
+            assertTrue(eventMessage.length != 0);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        } // try catch
     } // testGetEvents
     
 } // OrionRestHandlerTest


### PR DESCRIPTION
* Implements issue #493 
* 100% unit tests passed:
```
Results :
Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ cat resources/ngsi-examples/notification-json-simple.sh | grep User-Agent
curl $URL -v -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'User-Agent: whatever/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" -d @- <<EOF
[BEFORE THE FIX]
...
15/08/06 10:59:26 INFO handlers.OrionRestHandler: Starting transaction (1438851510-508-0000000000)
15/08/06 10:59:26 WARN handlers.OrionRestHandler: Bad HTTP notification (whatever/0.10.0 user agent not supported)
15/08/06 10:59:26 WARN http.HTTPSource: Received bad request from client. 
org.apache.flume.source.http.HTTPBadRequestException: whatever/0.10.0 user agent not supported
...
[AFTER THE FIX]
...
15/08/06 11:00:29 INFO handlers.OrionRestHandler: Starting transaction (1438851625-811-0000000000)
15/08/06 11:00:29 INFO handlers.OrionRestHandler: Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
15/08/06 11:00:29 INFO handlers.OrionRestHandler: Event put in the channel (id=1809172135, ttl=10)
15/08/06 11:00:29 INFO sinks.OrionSink: Event got from the channel (id=1809172135, headers={fiware-servicepath=def_serv_path, destination=room1_room, content-type=application/json, fiware-service=def_serv, ttl=10, transactionId=1438851625-811-0000000000, timestamp=1438851629611}, bodyLength=460)
15/08/06 11:00:29 INFO sinks.OrionHDFSSink: [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv/def_serv_path/room1_room/room1_room.txt), Data ({"recvTime":"2015-08-06T09:00:29.611Z", "temperature":"26.5", "temperature_md":[]})
...
```
* Assignee @fgalan