### PR TITLE
bug/546_ckan_api_2_4

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - [HARDENING] Cygnus user creation added to the from the sources installation guide (#558)
 - [FEATURE] Add a binary implementation of the HDFS backend (#537)
 - [FEATURE] Add support to batch processing within a transaction in OrionHDFSSink (#554)
+- [BUG] Add support to CKAN 2.4 API changes (#546)

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -388,6 +388,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             // create the CKAN request JSON
             String jsonString = "{ \"name\": \"" + resourceName + "\", "
                     + "\"url\": \"none\", "
+                    + "\"format\": \"\", "
                     + "\"package_id\": \"" + pkgId + "\" }";
             
             // create the CKAN request URL

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -157,7 +157,7 @@ public class CKANCache extends HttpBackend {
         LOGGER.debug("Organization not found in the cache, querying CKAN for it (orgName=" + orgName + ")");
         
         // query CKAN for the organization information
-        String ckanURL = "/api/3/action/organization_show?id=" + orgName;
+        String ckanURL = "/api/3/action/organization_show?id=" + orgName + "&include_datasets=true";
         ArrayList<Header> headers = new ArrayList<Header>();
         headers.add(new BasicHeader("Authorization", apiKey));
         JsonResponse res = doRequest("GET", ckanURL, true, headers, null);


### PR DESCRIPTION
* Fixes issue #546 
* 100% unit tests passed:
```
Tests run: 59, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
time=2015-10-30T10:49:50.881CET | lvl=INFO | trans=1446198585-108-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1446198585-108-0000000000)
time=2015-10-30T10:49:50.886CET | lvl=INFO | trans=1446198585-108-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[232] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-10-30T10:49:50.892CET | lvl=INFO | trans=1446198585-108-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[255] : Event put in the channel (id=11514569, ttl=10)
time=2015-10-30T10:49:50.964CET | lvl=INFO | trans=1446198585-108-0000000000 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[207] : [ckan-sink] Persisting data at OrionCKANSink (orgName=def_serv_deleteme_1, pkgName=def_serv_deleteme_1_def_serv_path_delete_1, resName=room1_room, data=1446198590892,2015-10-30T09:49:50.892Z,Room1,Room,temperature,centigrade,"26.5",[])
time=2015-10-30T10:49:55.962CET | lvl=INFO | trans=1446198585-108-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[250] : Finishing transaction (1446198585-108-0000000000)
time=2015-10-30T10:50:43.304CET | lvl=INFO | trans=1446198585-108-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1446198585-108-0000000001)
time=2015-10-30T10:50:43.305CET | lvl=INFO | trans=1446198585-108-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[232] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-10-30T10:50:43.305CET | lvl=INFO | trans=1446198585-108-0000000001 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[255] : Event put in the channel (id=702863210, ttl=10)
time=2015-10-30T10:50:43.315CET | lvl=INFO | trans=1446198585-108-0000000001 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[207] : [ckan-sink] Persisting data at OrionCKANSink (orgName=def_serv_deleteme_1, pkgName=def_serv_deleteme_1_def_serv_path_delete_1, resName=room1_room, data=1446198643305,2015-10-30T09:50:43.305Z,Room1,Room,temperature,centigrade,"26.5",[])
time=2015-10-30T10:50:43.607CET | lvl=INFO | trans=1446198585-108-0000000001 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[250] : Finishing transaction (1446198585-108-0000000001)
```
![ckan_resource_view_create](https://cloud.githubusercontent.com/assets/3865056/10842819/d393d0d6-7ef4-11e5-92b1-96778af36dda.png)
* Assignee @fgalan, but LGTM from @acs is also required