### PR TITLE
feature/651_sth_use_time_instant

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -17,3 +17,4 @@
 - [HARDENING] Add a piece of documentation about required dependencies to be manually installed when building and installing without dependencies (#635)
 - [HARDENING] Add a configurable value for CSV separator in OrionHDFSSink (#495)
 - [HARDENING] Rename initializeBatching with initialize in all the sinks (#704)
+- [FEATURE] Use TimeInstant (when available) instead of the reception time in OrionSTHSink (#651)


### PR DESCRIPTION
* Implements issue #651 
* 100% unit tests passed:
```
Tests run: 72, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
Room1:Room
   * temperature with no metadata
   * pressure with TimeInstant metadata
   * humidity with empty metadata
   * luminance with metadata different than TimeInstant

time=2016-01-13T08:13:37.038CET | lvl=INFO | trans=1452669211-865-0000000000 | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[232] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "pressure",            "type" : "mmhg",            "value" : "720",            "metadatas": [              {                "name": "TimeInstant",                "type": "long",                "value": "12345000"              }            ]          },          {            "name" : "humidity",            "type" : "percentage",            "value" : "42",            "metadatas": [  ]          },          {            "name" : "luminance",            "type" : "lumen",            "value" : "14",            "metadatas": [              {                "name": "ID",                "type": "String",                "value": "x89.rt5"              }            ]          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-01-13T08:13:38.204CET | lvl=INFO | trans=1452669211-865-0000000000 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[147] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_def_serv, Collection: sth_/def_serv_path_room1_room.aggr, Data: 1452669217,2016-01-13T07:13:37.42Z,Room1,Room,temperature,Room,26.5,[]
time=2016-01-13T08:13:39.103CET | lvl=INFO | trans=1452669211-865-0000000000 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[147] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_def_serv, Collection: sth_/def_serv_path_room1_room.aggr, Data: 12345,1970-01-01T03:25:45.0Z,Room1,Room,pressure,Room,720,[{"name":"TimeInstant","type":"long","value":"12345000"}]
time=2016-01-13T08:13:39.792CET | lvl=INFO | trans=1452669211-865-0000000000 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[147] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_def_serv, Collection: sth_/def_serv_path_room1_room.aggr, Data: 1452669217,2016-01-13T07:13:37.42Z,Room1,Room,humidity,Room,42,[]
time=2016-01-13T08:13:40.563CET | lvl=INFO | trans=1452669211-865-0000000000 | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[147] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_def_serv, Collection: sth_/def_serv_path_room1_room.aggr, Data: 1452669217,2016-01-13T07:13:37.42Z,Room1,Room,luminance,Room,14,[{"name":"ID","type":"String","value":"x89.rt5"}]
```
* Assignee @pcoello25 