### PR TITLE
hardening/326_libthrift_issue_fix_from_pom_xml

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,3 +18,4 @@
 - [HARDENING] Add a configurable value for CSV separator in OrionHDFSSink (#495)
 - [HARDENING] Rename initializeBatching with initialize in all the sinks (#704)
 - [FEATURE] Use TimeInstant (when available) instead of the reception time in OrionSTHSink (#651)
+- [HARDENING] Fix libthrift installation (#706)

--- a/doc/installation_and_administration_guide/install_from_sources.md
+++ b/doc/installation_and_administration_guide/install_from_sources.md
@@ -62,6 +62,7 @@ Apache Flume can be easily installed by downloading its latests version from [fl
     $ mv apache-flume-1.4.0-bin APACHE_FLUME_HOME
     $ mv APACHE_FLUME_HOME/lib/httpclient-4.2.1.jar APACHE_FLUME_HOME/lib/httpclient-4.2.1.jar.old
     $ mv APACHE_FLUME_HOME/lib/httpcore-4.2.1.jar APACHE_FLUME_HOME/lib/httpcore-4.2.1.jar.old
+    $ mv APACHE_FLUME_HOME/lib/libthrift-0.7.0.jar APACHE_FLUME_HOME/lib/libthrift-0.7.0.jar.old
     $ mkdir -p APACHE_FLUME_HOME/plugins.d/cygnus/
     $ mkdir APACHE_FLUME_HOME/plugins.d/cygnus/lib
     $ mkdir APACHE_FLUME_HOME/plugins.d/cygnus/libext

--- a/doc/installation_and_administration_guide/install_from_sources.md
+++ b/doc/installation_and_administration_guide/install_from_sources.md
@@ -62,8 +62,6 @@ Apache Flume can be easily installed by downloading its latests version from [fl
     $ mv apache-flume-1.4.0-bin APACHE_FLUME_HOME
     $ mv APACHE_FLUME_HOME/lib/httpclient-4.2.1.jar APACHE_FLUME_HOME/lib/httpclient-4.2.1.jar.old
     $ mv APACHE_FLUME_HOME/lib/httpcore-4.2.1.jar APACHE_FLUME_HOME/lib/httpcore-4.2.1.jar.old
-    $ wget http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/libthrift-0.9.1.jar -P APACHE_FLUME_HOME/lib
-    $ mv APACHE_FLUME_HOME/lib/libthrift-0.7.0.jar APACHE_FLUME_HOME/lib/libthrift-0.7.0.jar.old
     $ mkdir -p APACHE_FLUME_HOME/plugins.d/cygnus/
     $ mkdir APACHE_FLUME_HOME/plugins.d/cygnus/lib
     $ mkdir APACHE_FLUME_HOME/plugins.d/cygnus/libext
@@ -72,7 +70,6 @@ Some remarks:
 
 * The creation of the `plugins.d` directory is related to the installation of third-party software, like Cygnus.
 * Please observe the version of `httpcomponents-core` and `httpcomponents-client` in the `pom.xml` (`httpclient-4.3.1.jar and httpcore-4.3.1.jar`) don't match match the version of such packages within the Flume bundle (`httpclient-4.2.1.jar and httpcore-4.2.1.jar`). In order the most recent version of the libraries, the ones within the Flume bundle must be removed (or renamed).
-* libthrift-0.9.1.jar must overwrite the 0.7.0 budled with Flume (it can be got from the [this](http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/libthrift-0.9.1.jar) URL).
 
 [Top](#top)
 
@@ -147,10 +144,8 @@ These are the packages you will need to install under `APACHE_FLUME_HOME/plugins
 |          httpclient          |       4.3.1        |
 |          httpcore            |       4.3.1        |
 |         jetty-server         |   7.2.0.v20101020  |
+|          libthrift           |       0.9.1        |
 
-In addition, as already said, remember to overwrite the `APACHE_FLUME_HOME/lib/libthrift-0.7.0.jar` package with this one:
-
-* libthrift-0.9.1.jar
 
 [Top](#top)
 

--- a/neore/scripts/package.sh
+++ b/neore/scripts/package.sh
@@ -54,22 +54,12 @@ function download_flume(){
         _logOk ".............. Done! .............."
     fi
 
-    _log "### Download libthrift patch... ###"
-    ARTIFACT_LIBTHRIFT_URL="http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/"
-    LIBTHRIFT_JAR=libthrift-0.9.1.jar 
-    curl -s -o ${LIBTHRIFT_JAR} ${ARTIFACT_LIBTHRIFT_URL}/${LIBTHRIFT_JAR}
-    if [[ $? -ne 0 ]]; then
-        _logError "cannot download libthrift jar (${LIBTHRIFT_JAR}) from ${ARTIFACT_LIBTHRIFT_URL}"
-        return 1
-    else
-        _logOk ".............. Done! .............."
-    fi
-    rm -f ${FLUME_WO_TAR}/lib/libthrift-*.jar
-    mv ${LIBTHRIFT_JAR} ${FLUME_WO_TAR}/lib
-
     _log "### Disable httpclient and httpcore libraries distributed within apache-flume bundle... ###"
     mv ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar.old
     mv ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar.old
+
+    _log "### Disable the bundled version of libthrift within Apache Flume... ###"
+    mv ${FLUME_WO_TAR}/lib/libthrift-0.9.1.jar ${FLUME_WO_TAR}/lib/libthrift-0.9.1.old
 
     _log "#### Cleaning the temporal folders... ####"
     rm -rf ${RPM_SOURCE_DIR}/${FLUME_WO_TAR}

--- a/neore/scripts/package.sh
+++ b/neore/scripts/package.sh
@@ -55,17 +55,6 @@ function download_flume(){
     fi
 
     
-    ARTIFACT_LIBTHRIFT_URL="http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/"
-    LIBTHRIFT_JAR=libthrift-0.9.1.jar 
-    curl -s -o ${LIBTHRIFT_JAR} ${ARTIFACT_LIBTHRIFT_URL}/${LIBTHRIFT_JAR}
-    if [[ $? -ne 0 ]]; then
-        _logError "cannot download libthrift jar (${LIBTHRIFT_JAR}) from ${ARTIFACT_LIBTHRIFT_URL}"
-        return 1
-    else
-        _logOk ".............. Done! .............."
-    fi
-    mv ${LIBTHRIFT_JAR} ${FLUME_WO_TAR}/lib
-
     _log "### Disable httpclient and httpcore libraries distributed within apache-flume bundle... ###"
     mv ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar.old
     mv ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar.old

--- a/neore/scripts/package.sh
+++ b/neore/scripts/package.sh
@@ -54,12 +54,24 @@ function download_flume(){
         _logOk ".............. Done! .............."
     fi
 
+    
+    ARTIFACT_LIBTHRIFT_URL="http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/"
+    LIBTHRIFT_JAR=libthrift-0.9.1.jar 
+    curl -s -o ${LIBTHRIFT_JAR} ${ARTIFACT_LIBTHRIFT_URL}/${LIBTHRIFT_JAR}
+    if [[ $? -ne 0 ]]; then
+        _logError "cannot download libthrift jar (${LIBTHRIFT_JAR}) from ${ARTIFACT_LIBTHRIFT_URL}"
+        return 1
+    else
+        _logOk ".............. Done! .............."
+    fi
+    mv ${LIBTHRIFT_JAR} ${FLUME_WO_TAR}/lib
+
     _log "### Disable httpclient and httpcore libraries distributed within apache-flume bundle... ###"
     mv ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar ${FLUME_WO_TAR}/lib/httpclient-4.2.1.jar.old
     mv ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar ${FLUME_WO_TAR}/lib/httpcore-4.2.1.jar.old
 
     _log "### Disable the bundled version of libthrift within Apache Flume... ###"
-    mv ${FLUME_WO_TAR}/lib/libthrift-0.9.1.jar ${FLUME_WO_TAR}/lib/libthrift-0.9.1.old
+    mv ${FLUME_WO_TAR}/lib/libthrift-0.7.0.jar ${FLUME_WO_TAR}/lib/libthrift-0.7.0.old
 
     _log "#### Cleaning the temporal folders... ####"
     rm -rf ${RPM_SOURCE_DIR}/${FLUME_WO_TAR}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.telefonica.iot</groupId>
   <artifactId>cygnus</artifactId>
-  <version>0.11.0</version>
+  <version>0.11.0_SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cygnus</name>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>1.10.32</version>
     </dependency>
+    <dependency>
+	<groupId>org.apache.thrift</groupId>
+	<artifactId>libthrift</artifactId>
+	<version>0.9.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.telefonica.iot</groupId>
   <artifactId>cygnus</artifactId>
-  <version>0.11.0_SNAPSHOT</version>
+  <version>0.11.0</version>
   <packaging>jar</packaging>
 
   <name>cygnus</name>


### PR DESCRIPTION
* Fix issue #326 
* Cygnus installed on my computer without any problem. 
I checked my installation path, in `/usr/cygnus/lib` where `libthrift-0.7.0.old` has the .old extension and `libthrift-0.9.1.jar` doesn't appear due to it's included in the .jar file `cygnus-0.11.0-jar-with-dependencies.jar`
* Assignee @frbattid & @vgarciag 