### PR TITLE
feature/745_add_support_to_autoincremented_grouping_rules_id

### DIFF
--- a/conf/grouping_rules.conf.template
+++ b/conf/grouping_rules.conf.template
@@ -1,4 +1,4 @@
-# Copyright 2015 Telefónica Investigación y Desarrollo, S.A.U
+# Copyright 2016 Telefónica Investigación y Desarrollo, S.A.U
 # 
 # This file is part of fiware-cygnus (FI-WARE project).
 # 
@@ -37,8 +37,7 @@
 # }
 #
 # Being:
-# - id: A unique unsigned integer-based identifier. Not really used in the current implementation, but could be useful
-#   in the future.
+# - id: A unique unsigned integer-based identifier.
 # - fields: These are the fields that will be concatenated for regular expression matching. The available dictionary of
 #   fields for concatenation is "entityId", "entityType" and "servicePath". The order of these fields is important
 #   since the concatenation is made from left to right.

--- a/doc/flume_extensions_catalogue/grouping_interceptor.md
+++ b/doc/flume_extensions_catalogue/grouping_interceptor.md
@@ -114,7 +114,7 @@ It is <b>very important</b> to configure the <b>absolute path to the grouping ru
 
 ##<a name="section4"></a>Management Interface related operations
 
-The Management Interface of Cygnus exposes a set of operations under the `/v1/groupingrules` path related to the groupiong rules feature, allowing listing/updating/removing the rules. For instance:
+The Management Interface of Cygnus exposes a set of operations under the `/v1/groupingrules` path related to the grouping rules feature, allowing listing/updating/removing the rules. For instance:
 
 ```
 GET http://<cygnus_host>:<management_port>/v1/groupingrules

--- a/doc/flume_extensions_catalogue/grouping_interceptor.md
+++ b/doc/flume_extensions_catalogue/grouping_interceptor.md
@@ -4,6 +4,7 @@ Content:
 * [Functionality](#section1)
 * [Grouping rules syntax](#section2)
 * [Usage](#section3)
+* [Management Interface related operations](#section4)
 
 ##<a name="section1"></a>Functionality
 This is a custom Interceptor specifically designed for Cygnus. Its goal is to infer the destination entity where the data regarding a notified entity is going to be persisted. This destination entity, depending on the used sinks, may be a HDFS file name, a MySQL table name or a CKAN resource name. In addition, a new `fiware-servicePath` containing the destination entity may be configured (in case of HDFS, this is a folder; in case of CKAN this is a package; in case of MySQL this is simply a prefix for the table name; please, have a look to [doc/design/naming_conventions.md](doc/design/naming_conventions.md) for more details).
@@ -34,7 +35,7 @@ There exists a <i>grouping rules</i> file containing Json-like <i>rules</i> defi
 
 Being:
 
-* <b>id</b>: A unique unsigned integer-based identifier. Not really used in the current implementation, but could be useful in the future.
+* <b>id</b>: A unique unsigned integer-based identifier.
 * <b>fields</b>: These are the fields that will be concatenated for regular expression matching. The available dictionary of fields for concatenation is "entityId", "entityType" and "servicePath". The order of these fields is important since the concatenation is made from left to right.
 * <b>regex</b>: Java-like regular expression to be applied on the concatenated fields. Special characters like '\' must be escaped ('\' is escaped as "\\\\").
 * <b>destination</b>: Name of the HDFS file or CKAN resource where the data will be effectively persisted. In the case of MySQL, Mongo and STH this sufixes the table/collection name. Please, have a look to [doc/design/naming_conventions.md](doc/design/naming_conventions.md) for more details.
@@ -108,5 +109,42 @@ The usage of such an Interceptor is:
     cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = [FLUME_HOME_DIR]/conf/grouping_rules.conf
 
 It is <b>very important</b> to configure the <b>absolute path to the grouping rules file</b>.
+
+[Top](#top)
+
+##<a name="section4"></a>Management Interface related operations
+
+The Management Interface of Cygnus exposes a set of operations under the `/v1/groupingrules` path related to the groupiong rules feature, allowing listing/updating/removing the rules. For instance:
+
+```
+GET http://<cygnus_host>:<management_port>/v1/groupingrules
+```
+
+```
+{
+    "grouping_rules": [
+        {
+            "destination": "allcars",
+            "fields": [
+                "entityType"
+            ],
+            "fiware_service_path": "cars",
+            "id": 1,
+            "regex": "Car"
+        },
+        {
+            "destination": "allrooms",
+            "fields": [
+                "entityType"
+            ],
+            "fiware_service_path": "rooms",
+            "id": 2,
+            "regex": "Room"
+        }
+    ]
+}
+```
+
+Please, check [this](../installation_and_administration_guide/management_interface.md) link in order to know further details. 
 
 [Top](#top)

--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -95,7 +95,7 @@ Response:
 [Top](#top)
 
 ##<a neme="section3"></a>`GET /v1/groupingrules`
-Gets the configured grouping rules.
+Gets the configured [grouping rules](../flume_extensions_catalogue/grouping_interceptor.md).
 
 ```
 GET http://<cygnus_host>:<management_port>/v1/groupingrules
