### PR TITLE
hardening/743_check_if_content_type_is_null

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 - [FEATURE] Add /stats route to the Management Interface (#737)
 - [HARDENING] Check Http method in Management Interface API routes (#740)
 - [HARDENING] Add /v1 to Management Interface API routes (#739)
-- [HARDENING] ADD check for null content-type in notifications (#743) 
+- [HARDENING] Add check for null content-type in notifications (#743) 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - [FEATURE] Add /stats route to the Management Interface (#737)
 - [HARDENING] Check Http method in Management Interface API routes (#740)
 - [HARDENING] Add /v1 to Management Interface API routes (#739)
+- [HARDENING] ADD check for null content-type in notifications (#743) 

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -235,8 +235,8 @@ public class OrionRestHandler implements HTTPSourceHandler {
         
         // check if received content type is null
         if (contentType == null) {
-            LOGGER.warn("Missing content type. Required xml or json.");
-            throw new HTTPBadRequestException("Missing content type. Required xml or json.");
+            LOGGER.warn("Missing content type. Required application/json or application/xml.");
+            throw new HTTPBadRequestException("Missing content type. Required application/json or application/xml.");
         } // if
         
         // get a service and servicePath and store it in the log4j Mapped Diagnostic Context (MDC)

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -34,6 +34,7 @@ import org.apache.http.MethodNotSupportedException;
 import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.Date;
+import java.util.EventListener;
 import org.apache.flume.event.EventBuilder;
 import org.slf4j.MDC;
 
@@ -232,6 +233,12 @@ public class OrionRestHandler implements HTTPSourceHandler {
                 } // if else
             } // if else if
         } // while
+        
+        // check if received content type is null
+        if (contentType == null) {
+            LOGGER.warn("Missing content type. Required xml or json.");
+            throw new HTTPBadRequestException("Missing content type. Required xml or json.");
+        } // if
         
         // get a service and servicePath and store it in the log4j Mapped Diagnostic Context (MDC)
         MDC.put(Constants.LOG4J_SVC, service == null ? defaultService : service);

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -34,7 +34,6 @@ import org.apache.http.MethodNotSupportedException;
 import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.Date;
-import java.util.EventListener;
 import org.apache.flume.event.EventBuilder;
 import org.slf4j.MDC;
 


### PR DESCRIPTION
* Implements issue #743 
* 100% unit test passed: 
```
Results :
Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:  

Avoiding a Content-Type:
```
   time=2016-02-08T14:07:35.279CET | lvl=WARN | trans=1454936683-205-0000000000 | srv=fiservnoti | subsrv=fiservpathnoti | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[240] : Missing content type. Required xml or json.
```
   With a wrong Content-Type or using `curl` without a `Content-Type` header:
```
time=2016-02-08T14:04:55.447CET | lvl=WARN | trans= | srv= | subsrv= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[212] : Bad HTTP notification (application/x-www-form-urlencoded content type not supported)
```
* Assignee @frbattid 