### PR TITLE
feature/513_hiveserver2_support

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - [FEATURE] The notified user agent is not checked anymore (#493)
 - [FEATURE] Add OrionKafkaSink (#456)
 - [HARDENING] Add missing configuration and documentation regarding OrionMongoSink and OrionSTHSink (#505)
+- [FEATURE] Add HiveServer2 support to OrionHDFSSink (#513)

--- a/README.md
+++ b/README.md
@@ -750,10 +750,14 @@ cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
 cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 # username allowed to write in HDFS
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
-# OAuth2 token
-cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxxxxxxx
+# password for the above username; this is only required for Hive authentication
+cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxx
+# OAuth2 token for HDFS authentication
+cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxx
 # how the attributes are stored, available formats are json-row, json-column, csv-row and csv-column
 cygnusagent.sinks.hdfs-sink.file_format = json-column
+# Hive server version (1 or 2)
+cygnusagent.sinks.hdfs-sink.hive_server_version = 2
 # Hive FQDN/IP address of the Hive server
 cygnusagent.sinks.hdfs-sink.hive_host = x.y.z.w
 # Hive port for Hive external table provisioning

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -71,10 +71,14 @@ cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
 cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
 # username allowed to write in HDFS
 cygnusagent.sinks.hdfs-sink.hdfs_username = hdfs_username
-# OAuth2 token
+# password for the above username; this is only required for Hive authentication
+cygnusagent.sinks.hdfs-sink.hdfs_password = xxxxxxxx
+# OAuth2 token for HDFS authentication
 cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxx
 # how the attributes are stored, available formats are json-row, json-column, csv-row and csv-column
 cygnusagent.sinks.hdfs-sink.file_format = json-column
+# Hive server version (1 or 2)
+cygnusagent.sinks.hdfs-sink.hive_server_version = 2
 # Hive FQDN/IP address of the Hive server
 cygnusagent.sinks.hdfs-sink.hive_host = x.y.z.w
 # Hive port for Hive external table provisioning

--- a/doc/design/OrionHDFSSink.md
+++ b/doc/design/OrionHDFSSink.md
@@ -162,9 +162,11 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | cosmos_port<br>(**deprecated**) | no | 14000 | <i>14000</i> if using HttpFS, <i>50070</i> if using WebHDFS.<br>Still usable; if both are configured, `hdfs_port` is preferred |
 | hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser |
 | cosmos\_default\_username<br>(**deprecated**) | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser.<br>Still usable; if both are configured, `hdfs_username` is preferred |
-| oauth2_token | yes | N/A |
+| hdfs_password | yes | N/A | Password for the above `hdfs_username`/`cosmos_default_username`; this is only required for Hive authentication |
+| oauth2_token | yes | N/A | OAuth2 token required for the HDFS authentication |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
 | file_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>
+| hive\_server\_version | no | 2 | `1` if the remote Hive server runs HiveServer1 or `2` if the remote Hive server runs HiveServer2 |
 | hive_host | no | localhost |
 | hive_port | no | 10000 |
 | krb5_auth | no | false |
@@ -182,9 +184,11 @@ A configuration example could be:
     cygnusagent.sinks.hdfs-sink.channel = hdfs-channel
     cygnusagent.sinks.hdfs-sink.hdfs_host = 192.168.80.34
     cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
-    cygnusagent.sinks.hdfsƒsink.hdfs_username = myuser
+    cygnusagent.sinks.hdfs-sink.hdfs_username = myuser
+    cygnusagent.sinks.hdfs-sink.hdfs_password = mypassword
     cygnusagent.sinks.hdfs-sink.oauth2_token = mytoken
     cygnusagent.sinks.hdfs-sink.file_format = json-column
+    cygnusagent.sinks.hdfs-sink.hive_server_version = 2
     cygnusagent.sinks.hdfs-sink.hive_host = 192.168.80.35
     cygnusagent.sinks.hdfs-sink.hive_port = 10000
     cygnusagent.sinks.hdfs-sink.krb5_auth = false

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>0.12.0</version>
+      <version>0.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
-      <version>0.12.0</version>
+      <version>0.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImpl.java
@@ -45,7 +45,9 @@ public class HDFSBackendImpl extends HttpBackend implements HDFSBackend {
     public enum FileFormat { JSONROW, CSVROW, JSONCOLUMN, CSVCOLUMN };
     
     private final String hdfsUser;
+    private final String hdfsPassword;
     private final String oauth2Token;
+    private final String hiveServerVersion;
     private final String hiveHost;
     private final String hivePort;
     private final boolean serviceAsNamespace;
@@ -58,8 +60,10 @@ public class HDFSBackendImpl extends HttpBackend implements HDFSBackend {
      * @param hdfsHosts
      * @param hdfsPort
      * @param hdfsUser
-     * @param hiveHost
+     * @param hdfsPassword
      * @param oauth2Token
+     * @param hiveServerVersion
+     * @param hiveHost
      * @param hivePort
      * @param krb5
      * @param krb5User
@@ -68,12 +72,15 @@ public class HDFSBackendImpl extends HttpBackend implements HDFSBackend {
      * @param krb5ConfFile
      * @param serviceAsNamespace
      */
-    public HDFSBackendImpl(String[] hdfsHosts, String hdfsPort, String hdfsUser, String oauth2Token, String hiveHost,
-            String hivePort, boolean krb5, String krb5User, String krb5Password, String krb5LoginConfFile,
-            String krb5ConfFile, boolean serviceAsNamespace) {
+    public HDFSBackendImpl(String[] hdfsHosts, String hdfsPort, String hdfsUser, String hdfsPassword,
+            String oauth2Token, String hiveServerVersion, String hiveHost, String hivePort, boolean krb5,
+            String krb5User, String krb5Password, String krb5LoginConfFile, String krb5ConfFile,
+            boolean serviceAsNamespace) {
         super(hdfsHosts, hdfsPort, false, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile);
         this.hdfsUser = hdfsUser;
+        this.hdfsPassword = hdfsPassword;
         this.oauth2Token = oauth2Token;
+        this.hiveServerVersion = hiveServerVersion;
         this.hiveHost = hiveHost;
         this.hivePort = hivePort;
         this.serviceAsNamespace = serviceAsNamespace;
@@ -215,7 +222,7 @@ public class HDFSBackendImpl extends HttpBackend implements HDFSBackend {
         LOGGER.info("Creating Hive external table=" + tableName);
         
         // get a Hive client
-        HiveBackend hiveClient = new HiveBackend(hiveHost, hivePort, hdfsUser, oauth2Token);
+        HiveBackend hiveClient = new HiveBackend(hiveServerVersion, hiveHost, hivePort, hdfsUser, hdfsPassword);
         
         // create the query
         String query;

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -87,8 +87,10 @@ public class OrionHDFSSink extends OrionSink {
     private String[] host;
     private String port;
     private String username;
+    private String password;
     private FileFormat fileFormat;
     private String oauth2Token;
+    private String hiveServerVersion;
     private String hiveHost;
     private String hivePort;
     private boolean krb5;
@@ -131,6 +133,15 @@ public class OrionHDFSSink extends OrionSink {
     } // getHDFSUsername
     
     /**
+     * Gets the password for the default Cosmos username. It is protected due to it is only required for testing
+     * purposes.
+     * @return The password for the default Cosmos username
+     */
+    protected String getHDFSPassword() {
+        return password;
+    } // getHDFSPassword
+    
+    /**
      * Gets the OAuth2 token used for authentication and authorization. It is protected due to it is only required
      * for testing purposes.
      * @return The Cosmos oauth2Token for the detault Cosmos username
@@ -166,6 +177,14 @@ public class OrionHDFSSink extends OrionSink {
                 return "";
         } // switch;
     } // getFileFormat
+    
+    /**
+     * Gets the Hive server version. It is protected due to it is only required for testing purposes.
+     * @return The Hive server version
+     */
+    protected String getHiveServerVersion() {
+        return hiveServerVersion;
+    } // getHiveServerVersion
     
     /**
      * Gets the Hive host. It is protected due to it is only required for testing purposes.
@@ -265,6 +284,9 @@ public class OrionHDFSSink extends OrionSink {
                     + "authorization mechanism!");
         } // if else
         
+        password = context.getString("hdfs_password");
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_password=" + password + ")");
+
         boolean rowAttrPersistenceConfigured = context.getParameters().containsKey("attr_persistence");
         boolean fileFormatConfigured = context.getParameters().containsKey("file_format");
         
@@ -282,6 +304,8 @@ public class OrionHDFSSink extends OrionSink {
             LOGGER.debug("[" + this.getName() + "] Defaulting to file_format=json-row");
         } // if else if
 
+        hiveServerVersion = context.getString("hive_server_version", "2");
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_server_version=" + hiveServerVersion + ")");
         hiveHost = context.getString("hive_host", "localhost");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_host=" + hiveHost + ")");
         hivePort = context.getString("hive_port", "10000");
@@ -307,8 +331,9 @@ public class OrionHDFSSink extends OrionSink {
     public void start() {
         try {
             // create the persistence backend
-            persistenceBackend = new HDFSBackendImpl(host, port, username, oauth2Token, hiveHost, hivePort, krb5,
-                    krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, serviceAsNamespace);
+            persistenceBackend = new HDFSBackendImpl(host, port, username, password, oauth2Token, hiveServerVersion,
+                    hiveHost, hivePort, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile,
+                    serviceAsNamespace);
             LOGGER.debug("[" + this.getName() + "] HDFS persistence backend created");
         } catch (Exception e) {
             LOGGER.error(e.getMessage());

--- a/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplTest.java
@@ -57,6 +57,8 @@ public class HDFSBackendImplTest {
     private final String hdfsPort = "50070";
     private final String user = "hdfs-user";
     private final String password = "12345abcde";
+    private final String token = "erwfgwegwegewtgewtg";
+    private final String hiveServerVersion = "2";
     private final String hiveHost = "1.2.3.4";
     private final String hivePort = "10000";
     private final String dirPath = "path/to/my/data";
@@ -71,8 +73,8 @@ public class HDFSBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new HDFSBackendImpl(hdfsHosts, hdfsPort, user, password, hiveHost, hivePort, false, null, null, null,
-                null, false);
+        backend = new HDFSBackendImpl(hdfsHosts, hdfsPort, user, password, token, hiveServerVersion, hiveHost, hivePort,
+                false, null, null, null, null, false);
         
         // set up other instances
         BasicHttpResponse resp200 = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "OK");

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -60,9 +60,11 @@ public class OrionHDFSSinkTest {
     private final String[] cosmosHost = {"localhost"};
     private final String cosmosPort = "14000";
     private final String hdfsUsername = "user1";
+    private final String hdfsPassword = "12345";
     private final String oauth2Token = "tokenabcdefghijk";
     private final String serviceAsNamespace = "false";
     private final String fileFormat = "json-row";
+    private final String hiveServerVersion = "2";
     private final String hiveHost = "localhost";
     private final String hivePort = "10000";
     private final String krb5Auth = "false";
@@ -172,6 +174,7 @@ public class OrionHDFSSinkTest {
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);
+        context.put("hive_server_version", hiveServerVersion);
         context.put("hive_host", hiveHost);
         context.put("hive_port", hivePort);
         context.put("krb5_auth", krb5Auth);
@@ -197,9 +200,11 @@ public class OrionHDFSSinkTest {
         assertEquals(cosmosHost[0], sink.getHDFSHosts()[0]);
         assertEquals(cosmosPort, sink.getHDFSPort());
         assertEquals(hdfsUsername, sink.getHDFSUsername());
+        assertEquals(hdfsPassword, sink.getHDFSPassword());
         assertEquals(oauth2Token, sink.getOAuth2Token());
         assertEquals(serviceAsNamespace, sink.getServiceAsNamespace());
         assertEquals(fileFormat, sink.getFileFormat());
+        assertEquals(hiveServerVersion, sink.getHiveServerVersion());
         assertEquals(hiveHost, sink.getHiveHost());
         assertEquals(hivePort, sink.getHivePort());
         assertEquals(krb5Auth, sink.getKrb5Auth());

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -171,6 +171,7 @@ public class OrionHDFSSinkTest {
         context.put("hdfs_host", cosmosHost[0]);
         context.put("hdfs_port", cosmosPort);
         context.put("hdfs_username", hdfsUsername);
+        context.put("hdfs_password", hdfsPassword);
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);


### PR DESCRIPTION
* Implements issue #513 
* 100% unit tests passed (except for https://github.com/telefonicaid/fiware-cygnus/issues/514)
```
Results :

Tests in error: 
  testStart(com.telefonica.iot.cygnus.sinks.OrionKafkaSinkTest): Unable to connect to zookeeper server within timeout: 10000

Tests run: 54, Failures: 0, Errors: 1, Skipped: 0
```
* (unofficial) e2e tests passed:
```
time=2015-09-16T10:19:51.627CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1442391583-945-0000000000)
time=2015-09-16T10:19:51.629CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[231] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-16T10:19:51.634CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[253] : Event put in the channel (id=14288779, ttl=10)
time=2015-09-16T10:19:51.680CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=14288779, headers={fiware-servicepath=def_serv_path_hs2_14, destination=room1_room, content-type=application/json, fiware-service=def_serv_hs2_14, ttl=10, transactionId=1442391583-945-0000000000, timestamp=1442391591635}, bodyLength=460)
time=2015-09-16T10:19:52.009CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=persistData | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[516] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv_hs2_14/def_serv_path_hs2_14/room1_room/room1_room.txt), Data ({"recvTime":"2015-09-16T08:19:51.635Z", "temperature":"26.5", "temperature_md":[]})
time=2015-09-16T10:19:52.588CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl[222] : Creating Hive external table=frb_def_serv_hs2_14_def_serv_path_hs2_14_room1_room_column
time=2015-09-16T10:19:53.480CEST | lvl=INFO | trans=1442391583-945-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1442391583-945-0000000000)
...
hive> show tables like "frb_def_serv_hs2_14_def_serv_path_hs2_14_room1_room_column";
OK
frb_def_serv_hs2_14_def_serv_path_hs2_14_room1_room_column
Time taken: 0.049 seconds, Fetched: 1 row(s)
hive> select * from frb_def_serv_hs2_14_def_serv_path_hs2_14_room1_room_column;
OK
2015-09-16T08:19:51.635Z	26.5	[]
Time taken: 1.002 seconds, Fetched: 1 row(s)
```
* Assignee @fgalan