### PR TITLE
feature/745_add_groupingrules_route_to_the_api

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - [FEATURE] Add /stats route to the Management Interface (#737)
+- [FEATURE] Add /groupingrules route to the Management Interface (#745)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ $ curl -X GET "http://localhost:8081/v1/stats" | python -m json.tool
 }
 ```
 
+Many other operations, like getting/updating/deleting the grouping rules can be found in Management Interface [documentation](./doc/installation_and_administration_guide/management_interface.md).
+
 [Top](#top)
 
 ##<a name="section3"></a>Advanced topics and further reading
@@ -268,8 +270,10 @@ Detailed information regarding Cygnus can be found in the [Installation and Admi
   <tr><td>Infinite events TTL</td><td>0.7.0</td></tr>
   <tr><td>enable/disable Grouping Rules</td><td>0.9.0</td></tr>
   <tr><td>Data model configuration</td><td>0.12.0</td></tr>
-  <tr><td rowspan="2">Management Interface</td><td>/version</td><td>0.5.0</td></tr>
-  <tr><td>/stats</td><td>0.12.0</td></tr>
+  <tr><td rowspan="4">Management Interface</td><td>GET /version</td><td>0.5.0</td></tr>
+  <tr><td>GET /stats</td><td>0.12.0</td></tr>
+  <tr><td>GET /groupingrules</td><td>0.12.0</td></tr>
+  <tr><td>POST /groupingrules</td><td>0.12.0</td></tr>
   <tr><td rowspan="7">General</td><td>RPM building framework</td><td>0.3.0</td></tr>
   <tr><td>TDAF-like logs</td><td>0.4.0</td></tr>
   <tr><td>RoundRobinChannelSelector</td><td>0.6.0</td></tr>

--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -3,6 +3,8 @@ Content:
 
 * [GET `/v1/version`](#section1)
 * [GET `/v1/stats`](#section2)
+* [GET `/v1/groupingrules`](#section3)
+* [POST `/v1/groupingrules`](#section4)
 
 ##<a name="section1"></a>`GET /v1/version`
 Gets the version of the running software, including the last Git commit:
@@ -14,7 +16,7 @@ GET http://<cygnus_host>:<management_port>/v1/version
 Response:
 
 ```
-{"version":"0.5_SNAPSHOT.8a6c07054da894fc37ef30480cb091333e2fccfa"}
+{"version":"0.12.0.8a6c07054da894fc37ef30480cb091333e2fccfa"}
 ```
 
 [Top](#top)
@@ -88,6 +90,64 @@ Response:
         }
     ]
 }
+```
+
+[Top](#top)
+
+##<a neme="section3"></a>`GET /v1/groupingrules`
+Gets the configured grouping rules.
+
+```
+GET http://<cygnus_host>:<management_port>/v1/groupingrules
+```
+
+Response:
+
+```
+{
+    "grouping_rules": [
+        {
+            "destination": "allcars",
+            "fields": [
+                "entityType"
+            ],
+            "fiware_service_path": "cars",
+            "id": 1,
+            "regex": "Car"
+        },
+        {
+            "destination": "allrooms",
+            "fields": [
+                "entityType"
+            ],
+            "fiware_service_path": "rooms",
+            "id": 2,
+            "regex": "Room"
+        }
+    ]
+}
+```
+
+[Top](#top)
+
+##<a neme="section4"></a>`POST /v1/groupingrules`
+Adds a new rule, passed as a Json in the payload, to the grouping rules.
+
+```
+POST http://<cygnus_host>:<management_port>/v1/groupingrules
+{
+	"id": 2,
+	"regex": "Room",
+	"destination": "allrooms",
+	"fiware_service_path": "rooms",
+	"fields": ["entityType"]
+}
+```
+
+Response:
+
+```
+{"success":"true"}
 ```
 
 [Top](#top)

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.interceptors;
+
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import com.telefonica.iot.cygnus.utils.Utils;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+/**
+ *
+ * @author frb
+ */
+public class GroupingRules {
+    
+    private static final CygnusLogger LOGGER = new CygnusLogger(GroupingRules.class);
+    private LinkedList<GroupingRule> groupingRules;
+
+    /**
+     * Constructor.
+     */
+    public GroupingRules() {
+        groupingRules = null;
+    } // GroupingRules
+
+    public synchronized LinkedList<GroupingRule> getRules() {
+        return groupingRules;
+    } // getRules
+
+    /**
+     * Sets the grouping rules given a Json Array of rules.
+     * @param jsonRules
+     */
+    public synchronized void setRules(JSONArray jsonRules) {
+        groupingRules = new LinkedList<GroupingRule>();
+
+        for (Object jsonGroupingRule : jsonRules) {
+            JSONObject jsonRule = (JSONObject) jsonGroupingRule;
+            int err = isValid(jsonRule);
+
+            if (err == 0) {
+                GroupingRule rule = new GroupingRule(jsonRule);
+                groupingRules.add(rule);
+            } else {
+                switch (err) {
+                    case 1:
+                        LOGGER.warn("Invalid grouping rule, some field is missing. It will be discarded. Details="
+                                + jsonRule.toJSONString());
+                        break;
+                    case 2:
+                        LOGGER.warn("Invalid grouping rule, the id is not numeric or it is missing. It will be "
+                                + "discarded. Details=" + jsonRule.toJSONString());
+                        break;
+                    case 3:
+                        LOGGER.warn("Invalid grouping rule, some field is empty. It will be discarded. Details="
+                                + jsonRule.toJSONString());
+                        break;
+                    default:
+                } // switch
+            } // if else
+        } // for
+    } // setRules
+
+    /**
+     * Gets the rule matching the given context element for the given service path.
+     * @param contextElement
+     * @param servicePath
+     * @return
+     */
+    public synchronized GroupingRule getMatchingRule(ContextElement contextElement, String servicePath) {
+        if (groupingRules != null) {
+            for (GroupingRule rule : groupingRules) {
+                String concat = concatenateFields(rule.getFields(), contextElement, servicePath);
+                Matcher matcher = rule.pattern.matcher(concat);
+
+                if (matcher.matches()) {
+                    return rule;
+                } // if
+            } // for
+
+            return null;
+        } else {
+            return null;
+        } // if else
+    } // getMatchingRule
+    
+    private String concatenateFields(ArrayList<String> fields, ContextElement contextElement, String servicePath) {
+        String concat = "";
+
+        for (String field : fields) {
+            if (field.equals("entityId")) {
+                concat += contextElement.getString(field);
+            } else if (field.equals("entityType")) {
+                concat += contextElement.getString(field);
+            } else if (field.equals("servicePath")) {
+                concat += servicePath;
+            } // if else
+        } // for
+        
+        return concat;
+    } // concatenateFields
+
+    private int isValid(JSONObject jsonRule) {
+        // check if the rule contains all the required fields
+        if (!jsonRule.containsKey("id")
+                || !jsonRule.containsKey("fields")
+                || !jsonRule.containsKey("regex")
+                || !jsonRule.containsKey("destination")
+                || !jsonRule.containsKey("fiware_service_path")) {
+            return 1;
+        } // if
+
+        // check if the id is numeric
+        try {
+            Long l = (Long) jsonRule.get("id");
+        } catch (Exception e) {
+            return 2;
+        } // catch
+
+        // check if the rule has any empty field
+        if (((JSONArray) jsonRule.get("fields")).size() == 0
+                || ((String) jsonRule.get("regex")).length() == 0
+                || ((String) jsonRule.get("destination")).length() == 0
+                || ((String) jsonRule.get("fiware_service_path")).length() == 0) {
+            return 3;
+        } // if
+
+        return 0;
+    } // isValid
+    
+    /**
+     * Each one of the entries of the matching table.
+     */
+    protected class GroupingRule {
+        
+        private final long id;
+        private final ArrayList<String> fields;
+        private final Pattern pattern;
+        private final String destination;
+        private final String newFiwareServicePath;
+        
+        /**
+         * Constructor.
+         * @param jsonRule
+         */
+        public GroupingRule(JSONObject jsonRule) {
+            this.id = (Long) jsonRule.get("id");
+            this.fields = (JSONArray) jsonRule.get("fields");
+            this.pattern = Pattern.compile((String) jsonRule.get("regex"));
+            this.destination = Utils.encode((String) jsonRule.get("destination"));
+            this.newFiwareServicePath = Utils.encode((String) jsonRule.get("fiware_service_path"));
+        } // GroupingRule
+        
+        /**
+         * Gets the rule's id.
+         * @return
+         */
+        public long getId() {
+            return id;
+        } // getId
+        
+        /**
+         * Gets the rule's fields array.
+         * @return The rule's fields array.
+         */
+        public ArrayList<String> getFields() {
+            return fields;
+        } // getFields
+        
+        /**
+         * Gets the rule's regular expression.
+         * @return the rule's regular expression.
+         */
+        public String getRegex() {
+            return pattern.toString();
+        } // getRegex
+        
+        /**
+         * Gets the rule's destination.
+         * @return The rule's destination.
+         */
+        public String getDestination() {
+            return destination;
+        } // destination
+        
+        /**
+         * Gets the rule's newFiwareServicePath.
+         * @return The rule's newFiwareServicePath.
+         */
+        public String getNewFiwareServicePath() {
+            return newFiwareServicePath;
+        } // getNewFiwareServicePath
+        
+    } // GroupingRule
+    
+} // GroupingRules

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -24,6 +24,7 @@ import com.telefonica.iot.cygnus.handlers.OrionRestHandler;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.OrionSink;
 import com.telefonica.iot.cygnus.utils.Utils;
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import javax.servlet.ServletException;
@@ -47,19 +48,22 @@ import org.mortbay.jetty.handler.AbstractHandler;
 public class ManagementInterface extends AbstractHandler {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(ManagementInterface.class);
+    private final File configurationFile;
     private final ImmutableMap<String, SourceRunner> sources;
     private final ImmutableMap<String, Channel> channels;
     private final ImmutableMap<String, SinkRunner> sinks;
     
     /**
      * Constructor.
+     * @param configurationFile
      * @param sources
      * @param channels
      * @param sinks
      */
-    public ManagementInterface(ImmutableMap<String, SourceRunner> sources, ImmutableMap<String, Channel> channels,
-            ImmutableMap<String, SinkRunner> sinks) {
+    public ManagementInterface(File configurationFile, ImmutableMap<String, SourceRunner> sources, ImmutableMap<String,
+            Channel> channels, ImmutableMap<String, SinkRunner> sinks) {
         // FIXME: these references are ready to be used for more advanced Management Interface operations
+        this.configurationFile = configurationFile;
         this.sources = sources;
         this.channels = channels;
         this.sinks = sinks;

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -27,7 +27,9 @@ import com.telefonica.iot.cygnus.utils.Utils;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -39,6 +41,10 @@ import org.apache.flume.SinkRunner;
 import org.apache.flume.Source;
 import org.apache.flume.SourceRunner;
 import org.apache.flume.source.http.HTTPSourceHandler;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.mortbay.jetty.HttpConnection;
 import org.mortbay.jetty.Request;
 import org.mortbay.jetty.handler.AbstractHandler;
@@ -51,6 +57,7 @@ public class ManagementInterface extends AbstractHandler {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(ManagementInterface.class);
     private final File configurationFile;
+    private String groupingRulesConfFile;
     private final ImmutableMap<String, SourceRunner> sources;
     private final ImmutableMap<String, Channel> channels;
     private final ImmutableMap<String, SinkRunner> sinks;
@@ -95,14 +102,20 @@ public class ManagementInterface extends AbstractHandler {
                 handleGetGroupingRules(response);
             } else {
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                response.getWriter().println("404 - Not found");
+                response.getWriter().println("404 - " + method + " " + uri + " Not found");
+            } // if else
+        } else if (method.equals("POST")) {
+            if (uri.equals("/v1/groupingrules")) {
+                handlePostGroupingRules(request, response);
+            } else {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                response.getWriter().println("404 - " + method + " " + uri + " Not found");
             } // if else
         } else {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            response.getWriter().println("404 - Not found");
+            response.getWriter().println("404 - " + method + " " + uri + " Not found");
         } // if else
     } // handle
-    
     
     private void handleGetVersion(HttpServletResponse response) throws IOException {
         response.setContentType("json;charset=utf-8");
@@ -246,17 +259,118 @@ public class ManagementInterface extends AbstractHandler {
     } // handleGetStats
     
     private void handleGetGroupingRules(HttpServletResponse response) throws IOException {
+        String configStr = readGroupingRules();
         response.setContentType("json;charset=utf-8");
-        response.setStatus(HttpServletResponse.SC_OK);
         
-        if (!configurationFile.exists()) {
+        if (configStr.startsWith("404")) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            response.getWriter().println("404 - Configuration file for Cygnus not found. Details: "
-                    + configurationFile.toString());
+        } else {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } // if else
+        
+        response.getWriter().println(configStr);
+    } // handleGetGroupingRules
+    
+    private void handlePostGroupingRules(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("json;charset=utf-8");
+        
+        // read the grouing rules we want to modify
+        String configStr = readGroupingRules();
+        
+        // check if there was an error while reading the grouping rules
+        if (configStr.startsWith("404")) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println(configStr);
+            LOGGER.error("Grouping rules not found... but they are supposed to be there!!!");
             return;
         } // if
+
+        // there was no error, and the syntax of the already configured grouping rules should be OK...
+        // thus read the new rule wanted to be added
+        BufferedReader reader = request.getReader();
+        String ruleStr = "";
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+            ruleStr += line;
+        } // while
         
-        String groupingRulesConfFile = null;
+        reader.close();
+        LOGGER.debug("Grouping rule to be added: " + ruleStr);
+
+        // check the Json syntax of the new rule
+        JSONParser jsonParser = new JSONParser();
+        JSONObject rule;
+
+        try {
+            rule = (JSONObject) jsonParser.parse(ruleStr);
+        } catch (ParseException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("400 - Parse error, invalid Json syntax. Details: " + e.getMessage());
+            LOGGER.error("Parse error, invalid Json syntax. Details: " + e.getMessage());
+            return;
+        } // try catch
+
+        // check if the rule is valid (it could be a valid Json document,
+        // but not a Json document describing a rule)
+        int err = isValid(rule);
+        
+        if (err > 0) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            
+            switch (err) {
+                case 1:
+                    response.getWriter().println("400 - Invalid grouping rule, some field is missing");
+                    LOGGER.error("Invalid grouping rule, some field is missing");
+                    return;
+                case 2:
+                    response.getWriter().println("400 - Invalid grouping rule, the id is not numeric or it is missing");
+                    LOGGER.error("Invalid grouping rule, the id is not numeric or it is missing");
+                    return;
+                case 3:
+                    response.getWriter().println("400 - Invalid grouping rule, some field is empty");
+                    LOGGER.error("Invalid grouping rule, some field is empty");
+                    return;
+                default:
+                    response.getWriter().println("400 - Invalid grouping rule");
+                    LOGGER.error("Invalid grouping rule");
+                    return;
+            } // swtich
+        } // if
+        
+        // add the rule to the already existent configuration... the easiest way is parsing the configuration
+        JSONObject config;
+        
+        try {
+            config = (JSONObject) jsonParser.parse(configStr);
+        } catch (ParseException e) {
+            LOGGER.error("Grouping rules syntax is wrong... but it is supposed to be OK!!! Details: "
+                    + e.getMessage());
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("500 - Internal server error");
+            return;
+        } // try catch
+        
+        JSONArray rules = (JSONArray) config.get("grouping_rules");
+        rules.add(rule);
+        LOGGER.debug("Grouping rules after adding the new rule: " + rules.toJSONString());
+        
+        // write the configuration
+        PrintWriter writer = new PrintWriter(new FileWriter(groupingRulesConfFile));
+        writer.println("{\"grouping_rules\":" + rules.toJSONString() + "}");
+        writer.flush();
+        writer.close();
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().println("{\"success\":\"true\"}");
+    } // handlePostGroupingRules
+    
+    private String readGroupingRules() throws IOException {
+        if (!configurationFile.exists()) {
+            return "404 - Configuration file for Cygnus not found. Details: "
+                    + configurationFile.toString();
+        } // if
+        
+        groupingRulesConfFile = null;
         BufferedReader reader = new BufferedReader(new FileReader(configurationFile));
         String line;
         
@@ -270,17 +384,15 @@ public class ManagementInterface extends AbstractHandler {
             } // if
         } // while
         
+        reader.close();
+        
         if (groupingRulesConfFile == null) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            response.getWriter().println("404 - Missing configuration file for Grouping Rules");
-            return;
+            return "404 - Missing configuration file for Grouping Rules";
         } // if
         
         if (!new File(groupingRulesConfFile).exists()) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            response.getWriter().println("404 - Configuration file for Grouing Rules not found. Details: "
-                    + groupingRulesConfFile);
-            return;
+            return "404 - Configuration file for Grouing Rules not found. Details: "
+                    + groupingRulesConfFile;
         } // if
         
         String jsonStr = "";
@@ -292,7 +404,37 @@ public class ManagementInterface extends AbstractHandler {
             } // if
         } // while
         
-        response.getWriter().println(jsonStr);
-    } // handleGetGroupingRules
+        reader.close();
+        
+        return jsonStr;
+    } // readGroupingRules
+    
+    private int isValid(JSONObject jsonRule) {
+        // check if the rule contains all the required fields
+        if (!jsonRule.containsKey("id")
+                || !jsonRule.containsKey("fields")
+                || !jsonRule.containsKey("regex")
+                || !jsonRule.containsKey("destination")
+                || !jsonRule.containsKey("fiware_service_path")) {
+            return 1;
+        } // if
+        
+        // check if the id is numeric
+        try {
+            Long l = (Long) jsonRule.get("id");
+        } catch (Exception e) {
+            return 2;
+        } // catch
+        
+        // check if the rule has any empty field
+        if (((JSONArray) jsonRule.get("fields")).size() == 0
+                || ((String) jsonRule.get("regex")).length() == 0
+                || ((String) jsonRule.get("destination")).length() == 0
+                || ((String) jsonRule.get("fiware_service_path")).length() == 0) {
+            return 3;
+        } // if
+        
+        return 0;
+    } // isValid
     
 } // ManagementInterface

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -249,7 +249,8 @@ public class CygnusApplication extends Application {
             
             // start the Management Interface, passing references to Flume components
             LOGGER.info("Starting a Jetty server listening on port " + mgmtIfPort + " (Management Interface)");
-            mgmtIfServer = new JettyServer(mgmtIfPort, new ManagementInterface(sourcesRef, channelsRef, sinksRef));
+            mgmtIfServer = new JettyServer(mgmtIfPort, new ManagementInterface(configurationFile,
+                    sourcesRef, channelsRef, sinksRef));
             mgmtIfServer.start();
 
             // create a hook "listening" for shutdown interrupts (runtime.exit(int), crtl+c, etc)

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -80,6 +80,7 @@ public class CygnusApplication extends Application {
     private static final int YAFS_CHECKING_INTERVAL = 1000;
     private static final int DEF_MGMT_IF_PORT = 8081;
     private static final int DEF_POLLING_INTERVAL = 30;
+    private boolean firstTime = true;
     
     /**
      * Constructor.
@@ -128,6 +129,17 @@ public class CygnusApplication extends Application {
     @Override
     @Subscribe
     public synchronized void handleConfigurationEvent(MaterializedConfiguration conf) {
+        if (firstTime) {
+            // get references to the different elements of the agent, this will be needed when shutting down Cygnus in a
+            // certain order
+            sourcesRef = conf.getSourceRunners();
+            channelsRef = conf.getChannels();
+            sinksRef = conf.getSinkRunners();
+            LOGGER.debug("References to Flume components have been taken");
+            firstTime = false;
+            return;
+        } // if
+        
         super.handleConfigurationEvent(conf);
         
         // get references to the different elements of the agent, this will be needed when shutting down Cygnus in a

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
@@ -18,11 +18,11 @@
 
 package com.telefonica.iot.cygnus.interceptors;
 
+import com.telefonica.iot.cygnus.interceptors.GroupingRules.GroupingRule;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.Event;
-import com.telefonica.iot.cygnus.interceptors.GroupingInterceptor.GroupingRule;
 import com.telefonica.iot.cygnus.utils.Constants;
 import java.io.File;
 import java.io.PrintWriter;
@@ -207,7 +207,7 @@ public class GroupingInterceptorTest {
         System.out.println("Testing GroupingInterceptor.initialize");
         groupingInterceptor = new GroupingInterceptor(groupingRulesFileName);
         groupingInterceptor.initialize();
-        LinkedList<GroupingRule> groupingRules = groupingInterceptor.getGroupingRules();
+        LinkedList<GroupingRule> groupingRules = groupingInterceptor.getGroupingRules().getRules();
         assertTrue(groupingRules.size() == 3); // there are 5 rules, but two are invalid
         GroupingRule firstRule = groupingRules.get(0);
         assertEquals(1, firstRule.getId());

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
@@ -29,6 +29,8 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -207,6 +209,17 @@ public class GroupingInterceptorTest {
         System.out.println("Testing GroupingInterceptor.initialize");
         groupingInterceptor = new GroupingInterceptor(groupingRulesFileName);
         groupingInterceptor.initialize();
+        
+        try {
+            // just wait a second until the configuration reader starts
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            System.out.println("There was an error while waiting until the configuration reader starts."
+                    + " Details: " + e.getMessage());
+            assertTrue(false);
+            return;
+        } // try catch
+        
         LinkedList<GroupingRule> groupingRules = groupingInterceptor.getGroupingRules().getRules();
         assertTrue(groupingRules.size() == 3); // there are 5 rules, but two are invalid
         GroupingRule firstRule = groupingRules.get(0);

--- a/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -59,7 +59,7 @@ public class ManagementInterfaceTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        managementInterface = new ManagementInterface(null, null, null);
+        managementInterface = new ManagementInterface(null, null, null, null);
         
         // set up the behaviour of the mocked classes
         when(mockRequest.getRequestURI()).thenReturn(requestURI);


### PR DESCRIPTION
* Partially implements issue #745 
    * `/GET /groupingrules`
    * `/POST /groupingrules`
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
--------
Test for not existing grouping rules file
--------
$ curl -X GET "http://localhost:8081/v1/groupingrules"
404 - Configuration file for Grouing Rules not found. Details: /Users/frb/devel/fiware/fiware-cygnus/conf/grouping_rules.con
--------
Test for not existing parameter in the main configuration
--------
$ curl -X GET "http://localhost:8081/v1/groupingrules"
404 - Missing configuration file for Grouping Rules
--------
GET /groupingrules OK
--------
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   242  100   242    0     0   3068      0 --:--:-- --:--:-- --:--:--  3102
{
    "grouping_rules": [
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 1,
            "regex": "Room"
        }
    ]
}
--------
POST /groupingrules OK
--------
$ curl -X POST "http://localhost:8081/v1/groupingrules" -d '{"id":2,"regex":"test","destination":"test_dest","fiware_service_path":"test_service_path","fields":["entityType"]}'
{"success":"true"}
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   240  100   240    0     0  33946      0 --:--:-- --:--:-- --:--:-- 34285
{
    "grouping_rules": [
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 1,
            "regex": "Room"
        },
        {
            "destination": "test_dest",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "test_service_path",
            "id": 2,
            "regex": "test"
        }
    ]
}
--------
POST /groupingrules OK and real persistence tests before and after changing the rules
--------
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   121  100   121    0     0   1778      0 --:--:-- --:--:-- --:--:--  1805
{
    "grouping_rules": [
        {
            "destination": "allcars",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "cars",
            "id": 1,
            "regex": "Car"
        }
    ]
}
..
time=2016-02-09T10:38:14.633CET | lvl=INFO | trans=1455010687-482-0000000000 | svc=def_serv | subsvc=def_serv_path | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[271] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
time=2016-02-09T10:38:14.688CET | lvl=DEBUG | trans=1455010687-482-0000000000 | svc=def_serv | subsvc=def_serv_path | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[423] : Event got from the channel (id=185361310, headers={grouped-entities=room1_room, grouped-servicepaths=def_serv_path, fiware-servicepath=def_serv_path, notified-servicepaths=def_serv_path, content-type=application/json, fiware-service=def_serv, ttl=10, transactionId=1455010687-482-0000000000, notified-entities=room1_room, timestamp=1455010694635}, bodyLength=460)
..
time=2016-02-09T10:38:40.706CET | lvl=INFO | trans=1455010687-482-0000000000 | svc=def_serv | subsvc=def_serv_path | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[948] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv/def_serv_path/room1_room/room1_room.txt), Data ({"recvtimets":"1455010694","recvtime":"2016-02-09T09:38:14.635Z","fiware_servicepath":"def_serv_path","entityid":"Room1","entitytype":"Room","attrname":"temperature","attrtype":"centigrade","attrvalue":"26.5","attrmd":[]})
..
$ curl -X POST "http://localhost:8081/v1/groupingrules" -d '{"id":2,"regex":"Room","destination":"allrooms","fiware_service_path":"rooms","fields":["entityType"]}'
{"success":"true"}
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   224  100   224    0     0  28411      0 --:--:-- --:--:-- --:--:-- 32000
{
    "grouping_rules": [
        {
            "destination": "allcars",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "cars",
            "id": 1,
            "regex": "Car"
        },
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 2,
            "regex": "Room"
        }
    ]
}
..
time=2016-02-09T10:39:15.910CET | lvl=INFO | trans=1455010687-482-0000000001 | svc=def_serv | subsvc=def_serv_path | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[271] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
time=2016-02-09T10:39:15.913CET | lvl=DEBUG | trans=1455010687-482-0000000001 | svc=def_serv | subsvc=def_serv_path | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[423] : Event got from the channel (id=1855788258, headers={grouped-entities=allrooms, grouped-servicepaths=rooms, fiware-servicepath=def_serv_path, notified-servicepaths=def_serv_path, content-type=application/json, fiware-service=def_serv, ttl=10, transactionId=1455010687-482-0000000001, notified-entities=room1_room, timestamp=1455010755910}, bodyLength=460)
..
time=2016-02-09T10:39:41.935CET | lvl=INFO | trans=1455010687-482-0000000001 | svc=def_serv | subsvc=def_serv_path | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[948] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (def_serv/rooms/allrooms/allrooms.txt), Data ({"recvtimets":"1455010755","recvtime":"2016-02-09T09:39:15.910Z","fiware_servicepath":"rooms","entityid":"Room1","entitytype":"Room","attrname":"temperature","attrtype":"centigrade","attrvalue":"26.5","attrmd":[]})
```
* Assignee @pcoello25