### PR TITLE
feature/554_hdfs_persist_one

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -35,6 +35,7 @@ import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -335,7 +336,10 @@ public class OrionHDFSSink extends OrionSink {
     // TBD: to be removed once all the sinks have been migrated to persistBatch method
     @Override
     void persistOne(Map<String, String> eventHeaders, NotifyContextRequest notification) throws Exception {
-        throw new Exception("Not yet supoported. You should be using persistBatch method.");
+        Accumulator accumulator = new Accumulator();
+        accumulator.initializeBatching(new Date().getTime());
+        accumulator.accumulate(eventHeaders, notification);
+        persistBatch(accumulator.getDefaultBatch(), accumulator.getGroupedBatch());
     } // persistOne
     
     @Override


### PR DESCRIPTION
* Implements a missing part of #554 
* 100% unit test passed:
```
Tests run: 59, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
time=2015-10-30T12:29:25.238CET | lvl=INFO | trans=1446204529-182-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[150] : Starting transaction (1446204529-182-0000000000)
time=2015-10-30T12:29:25.241CET | lvl=INFO | trans=1446204529-182-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[232] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2015-10-30T12:29:25.246CET | lvl=INFO | trans=1446204529-182-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[255] : Event put in the channel (id=1573731302, ttl=10)
time=2015-10-30T12:29:25.357CET | lvl=INFO | trans=1446204529-182-0000000000 | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[854] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv_deleteme_1/def_serv_path_deleteme_1/room1_room/room1_room.txt), Data ({"recvTimeTs":"1446204565","recvTime":"2015-10-30T11:29:25.246Z","fiware-servicepath":"def_serv_path_deleteme_1","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2015-10-30T12:29:26.627CET | lvl=INFO | trans=1446204529-182-0000000000 | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[201] : Creating Hive external table=frb_def_serv_deleteme_1_def_serv_path_deleteme_1_room1_room_row
time=2015-10-30T12:29:27.966CET | lvl=INFO | trans=1446204529-182-0000000000 | function=process | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[178] : Finishing transaction (1446204529-182-0000000000)
...
...
$ hadoop fs -cat /user/frb/def_serv_deleteme_1/def_serv_path_deleteme_1/room1_room/room1_room.txt
{"recvTimeTs":"1446204565","recvTime":"2015-10-30T11:29:25.246Z","fiware-servicepath":"def_serv_path_deleteme_1","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```
* Assignee @fgalan