### PR TITLE
hardening/495_configurable_csv_field_separator

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -12,4 +12,4 @@
 - [HARDENING] Document the service_as_namespace OrionHDFSSink parameter (#692)
 - [HARDENING] Add a piece of documentation about multitenancy (#607)
 - [HARDENING] Add a piece of documentation about required dependencies to be manually installed when building and installing without dependencies (#635)
-- [HARDENING] Add a configurable value for csv_separator in OrionHDFSSink (#495)
+- [HARDENING] Add a configurable value for CSV separator in OrionHDFSSink (#495)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -12,3 +12,4 @@
 - [HARDENING] Document the service_as_namespace OrionHDFSSink parameter (#692)
 - [HARDENING] Add a piece of documentation about multitenancy (#607)
 - [HARDENING] Add a piece of documentation about required dependencies to be manually installed when building and installing without dependencies (#635)
+- [HARDENING] Add a configurable value for csv_separator in OrionHDFSSink (#495)

--- a/doc/flume_extensions_catalogue/orion_hdfs_sink.md
+++ b/doc/flume_extensions_catalogue/orion_hdfs_sink.md
@@ -197,14 +197,15 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | hdfs_password | yes | N/A | Password for the above `hdfs_username`/`cosmos_default_username`; this is only required for Hive authentication |
 | oauth2_token | yes | N/A | OAuth2 token required for the HDFS authentication |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`/`cosmos_default_username`, which in this case must be a HDFS superuser |
-| file_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>
+| file_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>|
+| csv_separator | no | , | |
 | batch_size | no | 1 | Number of events accumulated before persistence |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is |
 | hive | no | true | <i>true</i> or <i>false</i> |
 | hive\_server\_version<br>(**deprecated**) | no | 2 | `1` if the remote Hive server runs HiveServer1 or `2` if the remote Hive server runs HiveServer2.<br>Still usable; if both are configured, `hive.server_version` is preferred |
 | hive.server\_version | no | 2 | `1` if the remote Hive server runs HiveServer1 or `2` if the remote Hive server runs HiveServer2 |
-| hive_host<br>(**deprecated**) | no | localhost | Still usable; if both are configured, `hive.host` is preferred |
-| hive.host | no | localhost |
+| hive_host<br>(**deprecated**) | no | localhost | Still usable; if both are configured, `hive.host` is preferred |
+| hive.host | no | localhost |
 | hive_port<br>(**deprecated**) | no | 10000 | Still usable; if both are configured, `hive.port` is preferred |
 | hive.port | no | 10000 |
 | hive.db_type | no | detault-db | <i>default-db</i> or <i>namespace-db</i>. If `hive.db_type=default-db` then the default Hive database is used. If `hive.db_type=namespace-db` and `service_as_namespace=false` then the `hdfs_username` is used as Hive database. If `hive.db_type=namespace-db` and `service_as_namespace=true` then the notified fiware-service is used as Hive database. |

--- a/doc/installation_and_administration_guide/configuration.md
+++ b/doc/installation_and_administration_guide/configuration.md
@@ -129,6 +129,8 @@ cygnusagent.sinks.hdfs-sink.oauth2_token = xxxxxxxx
 cygnusagent.sinks.hdfs-sink.service_as_namespace = false
 # how the attributes are stored, available formats are json-row, json-column, csv-row and csv-column
 cygnusagent.sinks.hdfs-sink.file_format = json-column
+# character used for separating the values when using CSV file formats
+cygnusagent.sinks.hdfs-sink.csv_separator = ,
 # number of notifications to be included within a processing batch
 cygnusagent.sinks.hdfs-sink.batch_size = 100
 # timeout for batch accumulation
@@ -141,7 +143,7 @@ cygnusagent.sinks.hdfs-sink.hive.server_version = 2
 cygnusagent.sinks.hdfs-sink.hive.host = x.y.z.w
 # Hive port for Hive external table provisioning (ignored if hive is false)
 cygnusagent.sinks.hdfs-sink.hive.port = 10000
-# Hive database type, available types are default-db and namespace-db
+# Hive database type, available types are default-db and namespace-db
 cygnusagent.sinks.hdfs-sink.hive.db_type = default-db
 # Kerberos-based authentication enabling
 cygnusagent.sinks.hdfs-sink.krb5_auth = false

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -265,12 +265,7 @@ public class OrionHDFSSink extends OrionSink {
         } // if else
         
         String csvSeparator = context.getString("csv_separator", ",");        
-        if (csvSeparator != null && csvSeparator.length() > 0) {
-            separator = csvSeparator;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + separator + ")");
-        } else  {
-            LOGGER.error("[" + this.getName() + "] No CSV separator provided. Using default separator ','.");
-        } 
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + separator + ")");
         
         oauth2Token = context.getString("oauth2_token");
         

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -85,7 +85,7 @@ public class OrionHDFSSink extends OrionSink {
     private HiveDBType hiveDBType;
     private HDFSBackend persistenceBackend;
     private HiveBackend hiveBackend;
-    private String separator;
+    private String csvSeparator;
     
     /**
      * Constructor.
@@ -264,8 +264,8 @@ public class OrionHDFSSink extends OrionSink {
                     + "properly work!");
         } // if else
         
-        String csvSeparator = context.getString("csv_separator", ",");        
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + separator + ")");
+        csvSeparator = context.getString("csv_separator", ",");        
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + csvSeparator + ")");
         
         oauth2Token = context.getString("oauth2_token");
         
@@ -751,14 +751,14 @@ public class OrionHDFSSink extends OrionSink {
                 mdAggregations.put(attrMdFileName, concatMdAggregation);
                 
                 // aggreagate the data
-                String line = recvTimeTs / 1000 + separator
-                    + recvTime + separator
-                    + servicePath + separator
-                    + entityId + separator
-                    + entityType + separator
-                    + attrName + separator
-                    + attrType + separator
-                    + attrValue.replaceAll("\"", "") + separator
+                String line = recvTimeTs / 1000 + csvSeparator
+                    + recvTime + csvSeparator
+                    + servicePath + csvSeparator
+                    + entityId + csvSeparator
+                    + entityType + csvSeparator
+                    + attrName + csvSeparator
+                    + attrType + csvSeparator
+                    + attrValue.replaceAll("\"", "") + csvSeparator
                     + printableAttrMdFileName;
                 if (aggregation.isEmpty()) {
                     aggregation = line;
@@ -851,7 +851,7 @@ public class OrionHDFSSink extends OrionSink {
                 return;
             } // if
             
-            String line = recvTime + separator + servicePath + separator + entityId + separator + entityType;
+            String line = recvTime + csvSeparator + servicePath + csvSeparator + entityId + csvSeparator + entityType;
             
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
@@ -885,7 +885,7 @@ public class OrionHDFSSink extends OrionSink {
                 mdAggregations.put(attrMdFileName, concatMdAggregation);
                 
                 // create part of the line with the current attribute (a.k.a. a column)
-                line += separator + attrValue.replaceAll("\"", "") + separator + printableAttrMdFileName;
+                line += csvSeparator + attrValue.replaceAll("\"", "") + csvSeparator + printableAttrMdFileName;
             } // for
             
             // now, aggregate the line

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -264,17 +264,13 @@ public class OrionHDFSSink extends OrionSink {
                     + "properly work!");
         } // if else
         
-        String defaultCsvSeparator = context.getString("default_csv_separator");
-        String csvSeparator = context.getString("csv_separator");
+        String csvSeparator = context.getString("csv_separator", ",");        
         if (csvSeparator != null && csvSeparator.length() > 0) {
             separator = csvSeparator;
             LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + separator + ")");
-        } else if (defaultCsvSeparator != null && defaultCsvSeparator.length() > 0) {
-            separator = defaultCsvSeparator;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (default_csv_separator=" + separator + ")");
-        } else {
+        } else  {
             LOGGER.error("[" + this.getName() + "] No CSV separator provided. Using default separator ','.");
-        }
+        } 
         
         oauth2Token = context.getString("oauth2_token");
         

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -467,7 +467,7 @@ public class OrionHDFSSinkTest {
             context.put("hdfs_username", hdfsUsername);
         } // if else
         
-        context.put("csv_separator",csvSeparator);
+        context.put("csv_separator", csvSeparator);
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -65,6 +65,7 @@ public class OrionHDFSSinkTest {
     private final String hivePort = "10000";
     private final String enableKrb5Auth = "false";
     private final String enableGrouping = "true";
+    private final String defaultCsvSeparator = ",";
     
     // batches constants
     private final Long recvTimeTs = 123456789L;
@@ -466,6 +467,7 @@ public class OrionHDFSSinkTest {
             context.put("hdfs_username", hdfsUsername);
         } // if else
         
+        context.put("default_csv_separator",defaultCsvSeparator);
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -65,7 +65,7 @@ public class OrionHDFSSinkTest {
     private final String hivePort = "10000";
     private final String enableKrb5Auth = "false";
     private final String enableGrouping = "true";
-    private final String defaultCsvSeparator = ",";
+    private final String csvSeparator = ",";
     
     // batches constants
     private final Long recvTimeTs = 123456789L;
@@ -467,7 +467,7 @@ public class OrionHDFSSinkTest {
             context.put("hdfs_username", hdfsUsername);
         } // if else
         
-        context.put("default_csv_separator",defaultCsvSeparator);
+        context.put("csv_separator",csvSeparator);
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);


### PR DESCRIPTION
* Implements issue https://github.com/telefonicaid/fiware-cygnus/issues/495
* 100% unit test passed
```
Results :
Tests run: 72, Failures: 0, Errors: 0, Skipped: 0
```

I add some examples that I tested with new code: 

##### CSVROW
Testing with value `csv_separator = "++"` 
```
16/01/12 09:23:23 INFO sinks.OrionHDFSSink: 123456++1970-01-02T10:17:36.789Z++cars++car1++car++speed++float++112.9++hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```
Testing with value `csv_separator = "_"`
```
16/01/12 09:21:35 INFO sinks.OrionHDFSSink: 123456_1970-01-02T10:17:36.789Z_cars_car1_car_speed_float_112.9_hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```
Testing with default value `csv_separator = ","`
```
16/01/12 09:17:41 INFO sinks.OrionHDFSSink: 123456,1970-01-02T10:17:36.789Z,cars,car1,car,speed,float,112.9,hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```

##### CSVCOLUMN
Testing with value `csv_separator = "_"`
```
16/01/12 09:21:35 INFO sinks.OrionHDFSSink: 1970-01-02T10:17:36.789Z_cars_car1_car_112.9_hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```
Testing with value `csv_separator = "@@"`
```
16/01/12 09:24:50 INFO sinks.OrionHDFSSink: 1970-01-02T10:17:36.789Z@@cars@@car1@@car@@112.9@@hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```
Testing with default value `csv_separator = ","`
```
16/01/12 09:17:41 INFO sinks.OrionHDFSSink: 1970-01-02T10:17:36.789Z,cars,car1,car,112.9,hdfs:///user/user1/vehicles/cars/my_cars_speed_float/my_cars_speed_float.txt
```

The value "," has been selected as default (own decision) but we can choose the character that we want. In OrionHDFSSinkTest (line:68) there are a "defaultCsvSeparator" that can be modified. 

* Assignee @frbattid 
