### PR TITLE
bug/539_add_entity_id_type_ckan_sink_row

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [FEATURE] Allow selecting the table type (by service, servicePath or destination) (#540)
 - [BUG] A second CKAN resource may be added to an existeng dataset in row mode (#280)
 - [HARDENING] Add references to FIWARE and Cosmos Big Data Analysis GE in the README (#534)
+- [BUG] entityId and entityType are now added to the CKAN resources when using OrionCKANSink in row mode (#539)

--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ Assuming `api_key=myapikey` and `attr_persistence=row` as configuration paramete
                     "id": "recvTime"
                 },
                 {
+                    "id": "entityId",
+                    "type": "text"
+                },
+                {
+                    "id": "entityType",
+                    "type": "text"
+                },
+                {
                     "type": "text",
                     "id": "attrName"
                 },

--- a/doc/design/OrionCKANSink.md
+++ b/doc/design/OrionCKANSink.md
@@ -100,6 +100,14 @@ Assuming `api_key=myapikey` and `attr_persistence=row` as configuration paramete
                     "id": "recvTime"
                 },
                 {
+                    "id": "entityId",
+                    "type": "text"
+                },
+                {
+                    "id": "entityType",
+                    "type": "text"
+                },
+                {
                     "type": "text",
                     "id": "attrName"
                 },

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
@@ -35,14 +35,16 @@ public interface CKANBackend {
      * @param orgName Organization name
      * @param pkgName Package/dataset name
      * @param resName Resource name
+     * @param entityId Entity id
+     * @param entityType Entity type
      * @param attrName Attribute name
      * @param attrType Attribute type
      * @param attrValue Attribute value
      * @param attrMd Attribute metadata string serialization
      * @throws Exception
      */
-    void persist(long recvTimeTs, String recvTime, String orgName, String pkgName, String resName, String attrName,
-            String attrType, String attrValue, String attrMd) throws Exception;
+    void persist(long recvTimeTs, String recvTime, String orgName, String pkgName, String resName, String entityId,
+            String entityType, String attrName, String attrType, String attrValue, String attrMd) throws Exception;
 
     /**
      * Persist data in the CKAN datastore associated with the entity in a given organization (column mode).

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -66,7 +66,8 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
 
     @Override
     public void persist(long recvTimeTs, String recvTime, String orgName, String pkgName, String resName,
-        String attrName, String attrType, String attrValue, String attrMd) throws Exception {
+        String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd)
+        throws Exception {
         LOGGER.debug("Going to lookup for the resource id, the cache may be updated during the process (orgName="
                 + orgName + ", pkgName=" + pkgName + ", resName=" + resName + ")");
         String resId = resourceLookupOrCreate(orgName, pkgName, resName, true);
@@ -77,7 +78,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         } else {
             LOGGER.debug("Going to persist the data (orgName=" + orgName + ", pkgName=" + pkgName
                     + ", resName/resId=" + resName + "/" + resId + ")");
-            insert(recvTimeTs, recvTime, resId, attrName, attrType, attrValue, attrMd);
+            insert(recvTimeTs, recvTime, resId, entityId, entityType, attrName, attrType, attrValue, attrMd);
         } // if else
     } // persist
 
@@ -167,21 +168,25 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
      * Insert record in datastore (row mode).
      * @param recvTimeTs timestamp.
      * @param recvTime timestamp (human readable)
-     * @param resId the resource in which datastore the record is going to be inserted.
+     * @param resourceId the resource in which datastore the record is going to be inserted.
+     * @param entityId entiyd id
+     * @param entityType entity type
      * @param attrName attribute CKANBackend.
      * @param attrType attribute type.
      * @param attrValue attribute value.
      * @throws Exception
      */
-    private void insert(long recvTimeTs, String recvTime, String resourceId, String attrName, String attrType,
-            String attrValue, String attrMd) throws Exception {
+    private void insert(long recvTimeTs, String recvTime, String resourceId, String entityId, String entityType,
+            String attrName, String attrType, String attrValue, String attrMd) throws Exception {
         String urlPath;
         String jsonString;
         
         try {
             // create the CKAN request JSON
-            String records = "\"" + Constants.RECV_TIME_TS + "\": \"" + recvTimeTs / 1000 + "\", "
+            String records ="\"" + Constants.RECV_TIME_TS + "\": \"" + recvTimeTs / 1000 + "\", "
                     + "\"" + Constants.RECV_TIME + "\": \"" + recvTime + "\", "
+                    + "\"" + Constants.ENTITY_ID + "\": \"" + entityId + "\", "
+                    + "\"" + Constants.ENTITY_TYPE + "\": \"" + entityType + "\", "
                     + "\"" + Constants.ATTR_NAME + "\": \"" + attrName + "\", "
                     + "\"" + Constants.ATTR_TYPE + "\": \"" + attrType + "\", "
                     + "\"" + Constants.ATTR_VALUE + "\": " + attrValue;
@@ -425,6 +430,8 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                     + "\", \"fields\": [ "
                     + "{ \"id\": \"" + Constants.RECV_TIME_TS + "\", \"type\": \"int\"},"
                     + "{ \"id\": \"" + Constants.RECV_TIME + "\", \"type\": \"timestamp\"},"
+                    + "{ \"id\": \"" + Constants.ENTITY_ID + "\", \"type\": \"text\"},"
+                    + "{ \"id\": \"" + Constants.ENTITY_TYPE + "\", \"type\": \"text\"},"
                     + "{ \"id\": \"" + Constants.ATTR_NAME + "\", \"type\": \"text\"},"
                     + "{ \"id\": \"" + Constants.ATTR_TYPE + "\", \"type\": \"text\"},"
                     + "{ \"id\": \"" + Constants.ATTR_VALUE + "\", \"type\": \"json\"},"

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -183,7 +183,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         
         try {
             // create the CKAN request JSON
-            String records ="\"" + Constants.RECV_TIME_TS + "\": \"" + recvTimeTs / 1000 + "\", "
+            String records = "\"" + Constants.RECV_TIME_TS + "\": \"" + recvTimeTs / 1000 + "\", "
                     + "\"" + Constants.RECV_TIME + "\": \"" + recvTime + "\", "
                     + "\"" + Constants.ENTITY_ID + "\": \"" + entityId + "\", "
                     + "\"" + Constants.ENTITY_TYPE + "\": \"" + entityType + "\", "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -205,10 +205,11 @@ public class OrionCKANSink extends OrionSink {
 
                 if (rowAttrPersistence) {
                     LOGGER.info("[" + this.getName() + "] Persisting data at OrionCKANSink (orgName=" + orgName
-                            + ", pkgName=" + pkgName + ", resName=" + resName + ", data=" + recvTimeTs + ", "
-                            + recvTime + ", " + attrName + ", " + attrType + ", " + attrValue + ", " + attrMd + ")");
-                    persistenceBackend.persist(recvTimeTs, recvTime, orgName, pkgName, resName, attrName, attrType,
-                            attrValue, attrMd);
+                            + ", pkgName=" + pkgName + ", resName=" + resName + ", data=" + recvTimeTs + ","
+                            + recvTime + "," + entityId + "," + entityType + "," + attrName + "," + attrType + ","
+                            + attrValue + "," + attrMd + ")");
+                    persistenceBackend.persist(recvTimeTs, recvTime, orgName, pkgName, resName, entityId, entityType,
+                            attrName, attrType, attrValue, attrMd);
                 } else {
                     attrs.put(attrName, attrValue);
                     mds.put(attrName + "_md", attrMd);

--- a/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
@@ -65,6 +65,8 @@ public class CKANBackendImplTest {
     private final String resName = "room1-room";
     private final String recvTime = "2014-09-23T11:26:45";
     private final long recvTimeTs = Long.parseLong("123456789");
+    private final String entityId = "room1";
+    private final String entityType = "room";
     private final String attrName = "temperature";
     private final String attrType = "centigrade";
     private final String attrValue = "26.5";
@@ -105,7 +107,8 @@ public class CKANBackendImplTest {
         try {
             backend.setCache(mockCache);
             backend.setHttpClient(mockHttpClient);
-            backend.persist(recvTimeTs, recvTime, orgName, pkgName, resName, attrName, attrType, attrValue, attrMd);
+            backend.persist(recvTimeTs, recvTime, orgName, pkgName, resName, entityId, entityType, attrName, attrType,
+                    attrValue, attrMd);
         } catch (Exception e) {
             fail(e.getMessage());
         } finally {

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
@@ -74,6 +74,8 @@ public class OrionCKANSinkTest {
     private final String multipleDestinationName = "sport1,urban1";
     private final String abnormalDestinationName =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";
+    private static final String ENTITYID = "car1";
+    private static final String ENTITYTYPE = "car";
     private static final String ATTRNAME = "speed";
     private static final String ATTRTYPE = "float";
     private static final String ATTRVALUE = "112.9";
@@ -182,7 +184,8 @@ public class OrionCKANSinkTest {
         
         // set up the behaviour of the mocked classes
         doNothing().doThrow(new Exception()).when(mockCKANBackend).persist(recvTimeTs, recvTime, normalServiceName,
-                singleServicePathName, singleDestinationName, ATTRNAME, ATTRTYPE, ATTRVALUE, ATTRMD);
+                singleServicePathName, singleDestinationName, ENTITYID, ENTITYTYPE, ATTRNAME, ATTRTYPE, ATTRVALUE,
+                ATTRMD);
         doNothing().doThrow(new Exception()).when(mockCKANBackend).persist(recvTime, normalServiceName,
                 singleServicePathName, singleDestinationName, ATTRLIST, ATTRMDLIST);
     } // setUp


### PR DESCRIPTION
* Fixes issue #539 
* 100% unit tests passed:
```
Results :
Tests run: 54, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
time=2015-09-24T17:34:08.972CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1443108843-930-0000000000)
time=2015-09-24T17:34:08.974CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[232] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-09-24T17:34:08.976CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[255] : Event put in the channel (id=2046830609, ttl=10)
time=2015-09-24T17:34:09.026CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[145] : Event got from the channel (id=2046830609, headers={default-destinations=room1_room, grouped-fiware-servicepaths=rooms, fiware-servicepath=test_enable_grouping_14, content-type=application/json, grouped-destinations=other_rooms, fiware-service=deleteme4, ttl=10, transactionId=1443108843-930-0000000000, timestamp=1443108848976, default-fiware-servicepaths=test_enable_grouping_14}, bodyLength=460)
time=2015-09-24T17:34:09.031CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=persist | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[207] : [ckan-sink] Persisting data at OrionCKANSink (orgName=deleteme4, pkgName=deleteme4_test_enable_grouping_14, resName=room1_room, data=1443108848976,2015-09-24T15:34:08.976Z,Room1,Room,temperature,centigrade,"26.5",[])
time=2015-09-24T17:34:11.019CEST | lvl=INFO | trans=1443108843-930-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[210] : Finishing transaction (1443108843-930-0000000000)
...
$ curl -s -S -H "Authorization: f3627131-8184-42e7-ab33-9bf0f7e22dff" "http://130.206.83.8:80/api/3/action/datastore_search?resource_id=4b3ebff6-4343-47df-b445-6b702cef540d" | python -m json.tool
{
    "help": "Search a DataStore resource.\n\n    The datastore_search action allows you to search data in a resource.\n    DataStore resources that belong to private CKAN resource can only be\n    read by you if you have access to the CKAN resource and send the appropriate\n    authorization.\n\n    :param resource_id: id or alias of the resource to be searched against\n    :type resource_id: string\n    :param filters: matching conditions to select, e.g {\"key1\": \"a\", \"key2\": \"b\"} (optional)\n    :type filters: dictionary\n    :param q: full text query (optional)\n    :type q: string\n    :param plain: treat as plain text query (optional, default: true)\n    :type plain: bool\n    :param language: language of the full text query (optional, default: english)\n    :type language: string\n    :param limit: maximum number of rows to return (optional, default: 100)\n    :type limit: int\n    :param offset: offset this number of rows (optional)\n    :type offset: int\n    :param fields: fields to return (optional, default: all fields in original order)\n    :type fields: list or comma separated string\n    :param sort: comma separated field names with ordering\n                 e.g.: \"fieldname1, fieldname2 desc\"\n    :type sort: string\n\n    Setting the ``plain`` flag to false enables the entire PostgreSQL `full text search query language`_.\n\n    A listing of all available resources can be found at the alias ``_table_metadata``.\n\n    .. _full text search query language: http://www.postgresql.org/docs/9.1/static/datatype-textsearch.html#DATATYPE-TSQUERY\n\n    If you need to download the full resource, read :ref:`dump`.\n\n    **Results:**\n\n    The result of this action is a dictionary with the following keys:\n\n    :rtype: A dictionary with the following keys\n    :param fields: fields/columns and their extra metadata\n    :type fields: list of dictionaries\n    :param offset: query offset value\n    :type offset: int\n    :param limit: query limit value\n    :type limit: int\n    :param filters: query filters\n    :type filters: list of dictionaries\n    :param total: number of total matching records\n    :type total: int\n    :param records: list of matching results\n    :type records: list of dictionaries\n\n    ",
    "result": {
        "_links": {
            "next": "/api/3/action/datastore_search?offset=100&resource_id=4b3ebff6-4343-47df-b445-6b702cef540d",
            "start": "/api/3/action/datastore_search?resource_id=4b3ebff6-4343-47df-b445-6b702cef540d"
        },
        "fields": [
            {
                "id": "_id",
                "type": "int4"
            },
            {
                "id": "recvTimeTs",
                "type": "int4"
            },
            {
                "id": "recvTime",
                "type": "timestamp"
            },
            {
                "id": "entityId",
                "type": "text"
            },
            {
                "id": "entityType",
                "type": "text"
            },
            {
                "id": "attrName",
                "type": "text"
            },
            {
                "id": "attrType",
                "type": "text"
            },
            {
                "id": "attrValue",
                "type": "json"
            },
            {
                "id": "attrMd",
                "type": "json"
            }
        ],
        "records": [
            {
                "_id": 1,
                "attrMd": null,
                "attrName": "temperature",
                "attrType": "centigrade",
                "attrValue": "26.5",
                "entityId": "Room1",
                "entityType": "Room",
                "recvTime": "2015-09-24T15:34:08.976000",
                "recvTimeTs": 1443108848
            }
        ],
        "resource_id": "4b3ebff6-4343-47df-b445-6b702cef540d",
        "total": 1
    },
    "success": true
}
```
* Assignee @fgalan