### PR TITLE
bug/401_always_create_table_if_not_exists

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [FEATURE] Add Java-based clients both for HiveServer1 and HiveServer2 (#518)
 - [HARDENING] Replace logs containing "HttpFS response" by "Server response" (#517)
 - [BUG] Use a testing version of Zookeeper in OrionKafkaSink (#514)
+- [BUG] Always create the Hive tables if not existing yet (#401)

--- a/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImpl.java
@@ -230,15 +230,15 @@ public class HDFSBackendImpl extends HttpBackend implements HDFSBackend {
         switch (fileFormat) {
             case JSONCOLUMN:
             case JSONROW:
-                query = "create external table " + tableName + " (" + fields + ") row format serde "
+                query = "create external table if not exists " + tableName + " (" + fields + ") row format serde "
                         + "'org.openx.data.jsonserde.JsonSerDe' location '/user/"
                         + (serviceAsNamespace ? "" : (hdfsUser + "/")) + dirPath + "'";
                 break;
             case CSVCOLUMN:
             case CSVROW:
-                query = "create external table " + tableName + " (" + fields + ") row format delimited fields "
-                        + "terminated by ',' location '/user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
-                        + dirPath + "'";
+                query = "create external table if not exists " + tableName + " (" + fields + ") row format "
+                        + "delimited fields terminated by ',' location '/user/"
+                        + (serviceAsNamespace ? "" : (hdfsUser + "/")) + dirPath + "'";
                 break;
             default:
                 query = "";

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -417,13 +417,8 @@ public class OrionHDFSSink extends OrionSink {
                         String rowLine = createRow(fileFormat, recvTimeTs, recvTime, entityId, entityType, attrName,
                                 attrType, attrValue, attrMetadata);
                         persistData(rowLine, hdfsFolder, hdfsFile, dataFileExists);
-                        
-                        // Hive table is only created once the HDFS file is created
-                        if (!dataFileExists) {
-                            persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, "_row");
-                            dataFileExists = true;
-                        } // if
-                        
+                        persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, "_row");
+                        dataFileExists = true;
                         break;
                     case JSONCOLUMN:
                         // "accumulate" the data for future persistence
@@ -446,13 +441,8 @@ public class OrionHDFSSink extends OrionSink {
                         // metadata is persisted in a separated HDFS file
                         boolean mdFileExists = persistenceBackend.exists(attrMdFileName);
                         persistCSVMetadata(attrMetadata, recvTimeTs, attrMdFolder, attrMdFileName, mdFileExists);
-                        
-                        // Hive table is only created once the HDFS file is created
-                        if (!dataFileExists) {
-                            persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, "_row");
-                            dataFileExists = true;
-                        } // if
-                        
+                        persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, "_row");
+                        dataFileExists = true;
                         break;
                     case CSVCOLUMN:
                         // build some metadata related stuff
@@ -480,21 +470,11 @@ public class OrionHDFSSink extends OrionSink {
             switch (fileFormat) {
                 case JSONCOLUMN:
                     persistData(columnLine + "}", hdfsFolder, hdfsFile, dataFileExists);
-                    
-                    // Hive table is only created once the file is created
-                    if (!dataFileExists) {
-                        persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, hiveFields, "_column");
-                    } // if
-                    
+                    persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, hiveFields, "_column");
                     break;
                 case CSVCOLUMN:
                     persistData(columnLine, hdfsFolder, hdfsFile, dataFileExists);
-                    
-                    // Hive table is only created once the file is created
-                    if (!dataFileExists) {
-                        persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, hiveFields, "_column");
-                    } // if
-                    
+                    persistenceBackend.provisionHiveTable(fileFormat, hdfsFolder, hiveFields, "_column");
                     break;
                 default:
                     break;


### PR DESCRIPTION
* Fixes issues #401 
* 100% unit tests passed:
```
Results :
Tests run: 54, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
---HDFS file not existing, Hive table not existing
time=2015-09-18T12:11:47.775CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1442571103-504-0000000000)
time=2015-09-18T12:11:47.778CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[231] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-18T12:11:47.781CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[253] : Event put in the channel (id=1513381874, ttl=10)
time=2015-09-18T12:11:47.844CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=1513381874, headers={fiware-servicepath=rooms, destination=other_rooms, content-type=application/json, fiware-service=deleteme, ttl=10, transactionId=1442571103-504-0000000000, timestamp=1442571107781}, bodyLength=460)
time=2015-09-18T12:11:48.290CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=persistData | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[496] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (deleteme/rooms/other_rooms/other_rooms.txt), Data ({"recvTime":"2015-09-18T10:11:47.781Z", "temperature":"26.5", "temperature_md":[]})
time=2015-09-18T12:11:49.167CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl[222] : Creating Hive external table=frb_deleteme_rooms_other_rooms_column
time=2015-09-18T12:11:50.091CEST | lvl=INFO | trans=1442571103-504-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1442571103-504-0000000000)
...
hive> show tables like "frb*";
OK
frb_deleteme_rooms_other_rooms_column
Time taken: 0.049 seconds, Fetched: 1 row(s)
hive> select * from frb_deleteme_rooms_other_rooms_column;
OK
2015-09-18T10:11:47.781Z	26.5	[]
Time taken: 0.081 seconds, Fetched: 1 row(s)
...
$ hadoop fs -cat deleteme/rooms/other_rooms/other_rooms.txt
{"recvTime":"2015-09-18T10:11:47.781Z", "temperature":"26.5", "temperature_md":[]}
---HDFS file existing, Hive table existing
time=2015-09-18T12:12:37.897CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1442571103-504-0000000001)
time=2015-09-18T12:12:37.898CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[231] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-18T12:12:37.898CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[253] : Event put in the channel (id=809698348, ttl=10)
time=2015-09-18T12:12:37.903CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=809698348, headers={fiware-servicepath=rooms, destination=other_rooms, content-type=application/json, fiware-service=deleteme, ttl=10, transactionId=1442571103-504-0000000001, timestamp=1442571157898}, bodyLength=460)
time=2015-09-18T12:12:38.152CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=persistData | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[496] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (deleteme/rooms/other_rooms/other_rooms.txt), Data ({"recvTime":"2015-09-18T10:12:37.898Z", "temperature":"26.5", "temperature_md":[]})
time=2015-09-18T12:12:38.682CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl[222] : Creating Hive external table=frb_deleteme_rooms_other_rooms_column
time=2015-09-18T12:12:40.387CEST | lvl=INFO | trans=1442571103-504-0000000001 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1442571103-504-0000000001)
...
hive> show tables like "frb*";
OK
frb_deleteme_rooms_other_rooms_column
Time taken: 0.651 seconds, Fetched: 1 row(s)
hive> select * from frb_deleteme_rooms_other_rooms_column;
OK
2015-09-18T10:11:47.781Z	26.5	[]
2015-09-18T10:12:37.898Z	26.5	[]
Time taken: 0.792 seconds, Fetched: 2 row(s)
...
$ hadoop fs -cat deleteme/rooms/other_rooms/other_rooms.txt
{"recvTime":"2015-09-18T10:11:47.781Z", "temperature":"26.5", "temperature_md":[]}
{"recvTime":"2015-09-18T10:12:37.898Z", "temperature":"26.5", "temperature_md":[]}
---HDFS file existing, Hive table not existing
time=2015-09-18T12:15:40.855CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1442571103-504-0000000002)
time=2015-09-18T12:15:40.856CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[231] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-18T12:15:40.856CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[253] : Event put in the channel (id=1855164577, ttl=10)
time=2015-09-18T12:15:40.859CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=1855164577, headers={fiware-servicepath=rooms, destination=other_rooms, content-type=application/json, fiware-service=deleteme, ttl=10, transactionId=1442571103-504-0000000002, timestamp=1442571340856}, bodyLength=460)
time=2015-09-18T12:15:41.110CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=persistData | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[496] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (deleteme/rooms/other_rooms/other_rooms.txt), Data ({"recvTime":"2015-09-18T10:15:40.856Z", "temperature":"26.5", "temperature_md":[]})
time=2015-09-18T12:15:41.427CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl[222] : Creating Hive external table=frb_deleteme_rooms_other_rooms_column
time=2015-09-18T12:15:42.312CEST | lvl=INFO | trans=1442571103-504-0000000002 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1442571103-504-0000000002)
...
hive> drop table frb_deleteme_rooms_other_rooms_column;
OK
Time taken: 1.07 seconds
hive> show tables like "frb*";                         
OK
frb_deleteme_rooms_other_rooms_column
Time taken: 0.056 seconds, Fetched: 1 row(s)
hive> select * from frb_deleteme_rooms_other_rooms_column;
OK
2015-09-18T10:11:47.781Z	26.5	[]
2015-09-18T10:12:37.898Z	26.5	[]
2015-09-18T10:15:40.856Z	26.5	[]
Time taken: 0.453 seconds, Fetched: 3 row(s)
...
$ hadoop fs -cat deleteme/rooms/other_rooms/other_rooms.txt
{"recvTime":"2015-09-18T10:11:47.781Z", "temperature":"26.5", "temperature_md":[]}
{"recvTime":"2015-09-18T10:12:37.898Z", "temperature":"26.5", "temperature_md":[]}
{"recvTime":"2015-09-18T10:15:40.856Z", "temperature":"26.5", "temperature_md":[]}
---HDFS file not existing, Hive table existing
time=2015-09-18T12:16:49.470CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1442571103-504-0000000003)
time=2015-09-18T12:16:49.471CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[231] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-18T12:16:49.471CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[253] : Event put in the channel (id=1540021665, ttl=10)
time=2015-09-18T12:16:49.472CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[128] : Event got from the channel (id=1540021665, headers={fiware-servicepath=rooms, destination=other_rooms, content-type=application/json, fiware-service=deleteme, ttl=10, transactionId=1442571103-504-0000000003, timestamp=1442571409471}, bodyLength=460)
time=2015-09-18T12:16:49.954CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=persistData | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[496] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (deleteme/rooms/other_rooms/other_rooms.txt), Data ({"recvTime":"2015-09-18T10:16:49.471Z", "temperature":"26.5", "temperature_md":[]})
time=2015-09-18T12:16:50.994CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImpl[222] : Creating Hive external table=frb_deleteme_rooms_other_rooms_column
time=2015-09-18T12:16:51.638CEST | lvl=INFO | trans=1442571103-504-0000000003 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[193] : Finishing transaction (1442571103-504-0000000003)
...
hive> select * from frb_deleteme_rooms_other_rooms_column;
OK
2015-09-18T10:16:49.471Z	26.5	[]
Time taken: 0.96 seconds, Fetched: 1 row(s)
...
$ hadoop fs -cat deleteme/rooms/other_rooms/other_rooms.txt
{"recvTime":"2015-09-18T10:16:49.471Z", "temperature":"26.5", "temperature_md":[]}
```
* Assignee @fgalan