### PR TITLE
feature/737_management_interface_stats

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [FEATURE] Add /stats route to the Management Interface (#737)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Running](#section2.4)
     * [Unit testing](#section2.5)
     * [e2e testing](#section2.6)
+    * [Management API overview](#section2.7)
 * [Advanced topics and further reading](#section3)
 * [Features summary](#section4)
 * [Licensing](#section5)
@@ -166,6 +167,57 @@ Or you can connect a real NGSI source such as [Orion Context Broker](https://git
 
 [Top](#top)
 
+###<a name="section2.7"></a>Management API overview
+Run the following `curl` in order to get the version (assuming Cygnus runs on `localhost`):
+
+```
+$ curl -X GET "http://localhost:8081/version"
+{"version":"0.12.0.56eb400c2c50a87e34d6985326fc2c6eb044955c"}
+```
+
+Run the following `curl` in order to get certain Flume components statistics (assuming Cygnus runs on `localhost`):
+
+```
+$ curl -X GET "http://localhost:8081/stats" | python -m json.tool
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   489  100   489    0     0  81500      0 --:--:-- --:--:-- --:--:-- 97800
+{
+    "channels": [
+        {
+            "name": "mysql-channel",
+            "num_events": 0,
+            "num_puts_failed": 0,
+            "num_puts_ok": 11858,
+            "num_takes_failed": 1,
+            "num_takes_ok": 11858,
+            "setup_time": "2016-02-05T10:34:25.80Z",
+            "status": "START"
+        }
+    ],
+    "sinks": [
+        {
+            "name": "mysql-sink",
+            "num_persisted_events": 11800,
+            "num_processed_events": 11858,
+            "setup_time": "2016-02-05T10:34:24.978Z",
+            "status": "START"
+        }
+    ],
+    "sources": [
+        {
+            "name": "http-source",
+            "num_processed_events": 11858,
+            "num_received_events": 11858,
+            "setup_time": "2016-02-05T10:34:24.921Z",
+            "status": "START"
+        }
+    ]
+}
+```
+
+[Top](#top)
+
 ##<a name="section3"></a>Advanced topics and further reading
 Detailed information regarding Cygnus can be found in the [Installation and Administration Guide](./installation_and_administration_guide/introduction.md), the [User and Programmer Guide](./user_and_programmer_guide/introduction.md) and the [Flume extensions catalogue](./flume_extensions_catalogue/introduction.md). The following is just a list of shortcuts regarding the most popular topics:
 
@@ -216,6 +268,8 @@ Detailed information regarding Cygnus can be found in the [Installation and Admi
   <tr><td>Infinite events TTL</td><td>0.7.0</td></tr>
   <tr><td>enable/disable Grouping Rules</td><td>0.9.0</td></tr>
   <tr><td>Data model configuration</td><td>0.12.0</td></tr>
+  <tr><td rowspan="2">Management Interface</td><td>/version</td><td>0.5.0</td></tr>
+  <tr><td>/stats</td><td>0.12.0</td></tr>
   <tr><td rowspan="7">General</td><td>RPM building framework</td><td>0.3.0</td></tr>
   <tr><td>TDAF-like logs</td><td>0.4.0</td></tr>
   <tr><td>RoundRobinChannelSelector</td><td>0.6.0</td></tr>

--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -1,8 +1,90 @@
 #Management interface
-From Cygnus 0.5 there is a REST-based management interface for administration purposes. Current available operations are:
+Content:
 
-<b>Get the version of the running software, including the last Git commit</b>:
+* [GET `/version`](#section1)
+* [GET `/stats`](#section2)
 
-    GET http://host:management_port/version
+##<a name="section1"></a>`GET /version`
+Gets the version of the running software, including the last Git commit:
 
-    {"version":"0.5_SNAPSHOT.8a6c07054da894fc37ef30480cb091333e2fccfa"}
+```
+GET http://<cygnus_host>:<management_port>/version
+```
+
+Response:
+
+```
+{"version":"0.5_SNAPSHOT.8a6c07054da894fc37ef30480cb091333e2fccfa"}
+```
+
+##<a neme="section2"></a>`GET /stats`
+Gets statistics about the configured Flume components.
+
+Regarding the sources, it returns:
+
+* Name of the source as written in the configuration.
+* Setup time of the source.
+* Status of the source, i.e. started or stopped.
+* Number of processed events, i.e. number of events received by the source and attempeted to be put in the channels.
+* Number of finally events put in the channels.
+
+Regarding the channels, it returns:
+
+* Name of the channel as written in the configuration.
+* Setup time of the channel.
+* Status of the channel, i.e. started or stopped.
+* Number of events currently at the channel.
+* Number of successful puts.
+* Number of failed puts.
+* Number of sucessful takes.
+* Number of failed takes.
+
+Regarding the sinks, it returns:
+
+* Name of the sink as written in the configuration.
+* Setup time of the sink.
+* Status of the sink, i.e. started or stopped.
+* Number of processed events, i.e. number of events taken from the channel and attempted for persistence.
+* Number of finally persisted events.
+
+```
+GET http://<cygnus_host>:<management_port>/stats
+```
+
+Response:
+
+```
+{
+    "channels": [
+        {
+            "name": "mysql-channel",
+            "num_events": 0,
+            "num_puts_failed": 0,
+            "num_puts_ok": 11858,
+            "num_takes_failed": 1,
+            "num_takes_ok": 11858,
+            "setup_time": "2016-02-05T10:34:25.80Z",
+            "status": "START"
+        }
+    ],
+    "sinks": [
+        {
+            "name": "mysql-sink",
+            "num_persisted_events": 11800,
+            "num_processed_events": 11858,
+            "setup_time": "2016-02-05T10:34:24.978Z",
+            "status": "START"
+        }
+    ],
+    "sources": [
+        {
+            "name": "http-source",
+            "num_processed_events": 11858,
+            "num_received_events": 11858,
+            "setup_time": "2016-02-05T10:34:24.921Z",
+            "status": "START"
+        }
+    ]
+}
+```
+

--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -1,4 +1,4 @@
-#Management interface
+#<a name="top"></a>Management interface
 Content:
 
 * [GET `/version`](#section1)
@@ -16,6 +16,8 @@ Response:
 ```
 {"version":"0.5_SNAPSHOT.8a6c07054da894fc37ef30480cb091333e2fccfa"}
 ```
+
+[Top](#top)
 
 ##<a neme="section2"></a>`GET /stats`
 Gets statistics about the configured Flume components.
@@ -88,3 +90,4 @@ Response:
 }
 ```
 
+[Top](#top)

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -26,10 +26,40 @@ package com.telefonica.iot.cygnus.channels;
 public interface CygnusChannel {
     
     /**
+     * Gets the setup time of the channel.
+     * @return The setup time (in miliseconds) of the channel
+     */
+    long getSetupTime();
+    
+    /**
      * Gets the number of events within the channel.
      * @return The number of events within the channel.
      */
-    int getNumEvents();
+    long getNumEvents();
+    
+    /**
+     * Gets the number of put operations on the channel that went OK.
+     * @return The number of put operations on the channel that went OK
+     */
+    long getNumPutsOK();
+    
+    /**
+     * Gets the number of put operations on the channel that failed.
+     * @return The number of put operations on the channel that failed
+     */
+    long getNumPutsFail();
+    
+    /**
+     * Gets the number of take operations on the channel that went OK.
+     * @return The number of take operations on the channel that went OK
+     */
+    long getNumTakesOK();
+    
+    /**
+     * Gets the number of take operations on the channel that failed.
+     * @return The number of take operations on the channel that failed
+     */
+    long getNumTakesFail();
     
     /**
      * Rollbacks the number of events when a transaction is rollbacked as well. This method is necessary because when

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusFileChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusFileChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -17,6 +17,7 @@
  */
 package com.telefonica.iot.cygnus.channels;
 
+import java.util.Date;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.channel.file.FileChannel;
@@ -29,8 +30,13 @@ import org.apache.flume.channel.file.FileChannel;
  */
 public class CygnusFileChannel extends FileChannel implements CygnusChannel {
     
-    private int numEvents;
-    private int capacity;
+    private long setupTime;
+    private long numEvents;
+    private long numPutsOK;
+    private long numPutsFail;
+    private long numTakesOK;
+    private long numTakesFail;
+    private long capacity;
     
     @Override
     public void configure(Context context) {
@@ -41,14 +47,22 @@ public class CygnusFileChannel extends FileChannel implements CygnusChannel {
     @Override
     protected void initialize() {
         super.initialize();
+        setupTime = new Date().getTime();
         numEvents = 0;
+        numPutsOK = 0;
+        numPutsFail = 0;
+        numTakesOK = 0;
+        numTakesFail = 0;
     } // initialize
     
     @Override
     public void put(Event event) {
         if (numEvents != capacity) {
             numEvents++;
-        } // if
+            numPutsOK++;
+        } else {
+            numPutsFail++;
+        } // if else
         
         // independently of the remaining capacity, call the super version of the method in order to behave as a
         // FileChannel (exceptions, errors, etc)
@@ -61,15 +75,43 @@ public class CygnusFileChannel extends FileChannel implements CygnusChannel {
         
         if (event != null) {
             numEvents--;
-        } // if
+            numTakesOK++;
+        } else {
+            numTakesFail++;
+        } // if else
         
         return event;
     } // take
     
     @Override
-    public int getNumEvents() {
+    public long getSetupTime() {
+        return setupTime;
+    } // getSetupTime
+    
+    @Override
+    public long getNumEvents() {
         return numEvents;
     } // getNumEvents
+    
+    @Override
+    public long getNumPutsOK() {
+        return numPutsOK;
+    } // getNumPutsOK
+    
+    @Override
+    public long getNumPutsFail() {
+        return numPutsFail;
+    } // getNumPutsFail
+    
+    @Override
+    public long getNumTakesOK() {
+        return numTakesOK;
+    } // getNumTakesOK
+    
+    @Override
+    public long getNumTakesFail() {
+        return numTakesFail;
+    } // getNumTakesFail
     
     @Override
     public void rollback() {

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -17,6 +17,7 @@
  */
 package com.telefonica.iot.cygnus.channels;
 
+import java.util.Date;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.channel.MemoryChannel;
@@ -29,8 +30,13 @@ import org.apache.flume.channel.MemoryChannel;
  */
 public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel {
     
-    private int numEvents;
-    private int capacity;
+    private long setupTime;
+    private long numEvents;
+    private long numPutsOK;
+    private long numPutsFail;
+    private long numTakesOK;
+    private long numTakesFail;
+    private long capacity;
     
     @Override
     public void configure(Context context) {
@@ -41,14 +47,22 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
     @Override
     protected void initialize() {
         super.initialize();
+        setupTime = new Date().getTime();
         numEvents = 0;
+        numPutsOK = 0;
+        numPutsFail = 0;
+        numTakesOK = 0;
+        numTakesFail = 0;
     } // initialize
     
     @Override
     public void put(Event event) {
         if (numEvents != capacity) {
             numEvents++;
-        } // if
+            numPutsOK++;
+        } else {
+            numPutsFail++;
+        } // if else
         
         // independently of the remaining capacity, call the super version of the method in order to behave as a
         // MemoryChannel (exceptions, errors, etc)
@@ -61,15 +75,43 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
         
         if (event != null) {
             numEvents--;
-        } // if
+            numTakesOK++;
+        } else {
+            numTakesFail++;
+        } // if else
         
         return event;
     } // take
     
     @Override
-    public int getNumEvents() {
+    public long getSetupTime() {
+        return setupTime;
+    } // getSetupTime
+    
+    @Override
+    public long getNumEvents() {
         return numEvents;
     } // getNumEvents
+    
+    @Override
+    public long getNumPutsOK() {
+        return numPutsOK;
+    } // getNumPutsOK
+    
+    @Override
+    public long getNumPutsFail() {
+        return numPutsFail;
+    } // getNumPutsFail
+    
+    @Override
+    public long getNumTakesOK() {
+        return numTakesOK;
+    } // getNumTakesOK
+    
+    @Override
+    public long getNumTakesFail() {
+        return numTakesFail;
+    } // getNumTakesFail
     
     @Override
     public void rollback() {

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -56,6 +56,10 @@ public class OrionRestHandler implements HTTPSourceHandler {
     private long transactionCount;
     private final long bootTimeSeconds;
     private long bootTimeMilliseconds;
+    // statistics
+    private final long setupTime;
+    private long numReceivedEvents;
+    private long numProcessedEvents;
     
     /**
      * Constructor. This can be used as a place where to initialize all that things we would like to do in the Flume
@@ -73,7 +77,36 @@ public class OrionRestHandler implements HTTPSourceHandler {
         
         // print Cygnus version
         LOGGER.info("Cygnus version (" + Utils.getCygnusVersion() + "." + Utils.getLastCommit() + ")");
+        
+        // initialize the statistics
+        setupTime = new Date().getTime();
+        numReceivedEvents = 0;
+        numProcessedEvents = 0;
     } // OrionRestHandler
+    
+    /**
+     * Gets the setup time.
+     * @return The setup time
+     */
+    public long getSetupTime() {
+        return setupTime;
+    } // getSetupTime
+    
+    /**
+     * Gets the number of received events.
+     * @return The number of received events
+     */
+    public long getNumReceivedEvents() {
+        return numReceivedEvents;
+    } // getNumReceivedEvents
+        
+    /**
+     * Gets the number of processed events.
+     * @return The number of processed events
+     */
+    public long getNumProcessedEvents() {
+        return numProcessedEvents;
+    } // getNumProcessedEvents
     
     /**
      * Gets the notifications target. It is protected due to it is only required for testing purposes.
@@ -143,6 +176,8 @@ public class OrionRestHandler implements HTTPSourceHandler {
             
     @Override
     public List<Event> getEvents(javax.servlet.http.HttpServletRequest request) throws Exception {
+        numReceivedEvents++;
+        
         // check the method
         String method = request.getMethod().toUpperCase(Locale.ENGLISH);
         
@@ -248,7 +283,8 @@ public class OrionRestHandler implements HTTPSourceHandler {
         LOGGER.debug("Adding flume event header (name=" + Constants.HTTP_HEADER_FIWARE_SERVICE_PATH
                 + ", value=" + (servicePath == null ? defaultServicePath : servicePath) + ")");
         eventHeaders.put(Constants.FLUME_HEADER_TRANSACTION_ID, transId);
-        LOGGER.debug("Adding flume event header (name=" + Constants.FLUME_HEADER_TRANSACTION_ID + ", value=" + transId + ")");
+        LOGGER.debug("Adding flume event header (name=" + Constants.FLUME_HEADER_TRANSACTION_ID
+                + ", value=" + transId + ")");
         eventHeaders.put(Constants.FLUME_HEADER_TTL, eventsTTL);
         LOGGER.debug("Adding flume event header (name=" + Constants.FLUME_HEADER_TTL + ", value=" + eventsTTL + ")");
         
@@ -257,6 +293,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
         Event event = EventBuilder.withBody(data.getBytes(), eventHeaders);
         eventList.add(event);
         LOGGER.info("Event put in the channel (id=" + event.hashCode() + ", ttl=" + eventsTTL + ")");
+        numProcessedEvents++;
         return eventList;
     } // getEvents
     

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -174,7 +174,7 @@ public class ManagementInterface extends AbstractHandler {
                 jsonStr += "\"setup_time\":\"unknown\","
                         + "\"num_events\":-1,"
                         + "\"num_puts_ok\":-1,"
-                        + "\"num_puts_failed\":-1m"
+                        + "\"num_puts_failed\":-1,"
                         + "\"num_takes_ok\":-1,"
                         + "\"num_takes_failed\":-1}";
             } // if else

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/Batch.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/Batch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -31,6 +31,7 @@ import java.util.Set;
  */
 public class Batch {
     
+    private long numEvents;
     private final ArrayList<String> persistedDestinations;
     private final HashMap<String, ArrayList<CygnusEvent>> eventsPerDestination;
 
@@ -38,6 +39,7 @@ public class Batch {
      * Constructor.
      */
     public Batch() {
+        numEvents = 0;
         persistedDestinations = new ArrayList<String>();
         eventsPerDestination = new HashMap<String, ArrayList<CygnusEvent>>();
     } // Batch
@@ -54,15 +56,23 @@ public class Batch {
     public ArrayList<CygnusEvent> getEvents(String destination) {
         return eventsPerDestination.get(destination);
     } // getEvents
-
+    
     /**
-     * Adds a events of events to a given destination.
+     * Adds an event to a sub-barch, given its destination.
      * @param destination
-     * @param events
+     * @param event
      */
-    public void addEvents(String destination, ArrayList<CygnusEvent> events) {
-        eventsPerDestination.put(destination, events);
-    } // addEvents
+    public void addEvent(String destination, CygnusEvent event) {
+        ArrayList<CygnusEvent> list = eventsPerDestination.get(destination);
+
+        if (list == null) {
+            list = new ArrayList<CygnusEvent>();
+            eventsPerDestination.put(destination, list);
+        } // if
+        
+        list.add(event);
+        numEvents++;
+    } // addEvent
 
     /**
      * Sets a destination has been persistedDestinations.
@@ -80,5 +90,13 @@ public class Batch {
     public boolean isPersisted(String destination) {
         return persistedDestinations.contains(destination);
     } // isPersisted
+    
+    /**
+     * Gets the total number of events within this batch.
+     * @return The total number of events within this batch
+     */
+    public long getNumEvents() {
+        return numEvents;
+    } // getNumEvents
         
 } // Batch

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
@@ -403,10 +403,8 @@ public class OrionCKANSinkTest {
             NotifyContextRequest.ContextElement contextElement) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, destination, null,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSinkTest.java
@@ -326,10 +326,8 @@ public class OrionDynamoDBSinkTest {
             NotifyContextRequest.ContextElement contextElement) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, destination, null,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -446,10 +446,8 @@ public class OrionHDFSSinkTest {
             ContextElement contextElement) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, destination, null,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -414,8 +414,6 @@ public class OrionKafkaSinkTest {
             NotifyContextRequest.ContextElement contextElement, DataModel dataModel) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, entity, attribute,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
         String destination;
         
@@ -436,7 +434,7 @@ public class OrionKafkaSinkTest {
                 destination = null;
         } // switch
         
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSinkTest.java
@@ -328,10 +328,8 @@ public class OrionMySQLSinkTest {
             NotifyContextRequest.ContextElement contextElement) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, destination, null,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSinkTest.java
@@ -325,10 +325,8 @@ public class OrionPostgreSQLSinkTest {
             NotifyContextRequest.ContextElement contextElement) {
         CygnusEvent groupedEvent = new CygnusEvent(recvTimeTs, service, servicePath, destination, null,
             contextElement);
-        ArrayList<CygnusEvent> groupedBatchEvents = new ArrayList<CygnusEvent>();
-        groupedBatchEvents.add(groupedEvent);
         Batch batch = new Batch();
-        batch.addEvents(destination, groupedBatchEvents);
+        batch.addEvent(destination, groupedEvent);
         return batch;
     } // createBatch
 


### PR DESCRIPTION
* Implements issue #737 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/stats" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   774  100   774    0     0   118k      0 --:--:-- --:--:-- --:--:--  125k
{
    "channels": [
        {
            "name": "ckan-channel",
            "num_events": -1,
            "num_puts_failed": -1,
            "num_puts_ok": -1,
            "num_takes_failed": -1,
            "num_takes_ok": -1,
            "setup_time": "unknown",
            "status": "START"
        },
        {
            "name": "mysql-channel",
            "num_events": 37,
            "num_puts_failed": 0,
            "num_puts_ok": 1637,
            "num_takes_failed": 3,
            "num_takes_ok": 1600,
            "setup_time": "2016-02-05T11:19:04.817Z",
            "status": "START"
        }
    ],
    "sinks": [
        {
            "name": "ckan-sink",
            "num_persisted_events": 0,
            "num_processed_events": 1637,
            "setup_time": "2016-02-05T11:19:04.743Z",
            "status": "START"
        },
        {
            "name": "mysql-sink",
            "num_persisted_events": 1500,
            "num_processed_events": 1600,
            "setup_time": "2016-02-05T11:19:04.746Z",
            "status": "START"
        }
    ],
    "sources": [
        {
            "name": "http-source",
            "num_processed_events": 1637,
            "num_received_events": 1637,
            "setup_time": "2016-02-05T11:19:04.679Z",
            "status": "START"
        }
    ]
}
```
* Assignee @pcoello25 