@@ -131,12 +131,11 @@ Response:
 [Top](#top)
 
 ##<a neme="section4"></a>`POST /v1/groupingrules`
-Adds a new rule, passed as a Json in the payload, to the grouping rules.
+Adds a new rule, passed as a Json in the payload, to the [grouping rules](../flume_extensions_catalogue/grouping_interceptor.md).
 
 ```
 POST http://<cygnus_host>:<management_port>/v1/groupingrules
 {
-	"id": 2,
 	"regex": "Room",
 	"destination": "allrooms",
 	"fiware_service_path": "rooms",
@@ -149,5 +148,7 @@ Response:
 ```
 {"success":"true"}
 ```
+
+Please observe the `id` field is not passed as part of the posted Json. This is because the Management Interface automatically deals with the proper ID insertion.
 
 [Top](#top)

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
@@ -19,13 +19,18 @@ package com.telefonica.iot.cygnus.interceptors;
 
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import com.telefonica.iot.cygnus.utils.Utils;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 /**
  *
@@ -35,63 +40,54 @@ public class GroupingRules {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(GroupingRules.class);
     private LinkedList<GroupingRule> groupingRules;
-
+    private long lastIndex;
+    
     /**
      * Constructor.
+     * @param groupingRulesFileName
      */
-    public GroupingRules() {
+    public GroupingRules(String groupingRulesFileName) {
         groupingRules = null;
+        lastIndex = 0;
+        
+        // read the grouping rules file
+        // a JSONParse(groupingRulesFileName) method cannot be used since the file may contain comment lines
+        // starting by the '#' character (comments)
+        String jsonStr = readGroupingRulesFile(groupingRulesFileName);
+
+        if (jsonStr == null) {
+            LOGGER.info("No grouping rules have been read");
+            return;
+        } // if
+
+        LOGGER.info("Grouping rules read: " + jsonStr);
+
+        // parse the Json containing the grouping rules
+        JSONArray jsonGroupingRules = (JSONArray) parseGroupingRules(jsonStr);
+
+        if (jsonGroupingRules == null) {
+            LOGGER.warn("Grouping rules syntax has errors");
+            return;
+        } // if
+
+        LOGGER.info("Grouping rules syntax is OK");
+
+        // create a list of grouping rules, with precompiled regex
+        setRules(jsonGroupingRules);
+        LOGGER.info("Grouping rules regex'es have been compiled");
     } // GroupingRules
-
-    public synchronized LinkedList<GroupingRule> getRules() {
-        return groupingRules;
-    } // getRules
-
-    /**
-     * Sets the grouping rules given a Json Array of rules.
-     * @param jsonRules
-     */
-    public synchronized void setRules(JSONArray jsonRules) {
-        groupingRules = new LinkedList<GroupingRule>();
-
-        for (Object jsonGroupingRule : jsonRules) {
-            JSONObject jsonRule = (JSONObject) jsonGroupingRule;
-            int err = isValid(jsonRule);
-
-            if (err == 0) {
-                GroupingRule rule = new GroupingRule(jsonRule);
-                groupingRules.add(rule);
-            } else {
-                switch (err) {
-                    case 1:
-                        LOGGER.warn("Invalid grouping rule, some field is missing. It will be discarded. Details="
-                                + jsonRule.toJSONString());
-                        break;
-                    case 2:
-                        LOGGER.warn("Invalid grouping rule, the id is not numeric or it is missing. It will be "
-                                + "discarded. Details=" + jsonRule.toJSONString());
-                        break;
-                    case 3:
-                        LOGGER.warn("Invalid grouping rule, some field is empty. It will be discarded. Details="
-                                + jsonRule.toJSONString());
-                        break;
-                    default:
-                } // switch
-            } // if else
-        } // for
-    } // setRules
-
+    
     /**
      * Gets the rule matching the given context element for the given service path.
      * @param contextElement
      * @param servicePath
      * @return
      */
-    public synchronized GroupingRule getMatchingRule(ContextElement contextElement, String servicePath) {
+    public GroupingRule getMatchingRule(ContextElement contextElement, String servicePath) {
         if (groupingRules != null) {
             for (GroupingRule rule : groupingRules) {
                 String concat = concatenateFields(rule.getFields(), contextElement, servicePath);
-                Matcher matcher = rule.pattern.matcher(concat);
+                Matcher matcher = rule.getPattern().matcher(concat);
 
                 if (matcher.matches()) {
                     return rule;
@@ -103,6 +99,62 @@ public class GroupingRules {
             return null;
         } // if else
     } // getMatchingRule
+    
+    /**
+     * Adds a new rule to the grouping rules.
+     * @param rule
+     */
+    public void addRule(GroupingRule rule) {
+        lastIndex++;
+        rule.setId(this.lastIndex);
+        this.groupingRules.add(rule);
+    } // GroupingRule
+    
+    /**
+     * Gets a stringified version of the grouping rules.
+     * @return A stringified version of the grouping rules
+     */
+    @Override
+    public String toString() {
+        return "{\"grouping_rules\": " + groupingRules.toString() + "}";
+    } // toString
+    
+    /**
+     * Gets the grouping rules as a list of GroupingRule objects. It is protected since it is only used by the tests.
+     * @return The grouping rules as a list of GroupingRule objects
+     */
+    protected LinkedList<GroupingRule> getRules() {
+        return groupingRules;
+    } // getRules
+
+    private void setRules(JSONArray jsonRules) {
+        groupingRules = new LinkedList<GroupingRule>();
+
+        for (Object jsonGroupingRule : jsonRules) {
+            JSONObject jsonRule = (JSONObject) jsonGroupingRule;
+            int err = GroupingRule.isValid(jsonRule);
+
+            if (err == 0) {
+                GroupingRule rule = new GroupingRule(jsonRule);
+                groupingRules.add(rule);
+                lastIndex = rule.getId();
+            } else {
+                switch (err) {
+                    case 1:
+                        LOGGER.warn("Invalid grouping rule, some field is missing. It will be discarded. Details:"
+                                + jsonRule.toJSONString());
+                        break;
+                    case 2:
+                        LOGGER.warn("Invalid grouping rule, some field is empty. It will be discarded. Details:"
+                                + jsonRule.toJSONString());
+                        break;
+                    default:
+                        LOGGER.warn("Invalid grouping rule. It will be discarded. Details:"
+                                + jsonRule.toJSONString());
+                } // switch
+            } // if else
+        } // for
+    } // setRules
     
     private String concatenateFields(ArrayList<String> fields, ContextElement contextElement, String servicePath) {
         String concat = "";
@@ -119,98 +171,53 @@ public class GroupingRules {
         
         return concat;
     } // concatenateFields
-
-    private int isValid(JSONObject jsonRule) {
-        // check if the rule contains all the required fields
-        if (!jsonRule.containsKey("id")
-                || !jsonRule.containsKey("fields")
-                || !jsonRule.containsKey("regex")
-                || !jsonRule.containsKey("destination")
-                || !jsonRule.containsKey("fiware_service_path")) {
-            return 1;
+    
+    private String readGroupingRulesFile(String groupingRulesFileName) {
+        if (groupingRulesFileName == null) {
+            return null;
         } // if
 
-        // check if the id is numeric
+        String jsonStr = "";
+        BufferedReader reader;
+
         try {
-            Long l = (Long) jsonRule.get("id");
-        } catch (Exception e) {
-            return 2;
-        } // catch
+            reader = new BufferedReader(new FileReader(groupingRulesFileName));
+        } catch (FileNotFoundException e) {
+            LOGGER.error("File not found. Details=" + e.getMessage() + ")");
+            return null;
+        } // try catch
 
-        // check if the rule has any empty field
-        if (((JSONArray) jsonRule.get("fields")).size() == 0
-                || ((String) jsonRule.get("regex")).length() == 0
-                || ((String) jsonRule.get("destination")).length() == 0
-                || ((String) jsonRule.get("fiware_service_path")).length() == 0) {
-            return 3;
+        String line;
+
+        try {
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("#") || line.length() == 0) {
+                    continue;
+                } // if
+
+                jsonStr += line;
+            } // while
+
+            return jsonStr;
+        } catch (IOException e) {
+            LOGGER.error("Error while reading the Json-based grouping rules file. Details=" + e.getMessage() + ")");
+            return null;
+        } // try catch
+    } // readGroupingRulesFile
+
+    private JSONArray parseGroupingRules(String jsonStr) {
+        if (jsonStr == null) {
+            return null;
         } // if
 
-        return 0;
-    } // isValid
-    
-    /**
-     * Each one of the entries of the matching table.
-     */
-    protected class GroupingRule {
-        
-        private final long id;
-        private final ArrayList<String> fields;
-        private final Pattern pattern;
-        private final String destination;
-        private final String newFiwareServicePath;
-        
-        /**
-         * Constructor.
-         * @param jsonRule
-         */
-        public GroupingRule(JSONObject jsonRule) {
-            this.id = (Long) jsonRule.get("id");
-            this.fields = (JSONArray) jsonRule.get("fields");
-            this.pattern = Pattern.compile((String) jsonRule.get("regex"));
-            this.destination = Utils.encode((String) jsonRule.get("destination"));
-            this.newFiwareServicePath = Utils.encode((String) jsonRule.get("fiware_service_path"));
-        } // GroupingRule
-        
-        /**
-         * Gets the rule's id.
-         * @return
-         */
-        public long getId() {
-            return id;
-        } // getId
-        
-        /**
-         * Gets the rule's fields array.
-         * @return The rule's fields array.
-         */
-        public ArrayList<String> getFields() {
-            return fields;
-        } // getFields
-        
-        /**
-         * Gets the rule's regular expression.
-         * @return the rule's regular expression.
-         */
-        public String getRegex() {
-            return pattern.toString();
-        } // getRegex
-        
-        /**
-         * Gets the rule's destination.
-         * @return The rule's destination.
-         */
-        public String getDestination() {
-            return destination;
-        } // destination
-        
-        /**
-         * Gets the rule's newFiwareServicePath.
-         * @return The rule's newFiwareServicePath.
-         */
-        public String getNewFiwareServicePath() {
-            return newFiwareServicePath;
-        } // getNewFiwareServicePath
-        
-    } // GroupingRule
-    
+        JSONParser jsonParser = new JSONParser();
+
+        try {
+            return (JSONArray) ((JSONObject) jsonParser.parse(jsonStr)).get("grouping_rules");
+        } catch (ParseException e) {
+            LOGGER.error("Error while parsing the Json-based grouping rules file. Details=" + e.getMessage());
+            return null;
+        } // try catch
+    } // parseGroupingRules
+
 } // GroupingRules

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptorTest.java
@@ -18,7 +18,6 @@
 
 package com.telefonica.iot.cygnus.interceptors;
 
-import com.telefonica.iot.cygnus.interceptors.GroupingRules.GroupingRule;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flume.event.EventBuilder;
@@ -29,8 +28,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -18,6 +18,7 @@
 
 package com.telefonica.iot.cygnus.management;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import javax.servlet.ServletException;
@@ -59,7 +60,7 @@ public class ManagementInterfaceTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        managementInterface = new ManagementInterface(null, null, null, null);
+        managementInterface = new ManagementInterface(new File(""), null, null, null);
         
         // set up the behaviour of the mocked classes
         when(mockRequest.getRequestURI()).thenReturn(requestURI);


### PR DESCRIPTION
* Partially implements issue #745 
    * CHANGES_NEXT_RELEASE must not be updated
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   122  100   122    0     0  11090      0 --:--:-- --:--:-- --:--:-- 12200
{
    "grouping_rules": [
        {
            "destination": "allcars",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "cars",
            "id": 1,
            "regex": "Car"
        }
    ]
}
$ curl -X POST "http://localhost:8081/v1/groupingrules" -d '{"regex":"Room","destination":"allrooms","fiware_service_path":"rooms","fields":["entityType"]}'
{"success":"true"}
$ curl -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   226  100   226    0     0  34865      0 --:--:-- --:--:-- --:--:-- 37666
{
    "grouping_rules": [
        {
            "destination": "allcars",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "cars",
            "id": 1,
            "regex": "Car"
        },
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 2,
            "regex": "Room"
        }
    ]
}
```
* Assignee @pcoello25