### PR TITLE
hardening/752_check_for_input_parameters_validity

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [BUG] Fix wrong data_model configured for OrionPostgreSQLSink in agent.conf.template (#774)
 - [HARDENING] Remove the persistOne method from all the sinks (#609)
 - [HARDENING] Invalidate the sink if the data_model parameter is wrong (and prepare the code for further parameter checks) (#718)
+- [HARDENING] Check for input parameters validity (#752)

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -147,7 +147,7 @@ public class OrionCKANSink extends OrionSink {
         if (sslStr.equals("true") || sslStr.equals("false")) {
             ssl = Boolean.valueOf(sslStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl="
-                + (ssl ? "true" : "false") + ")");
+                + sslStr + ")");
         } else  {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (ssl="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -15,7 +15,7 @@
  *
  * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
  */
- 
+
 package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl;
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import org.apache.flume.Context;
 
 /**
- * 
+ *
  * @author fermin
  *
  * CKAN sink for Orion Context Broker.
@@ -45,7 +45,7 @@ public class OrionCKANSink extends OrionSink {
     private boolean rowAttrPersistence;
     private boolean ssl;
     private CKANBackend persistenceBackend;
-    
+
     /**
      * Constructor.
      */
@@ -68,7 +68,7 @@ public class OrionCKANSink extends OrionSink {
     protected String getCKANPort() {
         return ckanPort;
     } // getCKANPort
-    
+
     /**
      * Gets the CKAN API key. It is protected due to it is only required for testing purposes.
      * @return The CKAN API key
@@ -93,7 +93,7 @@ public class OrionCKANSink extends OrionSink {
     protected CKANBackend getPersistenceBackend() {
         return persistenceBackend;
     } // getPersistenceBackend
-    
+
     /**
      * Sets the persistence backend. It is protected due to it is only required for testing purposes.
      * @param persistenceBackend
@@ -101,7 +101,7 @@ public class OrionCKANSink extends OrionSink {
     protected void setPersistenceBackend(CKANBackend persistenceBackend) {
         this.persistenceBackend = persistenceBackend;
     } // setPersistenceBackend
-    
+
     /**
      * Gets if the connections with CKAN is SSL-enabled. It is protected due to it is only required for testing
      * purposes.
@@ -110,7 +110,7 @@ public class OrionCKANSink extends OrionSink {
     protected boolean getSSL() {
         return this.ssl;
     } // getSSL
-    
+
     @Override
     public void configure(Context context) {
         apiKey = context.getString("api_key", "nokey");
@@ -119,25 +119,29 @@ public class OrionCKANSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (ckan_host=" + ckanHost + ")");
         ckanPort = context.getString("ckan_port", "80");
         int intPort = Integer.parseInt(ckanPort);
+
         if ((intPort <= 0) || (intPort > 65535)) {
             invalidConfiguration = true;
-            LOGGER.debug("[" + this.getName() + "] Invalid configuration (ckan_port=" + ckanPort + ") "
-                    + "must be between 0 and 65535");
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (ckan_port=" + ckanPort + ")"
+                    + " -- Must be between 0 and 65535");
         } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + ckanPort + ")");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (ckan_port=" + ckanPort + ")");
         }  // if else
+
         orionUrl = context.getString("orion_url", "http://localhost:1026");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (orion_url=" + orionUrl + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence");
+
         if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") must be 'row' or 'column'");
+                + persistence + ") -- Must be 'row' or 'column'");
         }  // if else
+
         ssl = context.getBoolean("ssl", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl=" + (ssl ? "true" : "false") + ")");
         super.configure(context);
@@ -157,14 +161,14 @@ public class OrionCKANSink extends OrionSink {
 
         super.start();
     } // start
-    
+
     @Override
     void persistBatch(Batch batch) throws Exception {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
         } // if
- 
+
         // iterate on the destinations, for each one a single create / append will be performed
         for (String destination : batch.getDestinations()) {
             LOGGER.debug("[" + this.getName() + "] Processing sub-batch regarding the " + destination
@@ -172,7 +176,7 @@ public class OrionCKANSink extends OrionSink {
 
             // get the sub-batch for this destination
             ArrayList<CygnusEvent> subBatch = batch.getEvents(destination);
-            
+
             // get an aggregator for this destination and initialize it
             CKANAggregator aggregator = getAggregator(this.rowAttrPersistence);
             aggregator.initialize(subBatch.get(0));
@@ -180,18 +184,18 @@ public class OrionCKANSink extends OrionSink {
             for (CygnusEvent cygnusEvent : subBatch) {
                 aggregator.aggregate(cygnusEvent);
             } // for
-            
+
             // persist the aggregation
             persistAggregation(aggregator);
             batch.setPersisted(destination);
         } // for
     } // persistBatch
-    
+
     /**
      * Class for aggregating fieldValues.
      */
     private abstract class CKANAggregator {
-        
+
         // string containing the data records
         protected String records;
 
@@ -202,27 +206,27 @@ public class OrionCKANSink extends OrionSink {
         protected String pkgName;
         protected String resName;
         protected String resId;
-        
+
         public CKANAggregator() {
             records = "";
         } // CKANAggregator
-        
+
         public String getAggregation() {
             return records;
         } // getAggregation
-        
+
         public String getOrgName() {
             return orgName;
         } // getOrgName
-        
+
         public String getPkgName() {
             return pkgName;
         } // getPkgName
-        
+
         public String getResName() {
             return resName;
         } // getResName
-        
+
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             service = cygnusEvent.getService();
             servicePath = cygnusEvent.getServicePath();
@@ -231,21 +235,21 @@ public class OrionCKANSink extends OrionSink {
             pkgName = buildPkgName(service, servicePath);
             resName = buildResName(destination);
         } // initialize
-        
+
         public abstract void aggregate(CygnusEvent cygnusEvent) throws Exception;
-        
+
     } // CKANAggregator
-    
+
     /**
      * Class for aggregating batches in row mode.
      */
     private class RowAggregator extends CKANAggregator {
-        
+
         @Override
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
         } // initialize
-        
+
         @Override
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
@@ -258,7 +262,7 @@ public class OrionCKANSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -267,7 +271,7 @@ public class OrionCKANSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             for (NotifyContextRequest.ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -275,7 +279,7 @@ public class OrionCKANSink extends OrionSink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                
+
                 // create a column and aggregate it
                 String record = "{\"" + Constants.RECV_TIME_TS + "\": \"" + recvTimeTs / 1000 + "\","
                     + "\"" + Constants.RECV_TIME + "\": \"" + recvTime + "\","
@@ -285,7 +289,7 @@ public class OrionCKANSink extends OrionSink {
                     + "\"" + Constants.ATTR_NAME + "\": \"" + attrName + "\","
                     + "\"" + Constants.ATTR_TYPE + "\": \"" + attrType + "\","
                     + "\"" + Constants.ATTR_VALUE + "\": " + attrValue;
-                
+
                 // metadata is an special case, because CKAN doesn't support empty array, e.g. "[ ]"
                 // (http://stackoverflow.com/questions/24207065/inserting-empty-arrays-in-json-type-fields-in-datastore)
                 if (!attrMetadata.equals(Constants.EMPTY_MD)) {
@@ -303,7 +307,7 @@ public class OrionCKANSink extends OrionSink {
         } // aggregate
 
     } // RowAggregator
-    
+
     /**
      * Class for aggregating batches in column mode.
      */
@@ -313,7 +317,7 @@ public class OrionCKANSink extends OrionSink {
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
         } // initialize
-        
+
         @Override
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
@@ -326,7 +330,7 @@ public class OrionCKANSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -335,12 +339,12 @@ public class OrionCKANSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             String record = "{\"" + Constants.RECV_TIME + "\": \"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\": \"" + servicePath + "\","
                     + "\"" + Constants.ENTITY_ID + "\": \"" + entityId + "\","
                     + "\"" + Constants.ENTITY_TYPE + "\": \"" + entityType + "\"";
-            
+
             for (NotifyContextRequest.ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -348,17 +352,17 @@ public class OrionCKANSink extends OrionSink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                
+
                 // create part of the column with the current attribute (a.k.a. a column)
                 record += ",\"" + attrName + "\": " + attrValue;
-                
+
                 // metadata is an special case, because CKAN doesn't support empty array, e.g. "[ ]"
                 // (http://stackoverflow.com/questions/24207065/inserting-empty-arrays-in-json-type-fields-in-datastore)
                 if (!attrMetadata.equals(Constants.EMPTY_MD)) {
                     record += ",\"" + attrName + "_md\": " + attrMetadata;
                 } // if
             } // for
-            
+
             // now, aggregate the column
             if (records.isEmpty()) {
                 records += record + "}";
@@ -366,9 +370,9 @@ public class OrionCKANSink extends OrionSink {
                 records += "," + record + "}";
             } // if else
         } // aggregate
-        
+
     } // ColumnAggregator
-    
+
     private CKANAggregator getAggregator(boolean rowAttrPersistence) {
         if (rowAttrPersistence) {
             return new RowAggregator();
@@ -376,23 +380,23 @@ public class OrionCKANSink extends OrionSink {
             return new ColumnAggregator();
         } // if else
     } // getAggregator
-    
+
     private void persistAggregation(CKANAggregator aggregator) throws Exception {
         String aggregation = aggregator.getAggregation();
         String orgName = aggregator.getOrgName();
         String pkgName = aggregator.getPkgName();
         String resName = aggregator.getResName();
-        
+
         LOGGER.info("[" + this.getName() + "] Persisting data at OrionCKANSink (orgName=" + orgName
                 + ", pkgName=" + pkgName + ", resName=" + resName + ", data=" + aggregation + ")");
-        
+
         if (aggregator instanceof RowAggregator) {
             persistenceBackend.persist(orgName, pkgName, resName, aggregation, true);
         } else {
             persistenceBackend.persist(orgName, pkgName, resName, aggregation, false);
         } // if else
     } // persistAggregation
-    
+
     /**
      * Builds an organization name given a fiwareService. It throws an exception if the naming conventions are violated.
      * @param fiwareService
@@ -401,15 +405,15 @@ public class OrionCKANSink extends OrionSink {
      */
     private String buildOrgName(String fiwareService) throws Exception {
         String orgName = fiwareService;
-        
+
         if (orgName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building orgName=fiwareService (" + orgName + ") and its length is "
                     + "greater than " + Constants.MAX_NAME_LEN);
         } // if
-        
+
         return orgName;
     } // buildOrgName
-    
+
     /**
      * Builds a package name given a fiwareService and a fiwareServicePath. It throws an exception if the naming
      * conventions are violated.
@@ -420,18 +424,18 @@ public class OrionCKANSink extends OrionSink {
      */
     private String buildPkgName(String fiwareService, String fiwareServicePath) throws Exception {
         String pkgName;
-        
+
         if (fiwareServicePath.length() == 0) {
             pkgName = fiwareService;
         } else {
             pkgName = fiwareService + "_" + fiwareServicePath;
         } // if else
-        
+
         if (pkgName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building pkgName=fiwareService + '_' + fiwareServicePath (" + pkgName
                     + ") and its length is greater than " + Constants.MAX_NAME_LEN);
         } // if
-        
+
         return pkgName;
     } // buildPkgName
 
@@ -443,7 +447,7 @@ public class OrionCKANSink extends OrionSink {
      */
     private String buildResName(String destination) throws Exception {
         String resName = destination;
-        
+
         if (resName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building resName=destination (" + resName + ") and its length is greater "
                     + "than " + Constants.MAX_NAME_LEN);
@@ -451,5 +455,5 @@ public class OrionCKANSink extends OrionSink {
 
         return resName;
     } // buildResName
-    
+
 } // OrionCKANSink

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -130,21 +130,30 @@ public class OrionCKANSink extends OrionSink {
 
         orionUrl = context.getString("orion_url", "http://localhost:1026");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (orion_url=" + orionUrl + ")");
-        rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        String persistence = context.getString("attr_persistence");
+        String attrPersistenceStr = context.getString("attr_persistence");
 
-        if (persistence.equals("row") || persistence.equals("column")) {
+        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+            rowAttrPersistence = attrPersistenceStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + persistence + ")");
+                + attrPersistenceStr + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") -- Must be 'row' or 'column'");
+                + attrPersistenceStr + ") -- Must be 'row' or 'column'");
         }  // if else
 
-        ssl = context.getBoolean("ssl", false);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl=" + (ssl ? "true" : "false") + ")");
-        super.configure(context);
+        String sslStr = context.getString("ssl");
+        
+        if (sslStr.equals("true") || sslStr.equals("false")) {
+            ssl = Boolean.valueOf(sslStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl="
+                + (ssl ? "true" : "false") + ")");
+        } else  {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (ssl="
+                + sslStr + ") -- Must be 'true' or 'false'");
+        }  // if else
+        
         // Techdebt: allow this sink to work with all the data models
         dataModel = DataModel.DMBYENTITY;
     } // configure

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -118,12 +118,26 @@ public class OrionCKANSink extends OrionSink {
         ckanHost = context.getString("ckan_host", "localhost");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (ckan_host=" + ckanHost + ")");
         ckanPort = context.getString("ckan_port", "80");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (ckan_port=" + ckanPort + ")");
+        int intPort = Integer.parseInt(ckanPort);
+        if ((intPort <= 0) || (intPort > 65535)) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (ckan_port=" + ckanPort + ") "
+                    + "must be between 0 and 65535");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + ckanPort + ")");
+        }  // if else
         orionUrl = context.getString("orion_url", "http://localhost:1026");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (orion_url=" + orionUrl + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence=" + rowAttrPersistence
-                + ")");
+        String persistence = context.getString("attr_persistence");
+        if (persistence.equals("row") || persistence.equals("column")) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + persistence + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
+                + persistence + ") must be 'row' or 'column'");
+        }  // if else
         ssl = context.getBoolean("ssl", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl=" + (ssl ? "true" : "false") + ")");
         super.configure(context);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -92,7 +92,7 @@ public class OrionDynamoDBSink extends OrionSink {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (region="
                     + regionStr + ") -- Must be 'us-east-1', 'us-west-1', 'us-west-2',  'eu-west-1', 'eu-central-1', "
-                    + "'ap-northeast-1', 'ap-northeast1', 'ap-shouteast-1', 'ap-shouteast-2', 'sa-east-1'");
+                    + "'ap-northeast-1', 'ap-northeast1', 'ap-shouteast-1', 'ap-shouteast-2' or 'sa-east-1'");
         } // catch
         
         String attrPersistRowStr = context.getString("attr_persistence");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -78,7 +78,15 @@ public class OrionDynamoDBSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (region=" + region + ")");
         String attrPersistRowStr = context.getString("attr_persistence", "row");
         attrPersistenceRow = attrPersistRowStr.equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence=" + attrPersistRowStr + ")");
+        String persistence = context.getString("attr_persistence");
+        if (persistence.equals("row") || persistence.equals("column")) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + persistence + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
+                + persistence + ") must be 'row' or 'column'");
+        }  // if else
         super.configure(context);
     } // configure
     

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -39,7 +39,7 @@ public class OrionDynamoDBSink extends OrionSink {
     /**
      * Available DynamoDB regions implementation.
      */
-    public enum Regions { USEAST1, USWEST1, USWEST2,  EUWEST1, EUCENTRAL1, 
+    private enum Regions { USEAST1, USWEST1, USWEST2,  EUWEST1, EUCENTRAL1, 
         APNORTHEAST1, APNORTHEAST2, APSHOUTEAST1, APSHOUTEAST2, SAEAST1}
 
     private static final CygnusLogger LOGGER = new CygnusLogger(OrionDynamoDBSink.class);
@@ -91,7 +91,8 @@ public class OrionDynamoDBSink extends OrionSink {
         } catch (Exception e) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (region="
-                    + regionStr + ")");
+                    + regionStr + ") -- Must be 'us-east-1', 'us-west-1', 'us-west-2',  'eu-west-1', 'eu-central-1', "
+                    + "'ap-northeast-1', 'ap-northeast1', 'ap-shouteast-1', 'ap-shouteast-2', 'sa-east-1'");
         } // catch
         
         String attrPersistRowStr = context.getString("attr_persistence");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -35,6 +35,12 @@ import org.apache.flume.Context;
  * @author frb
  */
 public class OrionDynamoDBSink extends OrionSink {
+    
+    /**
+     * Available DynamoDB regions implementation.
+     */
+    public enum Regions { USEAST1, USWEST1, USWEST2,  EUWEST1, EUCENTRAL1, 
+        APNORTHEAST1, APNORTHEAST2, APSHOUTEAST1, APSHOUTEAST2, SAEAST1}
 
     private static final CygnusLogger LOGGER = new CygnusLogger(OrionDynamoDBSink.class);
     private DynamoDBBackend persistenceBackend;
@@ -74,19 +80,30 @@ public class OrionDynamoDBSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (access_key_id=" + accessKeyId + ")");
         secretAccessKey = context.getString("secret_access_key");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (secret_access_key=" + secretAccessKey + ")");
-        region = context.getString("region", "eu-central-1");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (region=" + region + ")");
-        String attrPersistRowStr = context.getString("attr_persistence", "row");
-        attrPersistenceRow = attrPersistRowStr.equals("row");
-        String persistence = context.getString("attr_persistence");
+        
+        String regionStr = context.getString("region");
 
-        if (persistence.equals("row") || persistence.equals("column")) {
+        try {
+            Regions regionReg = Regions.valueOf(regionStr.replaceAll("-", "").toUpperCase());
+            region = regionStr;
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (region="
+                    + regionStr + ")");
+        } catch (Exception e) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (region="
+                    + regionStr + ")");
+        } // catch
+        
+        String attrPersistRowStr = context.getString("attr_persistence");
+
+        if (attrPersistRowStr.equals("row") || attrPersistRowStr.equals("column")) {
+            attrPersistenceRow = attrPersistRowStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + persistence + ")");
+                + attrPersistRowStr + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") -- Must be 'row' or 'column'");
+                + attrPersistRowStr + ") -- Must be 'row' or 'column'");
         }  // if else
 
         super.configure(context);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -424,11 +424,9 @@ public class OrionHDFSSink extends OrionSink {
         String hiveDBTypeStr = context.getString("hive.db_type");
         
         try {
-            if (hiveDBTypeStr.equals("default-db") || hiveDBTypeStr.equals("namespace-db")) {
-                hiveDBType = HiveDBType.valueOf(hiveDBTypeStr.replaceAll("-", "").toUpperCase());
-                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type=" 
-				+ hiveDBType);
-            }
+            hiveDBType = HiveDBType.valueOf(hiveDBTypeStr.replaceAll("-", "").toUpperCase());
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type=" 
+                    + hiveDBType);
         } catch (Exception e) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.db_type="
@@ -473,11 +471,9 @@ public class OrionHDFSSink extends OrionSink {
         String backendImplStr = context.getString("backend_impl");
         
         try {
-            if (backendImplStr.equals("rest") || backendImplStr.equals("binary")) {
-                backendImpl = BackendImpl.valueOf(backendImplStr.toUpperCase());
-                LOGGER.debug("[" + this.getName() + "] Reading configuration (backend_impl=" 
-					+ backendImplStr + ")");
-            }
+            backendImpl = BackendImpl.valueOf(backendImplStr.toUpperCase());
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (backend_impl=" 
+                        + backendImplStr + ")");
         } catch (Exception e) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (backend_impl="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -230,22 +230,37 @@ public class OrionHDFSSink extends OrionSink {
         } else {
             host = new String[]{"localhost"};
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_host=localhost");
-        } // if else
+        } // if else 
         
         String cosmosPort = context.getString("cosmos_port");
         String hdfsPort = context.getString("hdfs_port");
         
+        int intPort;
         if (hdfsPort != null && hdfsPort.length() > 0) {
             port = hdfsPort;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_port=" + port + ")");
+            intPort = Integer.parseInt(port);
+            if ((intPort <= 0) || (intPort > 65535)) {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hdfs_port=" + port 
+                        + ") must be between 0 and 65535");
+            } else {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_port=" + port + ")");
+            }  // if else
         } else if (cosmosPort != null && cosmosPort.length() > 0) {
             port = cosmosPort;
+            intPort = Integer.parseInt(port);
+            if ((intPort <= 0) || (intPort > 65535)) {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (cosmos_port=" + port 
+                        + ") must be between 0 and 65535  -- DEPRECATED, use hdfs_port instead");
+            } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + port + ")"
                     + " -- DEPRECATED, use hdfs_port instead");
+            }  // if else
         } else {
             port = "14000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_port=14000");
-        }
+        }  // if else
         
         String cosmosDefaultUsername = context.getString("cosmos_default_username");
         String hdfsUsername = context.getString("hdfs_username");
@@ -319,13 +334,28 @@ public class OrionHDFSSink extends OrionSink {
         String hivePortOld = context.getString("hive_port");
         String hivePortNew = context.getString("hive.port");
         
+        int intHivePort;
         if (hivePortNew != null && hivePortNew.length() > 0) {
             hivePort = hivePortNew;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.port=" + hivePort + ")");
+            intHivePort = Integer.parseInt(hivePort);
+            if ((intHivePort <= 0) && (intHivePort > 65535)) {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.port=" + hivePort 
+                        + ") must be between 0 and 65535");
+            } else {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.port=" + hivePort + ")");
+            }  // if else
         } else if (hivePortOld != null && hivePortOld.length() > 0) {
             hivePort = hivePortOld;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_port=" + hivePort + ")"
-                    + " -- DEPRECATED, use hive.port instead");
+            intHivePort = Integer.parseInt(hivePort);
+            if ((intHivePort <= 0) && (intHivePort > 65535)) {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive_port=" + hivePort + ")"
+                    + " must be between 0 and 65535  -- DEPRECATED, use hive.port instead");
+            } else {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_port=" + hivePort + ")"
+                        + " -- DEPRECATED, use hive.port instead");
+            }  // else if
         } else {
             hivePort = "10000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.port=10000");
@@ -336,13 +366,26 @@ public class OrionHDFSSink extends OrionSink {
         
         if (hiveServerVersionNew != null && hiveServerVersionNew.length() > 0) {
             hiveServerVersion = hiveServerVersionNew;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.server_version=" + hiveServerVersion
+            if ((hiveServerVersion.equals("1")) || (hiveServerVersion.equals("2"))) {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.server_version=" + hiveServerVersion
                     + ")");
+            } else {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.server_version=" + hiveServerVersion
+                    + ") must be '1' for HiveServer1 or '2' for HiveServer2");
+            }  // if else
         } else if (hiveServerVersionOld != null && hiveServerVersionOld.length() > 0) {
             hiveServerVersion = hiveServerVersionOld;
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_server_version=" + hiveServerVersion
+            if (hiveServerVersion.equals("1") || hiveServerVersion.equals("2")) {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_server_version=" + hiveServerVersion
                     + ")"
                     + " -- DEPRECATED, use hive.server_version instead");
+            } else {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive_server_version=" + hiveServerVersion
+                    + ") must be '1' for HiveServer1 or '2' for HiveServer2"
+                    + " -- DEPRECATED, use hive.server_version instead");
+            }  // if else
         } else {
             hiveServerVersion = "2";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.server_version=2");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -60,7 +60,7 @@ public class OrionHDFSSink extends OrionSink {
     /**
      * Available file-format implementation.
      */
-    public enum FileFormat { JSONROW, JSONCOLUMN, CSVROW, CSVCOLUMN }
+    private enum FileFormat { JSONROW, JSONCOLUMN, CSVROW, CSVCOLUMN }
     
     /**
      * Available Hive database types.
@@ -244,6 +244,7 @@ public class OrionHDFSSink extends OrionSink {
         if (hdfsPort != null && hdfsPort.length() > 0) {
             port = hdfsPort;
             intPort = Integer.parseInt(port);
+            
             if ((intPort <= 0) || (intPort > 65535)) {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hdfs_port=" + port
@@ -251,17 +252,20 @@ public class OrionHDFSSink extends OrionSink {
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_port=" + port + ")");
             }  // if else
+            
         } else if (cosmosPort != null && cosmosPort.length() > 0) {
             port = cosmosPort;
             intPort = Integer.parseInt(port);
+            
             if ((intPort <= 0) || (intPort > 65535)) {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (cosmos_port=" + port
-                        + ") -- Must be between 0 and 65535  -- DEPRECATED, use hdfs_port instead");
+                        + ") -- Must be between 0 and 65535 -- DEPRECATED, use hdfs_port instead");
             } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + port + ")"
                     + " -- DEPRECATED, use hdfs_port instead");
             }  // if else
+            
         } else {
             port = "14000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_port=14000");
@@ -302,7 +306,6 @@ public class OrionHDFSSink extends OrionSink {
         boolean fileFormatConfigured = context.getParameters().containsKey("file_format");
         String attrPersistenceStr = context.getString("attr_persistence");
 
-
         if (fileFormatConfigured) {
             String fileFormatStr = context.getString("file_format");
             
@@ -339,7 +342,7 @@ public class OrionHDFSSink extends OrionSink {
         if (enableHiveStr.equals("true") || enableHiveStr.equals("false")) {
             enableHive = Boolean.valueOf(enableHiveStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (enableHive="
-                + (enableHive ? "true" : "false") + ")");
+                + enableHiveStr + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (enableHive="
@@ -368,6 +371,7 @@ public class OrionHDFSSink extends OrionSink {
         if (hivePortNew != null && hivePortNew.length() > 0) {
             hivePort = hivePortNew;
             intHivePort = Integer.parseInt(hivePort);
+            
             if ((intHivePort <= 0) && (intHivePort > 65535)) {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.port=" + hivePort
@@ -375,9 +379,11 @@ public class OrionHDFSSink extends OrionSink {
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.port=" + hivePort + ")");
             }  // if else
+            
         } else if (hivePortOld != null && hivePortOld.length() > 0) {
             hivePort = hivePortOld;
             intHivePort = Integer.parseInt(hivePort);
+            
             if ((intHivePort <= 0) && (intHivePort > 65535)) {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive_port=" + hivePort + ")"
@@ -386,6 +392,7 @@ public class OrionHDFSSink extends OrionSink {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_port=" + hivePort + ")"
                         + " -- DEPRECATED, use hive.port instead");
             }  // else if
+            
         } else {
             hivePort = "10000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.port=10000");
@@ -396,16 +403,18 @@ public class OrionHDFSSink extends OrionSink {
 
         if (hiveServerVersionNew != null && hiveServerVersionNew.length() > 0) {
             hiveServerVersion = hiveServerVersionNew;
+            
             if ((hiveServerVersion.equals("1")) || (hiveServerVersion.equals("2"))) {
-                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.server_version=" + hiveServerVersion
-                    + ")");
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.server_version=" + hiveServerVersion + ")");
             } else {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.server_version=" + hiveServerVersion
                     + ") -- Must be '1' for HiveServer1 or '2' for HiveServer2");
             }  // if else
+            
         } else if (hiveServerVersionOld != null && hiveServerVersionOld.length() > 0) {
             hiveServerVersion = hiveServerVersionOld;
+            
             if (hiveServerVersion.equals("1") || hiveServerVersion.equals("2")) {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_server_version=" + hiveServerVersion
                     + ")"
@@ -416,6 +425,7 @@ public class OrionHDFSSink extends OrionSink {
                     + ") -- Must be '1' for HiveServer1 or '2' for HiveServer2"
                     + " -- DEPRECATED, use hive.server_version instead");
             }  // if else
+            
         } else {
             hiveServerVersion = "2";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.server_version=2");
@@ -439,7 +449,7 @@ public class OrionHDFSSink extends OrionSink {
         if (enableKrb5Str.equals("true") || enableKrb5Str.equals("false")) {
             enableKrb5 = Boolean.valueOf(enableKrb5Str);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_auth="
-                + (enableKrb5 ? "true" : "false") + ")");
+                + enableKrb5Str + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (krb5_auth="
@@ -461,7 +471,7 @@ public class OrionHDFSSink extends OrionSink {
         if (serviceAsNamespaceStr.equals("true") || serviceAsNamespaceStr.equals("false")) {
             serviceAsNamespace = Boolean.valueOf(serviceAsNamespaceStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type="
-                + (serviceAsNamespace ? "true" : "false") + ")");
+                + serviceAsNamespaceStr + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (service_as_namespace="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -15,7 +15,7 @@
  *
  * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
  */
- 
+
 package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.backends.hdfs.HDFSBackend;
@@ -44,9 +44,9 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 /**
- * 
+ *
  * @author frb
- * 
+ *
  * Detailed documentation can be found at:
  * https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/flume_extensions_catalogue/orion_hdfs_sink.md
  */
@@ -56,7 +56,7 @@ public class OrionHDFSSink extends OrionSink {
      * Available backend implementation.
      */
     public enum BackendImpl { BINARY, REST }
-    
+
     /**
      * Available Hive database types.
      */
@@ -84,14 +84,14 @@ public class OrionHDFSSink extends OrionSink {
     private HDFSBackend persistenceBackend;
     private HiveBackend hiveBackend;
     private String csvSeparator;
-    
+
     /**
      * Constructor.
      */
     public OrionHDFSSink() {
         super();
     } // OrionHDFSSink
-    
+
     /**
      * Gets the Cosmos host. It is protected due to it is only required for testing purposes.
      * @return The Cosmos host
@@ -99,7 +99,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String[] getHDFSHosts() {
         return host;
     } // getHDFSHosts
-    
+
     /**
      * Gets the Cosmos port. It is protected due to it is only required for testing purposes.
      * @return The Cosmos port
@@ -115,7 +115,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getHDFSUsername() {
         return username;
     } // getHDFSUsername
-    
+
     /**
      * Gets the password for the default Cosmos username. It is protected due to it is only required for testing
      * purposes.
@@ -124,7 +124,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getHDFSPassword() {
         return password;
     } // getHDFSPassword
-    
+
     /**
      * Gets the OAuth2 token used for authentication and authorization. It is protected due to it is only required
      * for testing purposes.
@@ -133,7 +133,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getOAuth2Token() {
         return oauth2Token;
     } // getOAuth2Token
-    
+
     /**
      * Returns if the service is used as HDFS namespace. It is protected due to it is only required for testing
      * purposes.
@@ -142,7 +142,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getServiceAsNamespace() {
         return (serviceAsNamespace ? "true" : "false");
     } // getServiceAsNamespace
-    
+
     /**
      * Gets the file format. It is protected due to it is only required for testing purposes.
      * @return The file format
@@ -161,11 +161,11 @@ public class OrionHDFSSink extends OrionSink {
                 return "";
         } // switch;
     } // getFileFormat
-    
+
     protected boolean getEnableHive() {
         return enableHive;
     } // getEnableHive
-    
+
     /**
      * Gets the Hive server version. It is protected due to it is only required for testing purposes.
      * @return The Hive server version
@@ -173,7 +173,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getHiveServerVersion() {
         return hiveServerVersion;
     } // getHiveServerVersion
-    
+
     /**
      * Gets the Hive host. It is protected due to it is only required for testing purposes.
      * @return The Hive port
@@ -181,7 +181,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getHiveHost() {
         return hiveHost;
     } // getHiveHost
-    
+
     /**
      * Gets the Hive port. It is protected due to it is only required for testing purposes.
      * @return The Hive port
@@ -198,7 +198,7 @@ public class OrionHDFSSink extends OrionSink {
     protected String getEnableKrb5Auth() {
         return (enableKrb5 ? "true" : "false");
     } // getEnableKrb5Auth
-    
+
     /**
      * Returns the persistence backend. It is protected due to it is only required for testing purposes.
      * @return The persistence backend
@@ -206,7 +206,7 @@ public class OrionHDFSSink extends OrionSink {
     protected HDFSBackend getPersistenceBackend() {
         return persistenceBackend;
     } // getPersistenceBackend
-    
+
     /**
      * Sets the persistence backend. It is protected due to it is only required for testing purposes.
      * @param persistenceBackend
@@ -214,12 +214,12 @@ public class OrionHDFSSink extends OrionSink {
     protected void setPersistenceBackend(HDFSBackendImplREST persistenceBackend) {
         this.persistenceBackend = persistenceBackend;
     } // setPersistenceBackend
-       
+
     @Override
     public void configure(Context context) {
         String cosmosHost = context.getString("cosmos_host");
         String hdfsHost = context.getString("hdfs_host");
-        
+
         if (hdfsHost != null && hdfsHost.length() > 0) {
             host = hdfsHost.split(",");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_host=" + Arrays.toString(host) + ")");
@@ -230,19 +230,19 @@ public class OrionHDFSSink extends OrionSink {
         } else {
             host = new String[]{"localhost"};
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_host=localhost");
-        } // if else 
-        
+        } // if else
+
         String cosmosPort = context.getString("cosmos_port");
         String hdfsPort = context.getString("hdfs_port");
-        
         int intPort;
+
         if (hdfsPort != null && hdfsPort.length() > 0) {
             port = hdfsPort;
             intPort = Integer.parseInt(port);
             if ((intPort <= 0) || (intPort > 65535)) {
                 invalidConfiguration = true;
-                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hdfs_port=" + port 
-                        + ") must be between 0 and 65535");
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hdfs_port=" + port
+                        + ") -- Must be between 0 and 65535");
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_port=" + port + ")");
             }  // if else
@@ -251,8 +251,8 @@ public class OrionHDFSSink extends OrionSink {
             intPort = Integer.parseInt(port);
             if ((intPort <= 0) || (intPort > 65535)) {
                 invalidConfiguration = true;
-                LOGGER.debug("[" + this.getName() + "] Invalid configuration (cosmos_port=" + port 
-                        + ") must be between 0 and 65535  -- DEPRECATED, use hdfs_port instead");
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (cosmos_port=" + port
+                        + ") -- Must be between 0 and 65535  -- DEPRECATED, use hdfs_port instead");
             } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + port + ")"
                     + " -- DEPRECATED, use hdfs_port instead");
@@ -261,10 +261,10 @@ public class OrionHDFSSink extends OrionSink {
             port = "14000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_port=14000");
         }  // if else
-        
+
         String cosmosDefaultUsername = context.getString("cosmos_default_username");
         String hdfsUsername = context.getString("hdfs_username");
-        
+
         if (hdfsUsername != null && hdfsUsername.length() > 0) {
             username = hdfsUsername;
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_username=" + username + ")");
@@ -276,12 +276,12 @@ public class OrionHDFSSink extends OrionSink {
             LOGGER.error("[" + this.getName() + "] No username provided. Cygnus can continue, but HDFS sink will not "
                     + "properly work!");
         } // if else
-        
+
         csvSeparator = context.getString("csv_separator", ",");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (csvSeparator=" + csvSeparator + ")");
-        
+
         oauth2Token = context.getString("oauth2_token");
-        
+
         if (oauth2Token != null && oauth2Token.length() > 0) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (oauth2_token=" + this.oauth2Token + ")");
         } else {
@@ -289,13 +289,13 @@ public class OrionHDFSSink extends OrionSink {
                     + "not properly work if WebHDFS service is protected with such an authentication and "
                     + "authorization mechanism!");
         } // if else
-        
+
         password = context.getString("hdfs_password");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (hdfs_password=" + password + ")");
 
         boolean rowAttrPersistenceConfigured = context.getParameters().containsKey("attr_persistence");
         boolean fileFormatConfigured = context.getParameters().containsKey("file_format");
-        
+
         if (fileFormatConfigured) {
             fileFormat = FileFormat.valueOf(context.getString("file_format").replaceAll("-", "").toUpperCase());
             LOGGER.debug("[" + this.getName() + "] Reading configuration (file_format=" + fileFormat + ")");
@@ -309,16 +309,16 @@ public class OrionHDFSSink extends OrionSink {
             fileFormat = FileFormat.JSONROW;
             LOGGER.debug("[" + this.getName() + "] Defaulting to file_format=json-row");
         } // if else if
-        
+
         // Hive configuration
         String enableHiveStr = context.getString("hive", "true");
         enableHive = enableHiveStr.equals("true");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (hive=" + (enableHive ? "true" : "false")
                 + ")");
-        
+
         String hiveHostOld = context.getString("hive_host");
         String hiveHostNew = context.getString("hive.host");
-        
+
         if (hiveHostNew != null && hiveHostNew.length() > 0) {
             hiveHost = hiveHostNew;
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.host=" + hiveHost + ")");
@@ -330,18 +330,18 @@ public class OrionHDFSSink extends OrionSink {
             hiveHost = "localhost";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.host=localhost");
         } // if else
-        
+
         String hivePortOld = context.getString("hive_port");
         String hivePortNew = context.getString("hive.port");
-        
         int intHivePort;
+
         if (hivePortNew != null && hivePortNew.length() > 0) {
             hivePort = hivePortNew;
             intHivePort = Integer.parseInt(hivePort);
             if ((intHivePort <= 0) && (intHivePort > 65535)) {
                 invalidConfiguration = true;
-                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.port=" + hivePort 
-                        + ") must be between 0 and 65535");
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.port=" + hivePort
+                        + ") -- Must be between 0 and 65535");
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.port=" + hivePort + ")");
             }  // if else
@@ -351,7 +351,7 @@ public class OrionHDFSSink extends OrionSink {
             if ((intHivePort <= 0) && (intHivePort > 65535)) {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive_port=" + hivePort + ")"
-                    + " must be between 0 and 65535  -- DEPRECATED, use hive.port instead");
+                    + " -- Must be between 0 and 65535 -- DEPRECATED, use hive.port instead");
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive_port=" + hivePort + ")"
                         + " -- DEPRECATED, use hive.port instead");
@@ -360,10 +360,10 @@ public class OrionHDFSSink extends OrionSink {
             hivePort = "10000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.port=10000");
         } // if else
-        
+
         String hiveServerVersionOld = context.getString("hive_server_version");
         String hiveServerVersionNew = context.getString("hive.server_version");
-        
+
         if (hiveServerVersionNew != null && hiveServerVersionNew.length() > 0) {
             hiveServerVersion = hiveServerVersionNew;
             if ((hiveServerVersion.equals("1")) || (hiveServerVersion.equals("2"))) {
@@ -372,7 +372,7 @@ public class OrionHDFSSink extends OrionSink {
             } else {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive.server_version=" + hiveServerVersion
-                    + ") must be '1' for HiveServer1 or '2' for HiveServer2");
+                    + ") -- Must be '1' for HiveServer1 or '2' for HiveServer2");
             }  // if else
         } else if (hiveServerVersionOld != null && hiveServerVersionOld.length() > 0) {
             hiveServerVersion = hiveServerVersionOld;
@@ -383,18 +383,18 @@ public class OrionHDFSSink extends OrionSink {
             } else {
                 invalidConfiguration = true;
                 LOGGER.debug("[" + this.getName() + "] Invalid configuration (hive_server_version=" + hiveServerVersion
-                    + ") must be '1' for HiveServer1 or '2' for HiveServer2"
+                    + ") -- Must be '1' for HiveServer1 or '2' for HiveServer2"
                     + " -- DEPRECATED, use hive.server_version instead");
             }  // if else
         } else {
             hiveServerVersion = "2";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.server_version=2");
         } // if else
-        
+
         String hiveDBTypeStr = context.getString("hive.db_type", "default-db");
         hiveDBType = HiveDBType.valueOf(hiveDBTypeStr.replaceAll("-", "").toUpperCase());
         LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type=" + hiveDBTypeStr);
-        
+
         // Kerberos configuration
         enableKrb5 = context.getBoolean("krb5_auth", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_auth=" + (enableKrb5 ? "true" : "false")
@@ -408,7 +408,7 @@ public class OrionHDFSSink extends OrionSink {
                 + ")");
         krb5ConfFile = context.getString("krb5_auth.krb5_conf_file", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_conf_file=" + krb5ConfFile + ")");
-        
+
         serviceAsNamespace = context.getBoolean("service_as_namespace", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (service_as_namespace=" + serviceAsNamespace
                 + ")");
@@ -426,7 +426,7 @@ public class OrionHDFSSink extends OrionSink {
             // create Hive backend
             hiveBackend = new HiveBackendImpl(hiveServerVersion, hiveHost, hivePort, username, password);
             LOGGER.debug("[" + this.getName() + "] Hive persistence backend created");
-            
+
             // create the persistence backend
             if (backendImpl == BackendImpl.BINARY) {
                 persistenceBackend = new HDFSBackendImplBinary(host, port, username, password, oauth2Token,
@@ -441,23 +441,23 @@ public class OrionHDFSSink extends OrionSink {
                         + backendImpl.toString());
                 System.exit(-1);
             } // if else
-            
+
             LOGGER.debug("[" + this.getName() + "] HDFS persistence backend created");
         } catch (Exception e) {
             LOGGER.error("Error while creating the HDFS persistence backend. Details="
                     + e.getMessage());
         } // try catch
-        
+
         super.start();
     } // start
-    
+
     @Override
     void persistBatch(Batch batch) throws Exception {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
         } // if
- 
+
         // iterate on the destinations, for each one a single create / append will be performed
         for (String destination : batch.getDestinations()) {
             LOGGER.debug("[" + this.getName() + "] Processing sub-batch regarding the " + destination
@@ -465,7 +465,7 @@ public class OrionHDFSSink extends OrionSink {
 
             // get the sub-batch for this destination
             ArrayList<CygnusEvent> subBatch = batch.getEvents(destination);
-            
+
             // get an aggregator for this destination and initialize it
             HDFSAggregator aggregator = getAggregator(fileFormat);
             aggregator.initialize(subBatch.get(0));
@@ -473,16 +473,16 @@ public class OrionHDFSSink extends OrionSink {
             for (CygnusEvent cygnusEvent : subBatch) {
                 aggregator.aggregate(cygnusEvent);
             } // for
-            
+
             // persist the aggregation
             persistAggregation(aggregator);
             batch.setPersisted(destination);
-            
+
             // persist the metadata aggregations only in CSV-like file formats
             if (fileFormat == FileFormat.CSVROW || fileFormat == FileFormat.CSVCOLUMN) {
                 persistMDAggregations(aggregator);
             } // if
-            
+
             // create the Hive table
             if (enableHive) {
                 if (hiveDBType == HiveDBType.NAMESPACEDB) {
@@ -504,7 +504,7 @@ public class OrionHDFSSink extends OrionSink {
      * Class for aggregating aggregation.
      */
     private abstract class HDFSAggregator {
-        
+
         // string containing the data aggregation
         protected String aggregation;
         // map containing the HDFS files holding the attribute metadata, one per attribute
@@ -518,36 +518,36 @@ public class OrionHDFSSink extends OrionSink {
         protected String hdfsFolder;
         protected String hdfsFile;
         protected String hiveFields;
-        
+
         public HDFSAggregator() {
             aggregation = "";
             mdAggregations = new HashMap<String, String>();
         } // HDFSAggregator
-        
+
         public String getAggregation() {
             return aggregation;
         } // getAggregation
-        
+
         public Set<String> getAggregatedAttrMDFiles() {
             return mdAggregations.keySet();
         } // getAggregatedAttrMDFiles
-        
+
         public String getMDAggregation(String attrMDFile) {
             return mdAggregations.get(attrMDFile);
         } // getMDAggregation
-        
+
         public String getFolder() {
             return hdfsFolder;
         } // getFolder
-        
+
         public String getFile() {
             return hdfsFile;
         } // getFile
-        
+
         public String getHiveFields() {
             return hiveFields;
         } // getHiveFields
-        
+
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             service = cygnusEvent.getService();
             servicePath = cygnusEvent.getServicePath();
@@ -558,16 +558,16 @@ public class OrionHDFSSink extends OrionSink {
             hdfsFolder = firstLevel + "/" + secondLevel + "/" + thirdLevel;
             hdfsFile = hdfsFolder + "/" + thirdLevel + ".txt";
         } // initialize
-        
+
         public abstract void aggregate(CygnusEvent cygnusEvent) throws Exception;
-        
+
     } // HDFSAggregator
-    
+
     /**
      * Class for aggregating batches in JSON row mode.
      */
     private class JSONRowAggregator extends HDFSAggregator {
-        
+
         @Override
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
@@ -581,7 +581,7 @@ public class OrionHDFSSink extends OrionSink {
                     + Utils.encodeHive(Constants.ATTR_VALUE) + " string,"
                     + Utils.encodeHive(Constants.ATTR_MD) + " array<struct<name:string,type:string,value:string>>";
         } // initialize
-        
+
         @Override
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
@@ -594,7 +594,7 @@ public class OrionHDFSSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -603,7 +603,7 @@ public class OrionHDFSSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -611,7 +611,7 @@ public class OrionHDFSSink extends OrionSink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                
+
                 // create a line and aggregate it
                 String line = "{"
                     + "\"" + Constants.RECV_TIME_TS + "\":\"" + recvTimeTs / 1000 + "\","
@@ -624,7 +624,7 @@ public class OrionHDFSSink extends OrionSink {
                     + "\"" + Constants.ATTR_VALUE + "\":" + attrValue + ","
                     + "\"" + Constants.ATTR_MD + "\":" + attrMetadata
                     + "}";
-                
+
                 if (aggregation.isEmpty()) {
                     aggregation = line;
                 } else {
@@ -634,7 +634,7 @@ public class OrionHDFSSink extends OrionSink {
         } // aggregate
 
     } // JSONRowAggregator
-    
+
     /**
      * Class for aggregating batches in JSON column mode.
      */
@@ -643,27 +643,27 @@ public class OrionHDFSSink extends OrionSink {
         @Override
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
-            
+
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
                     + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<ContextAttribute> contextAttributes = cygnusEvent.getContextElement().getAttributes();
 
             if (contextAttributes == null || contextAttributes.isEmpty()) {
                 return;
             } // if
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 hiveFields += "," + Utils.encodeHive(attrName) + " string," + Utils.encodeHive(attrName)
                         + "_md array<struct<name:string,type:string,value:string>>";
             } // for
         } // initialize
-        
+
         @Override
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
@@ -676,7 +676,7 @@ public class OrionHDFSSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -685,12 +685,12 @@ public class OrionHDFSSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             String line = "{\"" + Constants.RECV_TIME + "\":\"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\":\"" + servicePath + "\","
                     + "\"" + Constants.ENTITY_ID + "\":\"" + entityId + "\","
                     + "\"" + Constants.ENTITY_TYPE + "\":\"" + entityType + "\"";
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -698,11 +698,11 @@ public class OrionHDFSSink extends OrionSink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                
+
                 // create part of the line with the current attribute (a.k.a. a column)
                 line += ", \"" + attrName + "\":" + attrValue + ", \"" + attrName + "_md\":" + attrMetadata;
             } // for
-            
+
             // now, aggregate the line
             if (aggregation.isEmpty()) {
                 aggregation = line + "}";
@@ -710,14 +710,14 @@ public class OrionHDFSSink extends OrionSink {
                 aggregation += "\n" + line + "}";
             } // if else
         } // aggregate
-        
+
     } // JSONColumnAggregator
-    
+
     /**
      * Class for aggregating batches in CSV row mode.
      */
     private class CSVRowAggregator extends HDFSAggregator {
-        
+
         @Override
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
@@ -744,7 +744,7 @@ public class OrionHDFSSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -753,7 +753,7 @@ public class OrionHDFSSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -768,22 +768,22 @@ public class OrionHDFSSink extends OrionSink {
                 String attrMdFileName = attrMdFolder + "/" + thirdLevelMd + ".txt";
                 String printableAttrMdFileName = "hdfs:///user/" + username + "/" + attrMdFileName;
                 String mdAggregation = mdAggregations.get(attrMdFileName);
-                                
+
                 if (mdAggregation == null) {
                     mdAggregation = new String();
                 } // if
-                
+
                 // aggregate the metadata
                 String concatMdAggregation;
-                
+
                 if (mdAggregation.isEmpty()) {
                     concatMdAggregation = getCSVMetadata(attrMetadata, recvTimeTs);
                 } else {
                     concatMdAggregation = mdAggregation.concat("\n" + getCSVMetadata(attrMetadata, recvTimeTs));
                 } // if else
-                
+
                 mdAggregations.put(attrMdFileName, concatMdAggregation);
-                
+
                 // aggreagate the data
                 String line = recvTimeTs / 1000 + csvSeparator
                     + recvTime + csvSeparator
@@ -801,10 +801,10 @@ public class OrionHDFSSink extends OrionSink {
                 } // if else
             } // for
         } // aggregate
-        
+
         private String getCSVMetadata(String attrMetadata, long recvTimeTs) throws Exception {
             String csvMd = "";
-            
+
             // metadata is in JSON format, decode it
             JSONParser jsonParser = new JSONParser();
             JSONArray attrMetadataJSON = (JSONArray) jsonParser.parse(attrMetadata);
@@ -816,41 +816,41 @@ public class OrionHDFSSink extends OrionSink {
                         + mdJSONObject.get("name") + ","
                         + mdJSONObject.get("type") + ","
                         + mdJSONObject.get("value");
-                
+
                 if (csvMd.isEmpty()) {
                     csvMd = line;
                 } else {
                     csvMd += "\n" + line;
                 } // if else
             } // for
-            
+
             return csvMd;
         } // getCSVMetadata
-        
+
     } // CSVRowAggregator
-    
+
     /**
      * Class for aggregating aggregation in CSV column mode.
      */
     private class CSVColumnAggregator extends HDFSAggregator {
-        
+
         @Override
         public void initialize(CygnusEvent cygnusEvent) throws Exception {
             super.initialize(cygnusEvent);
-            
+
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
                     + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
-            
+
             // iterate on all this context element attributes; it is supposed all the entity's attributes are notified
             ArrayList<ContextAttribute> contextAttributes = cygnusEvent.getContextElement().getAttributes();
 
             if (contextAttributes == null || contextAttributes.isEmpty()) {
                 return;
             } // if
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -875,7 +875,7 @@ public class OrionHDFSSink extends OrionSink {
             String entityType = contextElement.getType();
             LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                     + entityType + ")");
-            
+
             // iterate on all this context element attributes, if there are attributes
             ArrayList<ContextAttribute> contextAttributes = contextElement.getAttributes();
 
@@ -884,9 +884,9 @@ public class OrionHDFSSink extends OrionSink {
                         + ", type=" + entityType + ")");
                 return;
             } // if
-            
+
             String line = recvTime + csvSeparator + servicePath + csvSeparator + entityId + csvSeparator + entityType;
-            
+
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
@@ -894,7 +894,7 @@ public class OrionHDFSSink extends OrionSink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                
+
                 // this has to be done notification by notification and not at initialization since in row mode not all
                 // the notifications contain all the attributes
                 String thirdLevelMd = buildThirdLevelMd(destination, attrName, attrType);
@@ -902,26 +902,26 @@ public class OrionHDFSSink extends OrionSink {
                 String attrMdFileName = attrMdFolder + "/" + thirdLevelMd + ".txt";
                 String printableAttrMdFileName = "hdfs:///user/" + username + "/" + attrMdFileName;
                 String mdAggregation = mdAggregations.get(attrMdFileName);
-                
+
                 if (mdAggregation == null) {
                     mdAggregation = new String();
                 } // if
-                
+
                 // agregate the metadata
                 String concatMdAggregation;
-                
+
                 if (mdAggregation.isEmpty()) {
                     concatMdAggregation = getCSVMetadata(attrMetadata, recvTimeTs);
                 } else {
                     concatMdAggregation = mdAggregation.concat("\n" + getCSVMetadata(attrMetadata, recvTimeTs));
                 } // if else
-                
+
                 mdAggregations.put(attrMdFileName, concatMdAggregation);
-                
+
                 // create part of the line with the current attribute (a.k.a. a column)
                 line += csvSeparator + attrValue.replaceAll("\"", "") + csvSeparator + printableAttrMdFileName;
             } // for
-            
+
             // now, aggregate the line
             if (aggregation.isEmpty()) {
                 aggregation = line;
@@ -929,10 +929,10 @@ public class OrionHDFSSink extends OrionSink {
                 aggregation += "\n" + line;
             } // if else
         } // aggregate
-        
+
         private String getCSVMetadata(String attrMetadata, long recvTimeTs) throws Exception {
             String csvMd = "";
-            
+
             // metadata is in JSON format, decode it
             JSONParser jsonParser = new JSONParser();
             JSONArray attrMetadataJSON = (JSONArray) jsonParser.parse(attrMetadata);
@@ -944,19 +944,19 @@ public class OrionHDFSSink extends OrionSink {
                         + mdJSONObject.get("name") + ","
                         + mdJSONObject.get("type") + ","
                         + mdJSONObject.get("value");
-                
+
                 if (csvMd.isEmpty()) {
                     csvMd = line;
                 } else {
                     csvMd += "\n" + line;
                 } // if else
             } // for
-            
+
             return csvMd;
         } // getCSVMetadata
-        
+
     } // CSVColumnAggregator
-    
+
     private HDFSAggregator getAggregator(FileFormat fileFormat) {
         switch (fileFormat) {
             case JSONROW:
@@ -971,12 +971,12 @@ public class OrionHDFSSink extends OrionSink {
                 return null;
         } // switch
     } // getAggregator
-    
+
     private void persistAggregation(HDFSAggregator aggregator) throws Exception {
         String aggregation = aggregator.getAggregation();
         String hdfsFolder = aggregator.getFolder();
         String hdfsFile = aggregator.getFile();
-        
+
         LOGGER.info("[" + this.getName() + "] Persisting data at OrionHDFSSink. HDFS file ("
                 + hdfsFile + "), Data (" + aggregation + ")");
 
@@ -987,14 +987,14 @@ public class OrionHDFSSink extends OrionSink {
             persistenceBackend.createFile(hdfsFile, aggregation);
         } // if else
     } // persistAggregation
-    
+
     private void persistMDAggregations(HDFSAggregator aggregator) throws Exception {
         Set<String> attrMDFiles = aggregator.getAggregatedAttrMDFiles();
-        
+
         for (String hdfsMDFile : attrMDFiles) {
             String hdfsMdFolder = hdfsMDFile.substring(0, hdfsMDFile.lastIndexOf("/"));
             String mdAggregation = aggregator.getMDAggregation(hdfsMDFile);
-            
+
             LOGGER.info("[" + this.getName() + "] Persisting metadata at OrionHDFSSink. HDFS file ("
                     + hdfsMDFile + "), Data (" + mdAggregation + ")");
 
@@ -1006,12 +1006,12 @@ public class OrionHDFSSink extends OrionSink {
             } // if else
         } // for
     } // persistMDAggregations
-    
+
     private void provisionHiveTable(HDFSAggregator aggregator, String dbName) throws Exception {
         String dirPath = aggregator.getFolder();
         String fields = aggregator.getHiveFields();
         String tag;
-        
+
         switch (fileFormat) {
             case JSONROW:
             case CSVROW:
@@ -1024,18 +1024,18 @@ public class OrionHDFSSink extends OrionSink {
             default:
                 tag = "";
         } // switch
-        
+
         // get the table name to be created
         // the replacement is necessary because Hive, due it is similar to MySQL, does not accept '-' in the table names
         String tableName = Utils.encodeHive((serviceAsNamespace ? "" : username + "_") + dirPath) + tag;
         LOGGER.info("Creating Hive external table '" + tableName + "' in database '"  + dbName + "'");
-        
+
         // get a Hive client
         HiveBackendImpl hiveClient = new HiveBackendImpl(hiveServerVersion, hiveHost, hivePort, username, password);
-        
+
         // create the query
         String query;
-        
+
         switch (fileFormat) {
             case JSONCOLUMN:
             case JSONROW:
@@ -1056,13 +1056,13 @@ public class OrionHDFSSink extends OrionSink {
 
         // execute the query
         LOGGER.debug("Doing Hive query: '" + query + "'");
-        
+
         if (!hiveClient.doCreateTable(query)) {
             LOGGER.warn("The HiveQL external table could not be created, but Cygnus can continue working... "
                     + "Check your Hive/Shark installation");
         } // if
     } // provisionHive
-    
+
     /**
      * Builds the first level of a HDFS path given a fiwareService. It throws an exception if the naming conventions are
      * violated.
@@ -1072,15 +1072,15 @@ public class OrionHDFSSink extends OrionSink {
      */
     private String buildFirstLevel(String fiwareService) throws Exception {
         String firstLevel = fiwareService;
-        
+
         if (firstLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building firstLevel=fiwareService (fiwareService=" + fiwareService + ") "
                     + "and its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
-        
+
         return firstLevel;
     } // buildFirstLevel
-    
+
     /**
      * Builds the second level of a HDFS path given given a fiwareService and a destination. It throws an exception if
      * the naming conventions are violated.
@@ -1091,12 +1091,12 @@ public class OrionHDFSSink extends OrionSink {
      */
     private String buildSecondLevel(String fiwareServicePath) throws Exception {
         String secondLevel = fiwareServicePath;
-        
+
         if (secondLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building secondLevel=fiwareServicePath (" + fiwareServicePath + ") and "
                     + "its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
-        
+
         return secondLevel;
     } // buildSecondLevel
 
@@ -1109,7 +1109,7 @@ public class OrionHDFSSink extends OrionSink {
      */
     private String buildThirdLevel(String destination) throws Exception {
         String thirdLevel = destination;
-        
+
         if (thirdLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevel=destination (" + destination + ") and its length is "
                     + "greater than " + Constants.MAX_NAME_LEN_HDFS);
@@ -1117,7 +1117,7 @@ public class OrionHDFSSink extends OrionSink {
 
         return thirdLevel;
     } // buildThirdLevel
-    
+
     /**
      * Builds the third level of a HDFS path given a destination. It throws an exception if the naming conventions are
      * violated.
@@ -1127,7 +1127,7 @@ public class OrionHDFSSink extends OrionSink {
      */
     private String buildThirdLevelMd(String destination, String attrName, String attrType) throws Exception {
         String thirdLevelMd = destination + "_" + attrName + "_" + attrType;
-        
+
         if (thirdLevelMd.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevelMd=" + thirdLevelMd + " and its length is "
                     + "greater than " + Constants.MAX_NAME_LEN_HDFS);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -320,6 +320,7 @@ public class OrionHDFSSink extends OrionSink {
             } // catch
             
         } else if (rowAttrPersistenceConfigured) {
+            
             if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
                 boolean rowAttrPersistence = attrPersistenceStr.equals("row");
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
@@ -96,8 +96,15 @@ public class OrionKafkaSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (zookeeper_endpoint="
                 + zookeeperEndpoint + ")");
         partitions = context.getInteger("partitions", 1);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (partitions=" + partitions + ")");
+        if (partitions <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (partitions=" + partitions 
+                    + ") must be upper than 1");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (partitions=" + partitions + ")");
+        }
         replicationFactor = context.getInteger("replication_factor", 1);
+        // TBD: Get the number of brokers for check this parameter
         LOGGER.debug("[" + this.getName() + "] Reading configuration (replication factor="
                 + replicationFactor + ")");
         super.configure(context);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
@@ -99,14 +99,18 @@ public class OrionKafkaSink extends OrionSink {
         if (partitions <= 0) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (partitions=" + partitions 
-                    + ") must be upper than 1");
+                    + ") must be upper than 0");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (partitions=" + partitions + ")");
         }
         replicationFactor = context.getInteger("replication_factor", 1);
-        // TBD: Get the number of brokers for check this parameter
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (replication factor="
-                + replicationFactor + ")");
+        if (replicationFactor <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (replication_factor=" 
+                    + replicationFactor + ") must be upper than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (replication_factor=" + replicationFactor + ")");
+        }
         super.configure(context);
     } // configure
     

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
@@ -100,7 +100,7 @@ public class OrionKafkaSink extends OrionSink {
         if (partitions <= 0) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (partitions=" + partitions
-                    + ") -- Must be upper than 0");
+                    + ") -- Must be greater than 0");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (partitions=" + partitions + ")");
         }
@@ -110,7 +110,7 @@ public class OrionKafkaSink extends OrionSink {
         if (replicationFactor <= 0) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (replication_factor="
-                    + replicationFactor + ") -- Must be upper than 0");
+                    + replicationFactor + ") -- Must be greater than 0");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (replication_factor=" + replicationFactor + ")");
         }

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -123,8 +123,15 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         shouldHash = context.getBoolean("should_hash", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash=" + shouldHash + ")");
         this.rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + (this.rowAttrPersistence ? "row" : "column") + ")");
+        String persistence = context.getString("attr_persistence");
+        if (persistence.equals("row") || persistence.equals("column")) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + persistence + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
+                + persistence + ") must be 'row' or 'column'");
+        }  // if else
         super.configure(context);
     } // configure
     

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -124,14 +124,16 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash=" + shouldHash + ")");
         this.rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence");
-        if (persistence.equals("row") || persistence.equals("column")) {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + persistence + ")");
-        } else {
+        try {
+            if (persistence.equals("row") || persistence.equals("column")) {
+                 LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                    + persistence + ")");
+            }
+        } catch (Exception e) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
                 + persistence + ") must be 'row' or 'column'");
-        }  // if else
+        }  // try catch
         super.configure(context);
     } // configure
     

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -120,21 +120,30 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (db_prefix=" + dbPrefix + ")");
         collectionPrefix = Utils.encode(context.getString("collection_prefix", "sth_"));
         LOGGER.debug("[" + this.getName() + "] Reading configuration (collection_prefix=" + collectionPrefix + ")");
-        shouldHash = context.getBoolean("should_hash", false);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash=" + shouldHash + ")");
-        this.rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        String persistence = context.getString("attr_persistence");
+        
+        String shouldHashStr = context.getString("should_hash");
+        
+        if (shouldHashStr.equals("true") || shouldHashStr.equals("false")) {
+            shouldHash = Boolean.valueOf(shouldHashStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash="
+                + (shouldHash ? "true" : "false") + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (should_hash="
+                + shouldHashStr + ") -- Must be 'true' or 'false'");
+        }  // if else
+        
+        String attrPersistenceStr = context.getString("attr_persistence");
 
-        try {
-            if (persistence.equals("row") || persistence.equals("column")) {
-                 LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                    + persistence + ")");
-            }
-        } catch (Exception e) {
+        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+            rowAttrPersistence = attrPersistenceStr.equals("row");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + attrPersistenceStr + ")");
+        } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") -- Must be 'row' or 'column'");
-        }  // try catch
+                + attrPersistenceStr + ") -- Must be 'row' or 'column'");
+        }  // if else
 
         super.configure(context);
     } // configure

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -126,14 +126,7 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         }  // if else
 
         dataExpiration = context.getLong("data_expiration");
-        
-        if (dataExpiration <= 0) {
-            invalidConfiguration = true;
-            LOGGER.debug("[" + this.getName() + "] Invalid configuration (data_expiration="
-                    + dataExpiration + ") -- Must be greater than 0");
-        } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiration=" + dataExpiration + ")");
-        }  // if else
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiration=" + dataExpiration + ")");
         
         super.configure(context);
     } // configure

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -125,8 +125,16 @@ public abstract class OrionMongoBaseSink extends OrionSink {
                 + shouldHashStr + ") -- Must be 'true' or 'false'");
         }  // if else
 
-        dataExpiration = context.getLong("data_expiration", 0L);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiraton=" + dataExpiration + ")");
+        dataExpiration = context.getLong("data_expiration");
+        
+        if (dataExpiration <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (data_expiration="
+                    + dataExpiration + ") -- Must be greater than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiration=" + dataExpiration + ")");
+        }  // if else
+        
         super.configure(context);
     } // configure
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -49,9 +49,24 @@ public class OrionMongoSink extends OrionMongoBaseSink {
     @Override
     public void configure(Context context) {
         collectionsSize = context.getLong("collections_size", 0L);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (collections_size=" + collectionsSize + ")");
+        
+        if (collectionsSize <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (collections_size="
+                    + collectionsSize + ") -- Must be greater than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (collections_size=" + collectionsSize + ")");
+        }  // if else
+       
         maxDocuments = context.getLong("max_documents", 0L);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (max_documents=" + maxDocuments + ")");
+        
+        if (maxDocuments <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (max_documents="
+                    + maxDocuments + ") -- Must be greater than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (max_documents=" + maxDocuments + ")");
+        }  // if else
         
         String attrPersistenceStr = context.getString("attr_persistence");
         

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -46,6 +46,10 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         super();
     } // OrionMongoSink
     
+    public boolean getRowAttrPersistence() {
+        return rowAttrPersistence;
+    }
+    
     @Override
     public void configure(Context context) {
         collectionsSize = context.getLong("collections_size", 0L);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -50,23 +50,16 @@ public class OrionMongoSink extends OrionMongoBaseSink {
     public void configure(Context context) {
         collectionsSize = context.getLong("collections_size", 0L);
         
-        if (collectionsSize <= 0) {
+        if (collectionsSize < 4096) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (collections_size="
-                    + collectionsSize + ") -- Must be greater than 0");
+                    + collectionsSize + ") -- Must be greater than or equal to 4096");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (collections_size=" + collectionsSize + ")");
         }  // if else
        
         maxDocuments = context.getLong("max_documents", 0L);
-        
-        if (maxDocuments <= 0) {
-            invalidConfiguration = true;
-            LOGGER.debug("[" + this.getName() + "] Invalid configuration (max_documents="
-                    + maxDocuments + ") -- Must be greater than 0");
-        } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (max_documents=" + maxDocuments + ")");
-        }  // if else
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (max_documents=" + maxDocuments + ")");
         
         String attrPersistenceStr = context.getString("attr_persistence");
         

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -85,6 +85,8 @@ public class OrionMongoSink extends OrionMongoBaseSink {
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
                 + attrPersistenceStr + ") must be 'row' or 'column'");
         }  // if else
+        
+        super.configure(context);
     } // configure
     
     /**

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -115,6 +115,7 @@ public class OrionMySQLSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_host=" + mysqlHost + ")");
         mysqlPort = context.getString("mysql_port", "3306");
         int intPort = Integer.parseInt(mysqlPort);
+        
         if ((intPort <= 0) || (intPort > 65535)) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (mysql_port=" + mysqlPort + ") "
@@ -122,6 +123,7 @@ public class OrionMySQLSink extends OrionSink {
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + mysqlPort + ")");
         }  // if else
+        
         mysqlUsername = context.getString("mysql_username", "opendata");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_username=" + mysqlUsername + ")");
         // FIXME: mysqlPassword should be read as a SHA1 and decoded here

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -114,15 +114,29 @@ public class OrionMySQLSink extends OrionSink {
         mysqlHost = context.getString("mysql_host", "localhost");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_host=" + mysqlHost + ")");
         mysqlPort = context.getString("mysql_port", "3306");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + mysqlPort + ")");
+        int intPort = Integer.parseInt(mysqlPort);
+        if ((intPort <= 0) || (intPort > 65535)) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (mysql_port=" + mysqlPort + ") "
+                    + "must be between 0 and 65535");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + mysqlPort + ")");
+        }  // if else
         mysqlUsername = context.getString("mysql_username", "opendata");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_username=" + mysqlUsername + ")");
         // FIXME: mysqlPassword should be read as a SHA1 and decoded here
         mysqlPassword = context.getString("mysql_password", "unknown");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_password=" + mysqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + (rowAttrPersistence ? "row" : "column") + ")");
+        String persistence = context.getString("attr_persistence");
+        if (persistence.equals("row") || persistence.equals("column")) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + persistence + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
+                + persistence + ") must be 'row' or 'column'");
+        }  // if else
         super.configure(context);
     } // configure
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -124,13 +124,15 @@ public class OrionPostgreSQLSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_host=" + postgresqlHost + ")");
         postgresqlPort = context.getString("postgresql_port", "3306");
         int intPort = Integer.parseInt(postgresqlPort);
+
         if ((intPort <= 0) || (intPort > 65535)) {
             invalidConfiguration = true;
-            LOGGER.debug("[" + this.getName() + "] Invalid configuration (postgresql_port=" + postgresqlPort + ") "
-                    + "must be between 0 and 65535");
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (postgresql_port=" + postgresqlPort + ")"
+                    + " -- Must be between 0 and 65535");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_port=" + postgresqlPort + ")");
         }  // if else
+
         postgresqlDatabase = context.getString("postgresql_database", "postgres");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_database=" + postgresqlDatabase + ")");
         postgresqlUsername = context.getString("postgresql_username", "opendata");
@@ -140,14 +142,16 @@ public class OrionPostgreSQLSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_password=" + postgresqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence");
+
         if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") must be 'row' or 'column'");
+                + persistence + ") -- Must be 'row' or 'column'");
         }  // if else
+
         super.configure(context);
     } // configure
 
@@ -161,7 +165,7 @@ public class OrionPostgreSQLSink extends OrionSink {
             LOGGER.error("Error while creating the PostgreSQL persistence backend. Details="
                     + e.getMessage());
         } // try catch
-        
+
         super.start();
         LOGGER.info("[" + this.getName() + "] Startup completed");
     } // start

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -123,7 +123,14 @@ public class OrionPostgreSQLSink extends OrionSink {
         postgresqlHost = context.getString("postgresql_host", "localhost");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_host=" + postgresqlHost + ")");
         postgresqlPort = context.getString("postgresql_port", "3306");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_port=" + postgresqlPort + ")");
+        int intPort = Integer.parseInt(postgresqlPort);
+        if ((intPort <= 0) || (intPort > 65535)) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (postgresql_port=" + postgresqlPort + ") "
+                    + "must be between 0 and 65535");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_port=" + postgresqlPort + ")");
+        }  // if else
         postgresqlDatabase = context.getString("postgresql_database", "postgres");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_database=" + postgresqlDatabase + ")");
         postgresqlUsername = context.getString("postgresql_username", "opendata");
@@ -132,8 +139,15 @@ public class OrionPostgreSQLSink extends OrionSink {
         postgresqlPassword = context.getString("postgresql_password", "unknown");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_password=" + postgresqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + (rowAttrPersistence ? "row" : "column") + ")");
+        String persistence = context.getString("attr_persistence");
+        if (persistence.equals("row") || persistence.equals("column")) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + persistence + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_persistence="
+                + persistence + ") must be 'row' or 'column'");
+        }  // if else
         super.configure(context);
     } // configure
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -169,7 +169,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
         if (enableGroupingStr.equals("true") || enableGroupingStr.equals("false")) {
             enableGrouping = Boolean.valueOf(enableGroupingStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (enable_grouping="
-                + (enableGrouping ? "true" : "false") + ")");
+                + enableGroupingStr + ")");
         }  else {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (enable_grouping="
@@ -181,7 +181,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
         if (batchSize <= 0) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (batch_size="
-                    + batchSize + ") -- Must be upper than 0");
+                    + batchSize + ") -- Must be greater than 0");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_size="
                     + batchSize + ")");
@@ -192,7 +192,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
         if (batchTimeout <= 0) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (batch_timeout="
-                    + batchTimeout + ") -- Must be upper than 0");
+                    + batchTimeout + ") -- Must be greater than 0");
         } else {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_timeout="
                     + batchTimeout + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -164,9 +164,17 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
                     + dataModelStr + ")");
         } // catch
 
-        enableGrouping = context.getBoolean("enable_grouping", false);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (enable_grouping="
+        String enableGroupingStr = context.getString("enable_grouping");
+        
+        if (enableGroupingStr.equals("true") || enableGroupingStr.equals("false")) {
+            enableGrouping = Boolean.valueOf(enableGroupingStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (enable_grouping="
                 + (enableGrouping ? "true" : "false") + ")");
+        }  else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (enable_grouping="
+                + enableGroupingStr + ") -- Must be 'true' or 'false'");
+        }  // try catch
 
         batchSize = context.getInteger("batch_size", 1);
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -82,7 +82,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
     protected boolean enableGrouping;
     protected int batchSize;
     protected int batchTimeout;
-    private boolean invalidConfiguration;
+    protected boolean invalidConfiguration;
     // accumulator utility
     private final Accumulator accumulator;
     // rollback queues
@@ -167,12 +167,25 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
         enableGrouping = context.getBoolean("enable_grouping", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (enable_grouping="
                 + (enableGrouping ? "true" : "false") + ")");
+        
         batchSize = context.getInteger("batch_size", 1);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_size="
-                + batchSize + ")");
+        if (batchSize <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (batch_size="
+                    + batchSize + ") must be upper than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_size="
+                    + batchSize + ")");
+        } // if
         batchTimeout = context.getInteger("batch_timeout", 30);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_timeout="
-                + batchTimeout + ")");
+        if (batchTimeout <= 0) {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (batch_timeout="
+                    + batchTimeout + ") must be upper than 0");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_timeout="
+                    + batchTimeout + ")");
+        } // if
     } // configure
 
     @Override

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
@@ -57,6 +57,8 @@ public class OrionCKANSinkTest {
     private final String apiKey = "xyzwxyzwxyzw";
     private final String orionURL = "http://localhost:1026";
     private final String ssl = "true";
+    private String enableGrouping = "true";
+    private String attrPersistence = "row";
     
     // batches constants
     private final Long recvTimeTs = 123456789L;
@@ -173,14 +175,12 @@ public class OrionCKANSinkTest {
     @Test
     public void testConfigure() {
         System.out.println("Testing OrionCKANSink.configure");
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
         Context context = createContext(attrPersistence, enableGrouping);
         sink.configure(context);
         assertEquals(ckanHost, sink.getCKANHost());
         assertEquals(ckanPort, sink.getCKANPort());
         assertEquals(apiKey, sink.getAPIKey());
-        assertEquals(enableGrouping, sink.getEnableGrouping() ? "true" : "false");
         assertEquals(apiKey, sink.getAPIKey());
         assertEquals(attrPersistence, sink.getRowAttrPersistence() ? "row" : "column");
         assertEquals(ssl, sink.getSSL() ? "true" : "false");
@@ -192,8 +192,8 @@ public class OrionCKANSinkTest {
     @Test
     public void testStart() {
         System.out.println("Testing OrionCKANSink.start");
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
+        enableGrouping = "true";
         Context context = createContext(attrPersistence, enableGrouping);
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
@@ -208,8 +208,8 @@ public class OrionCKANSinkTest {
     @Test
     public void testPersistNullBatches() {
         System.out.println("Testing OrionCKANSinkTest.persistBatch (null batches)");
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
+        enableGrouping = "true";
         Context context = createContext(attrPersistence, enableGrouping);
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
@@ -235,8 +235,8 @@ public class OrionCKANSinkTest {
                 singleNotifyContextRequest.getContextResponses().get(0).getContextElement());
         
         System.out.println("Testing OrionCKANSinkTest.persistBatch (row persistence, enable grouping)");
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
+        enableGrouping = "true";
         Context context = createContext(attrPersistence, enableGrouping);
         sink.configure(context);
         sink.setChannel(new MemoryChannel());
@@ -301,8 +301,8 @@ public class OrionCKANSinkTest {
     @Test
     public void testPersistResourceLengths() {
         // common objects
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
+        enableGrouping = "true";
         Context context = createContext(attrPersistence, enableGrouping);
         
         System.out.println("Testing OrionCKANSink.persisBatch (normal resource lengths)");
@@ -365,8 +365,8 @@ public class OrionCKANSinkTest {
     @Test
     public void testPersistServiceServicePath() {
         // common objects
-        String attrPersistence = "row";
-        String enableGrouping = "true";
+        attrPersistence = "row";
+        enableGrouping = "true";
         Context context = createContext(attrPersistence, enableGrouping);
         
         System.out.println("Testing OrionCKANSink.persistBatch (\"root\" servicePath name)");

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -493,13 +493,13 @@ public class OrionHDFSSinkTest {
         context.put("oauth2_token", oauth2Token);
         context.put("service_as_namespace", serviceAsNamespace);
         context.put("file_format", fileFormat);
+        context.put("hive", enableHive);
         
         if (useDeprecatedParams) {
             context.put("hive_server_version", hiveServerVersion);
             context.put("hive_host", hiveHost);
             context.put("hive_port", hivePort);
         } else {
-            context.put("hive", enableHive);
             context.put("hive.server_version", hiveServerVersion);
             context.put("hive.host", hiveHost);
             context.put("hive.port", hivePort);

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -441,6 +441,7 @@ public class OrionKafkaSinkTest {
     
     private Context createContext(String dataModel) {
         Context context = new Context();
+        context.put("enable_grouping", "true");
         context.put("data_model", dataModel);
         context.put("broker_list", brokerList);
         context.put("zookeeper_endpoint", zookeeperEndpoint);

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSinkTest.java
@@ -49,6 +49,8 @@ public class OrionMongoBaseSinkTest {
     private final String collectionPrefix = "test_";
     private final String enableGrouping = "true";
     private final String attrPersistence = "row";
+    private final String shouldHash = "true";
+    private final String dataExpiration = "0";
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -71,6 +73,8 @@ public class OrionMongoBaseSinkTest {
         context.put("collection_prefix", collectionPrefix);
         context.put("enable_grouping", enableGrouping);
         context.put("attr_persistence", attrPersistence);
+        context.put("should_hash", shouldHash);
+        context.put("data_expiration", dataExpiration);
     } // setUp
     
     /**

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSinkTest.java
@@ -48,6 +48,7 @@ public class OrionMongoBaseSinkTest {
     private final String dbPrefix = "test_";
     private final String collectionPrefix = "test_";
     private final String enableGrouping = "true";
+    private final String attrPersistence = "row";
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -69,6 +70,7 @@ public class OrionMongoBaseSinkTest {
         context.put("db_prefix", dbPrefix);
         context.put("collection_prefix", collectionPrefix);
         context.put("enable_grouping", enableGrouping);
+        context.put("attr_persistence", attrPersistence);
     } // setUp
     
     /**
@@ -85,6 +87,7 @@ public class OrionMongoBaseSinkTest {
         assertEquals(dbPrefix, sink.getDbPrefix());
         assertEquals(collectionPrefix, sink.getCollectionPrefix());
         assertEquals(enableGrouping, sink.getEnableGrouping() ? "true" : "false");
+        assertEquals(attrPersistence, sink.getRowAttrPersistence() ? "row" : "column");
     } // testConfigure
 
     /**

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
@@ -59,6 +59,7 @@ public class OrionMongoSinkTest {
     private final String dbPrefix = "test_";
     private final String collectionPrefix = "test_";
     private final String enableGrouping = "true";
+    private final String attrPersistence = "row";
     private final String dbName = "db-name";
     private final String collectionName = "collection-name";
     private final long recvTimeTs = 1429535775;
@@ -165,6 +166,7 @@ public class OrionMongoSinkTest {
         context.put("db_prefix", dbPrefix);
         context.put("collection_prefix", collectionPrefix);
         context.put("enable_grouping", enableGrouping);
+        context.put("attr_persistente", attrPersistence);
         singleNotifyContextRequest = TestUtils.createJsonNotifyContextRequest(singleContextElementNotification);
         multipleNotifyContextRequest = TestUtils.createJsonNotifyContextRequest(multipleContextElementNotification);
         


### PR DESCRIPTION
* Fix issue https://github.com/telefonicaid/fiware-cygnus/issues/752
* 100% unit test:
```
Results : Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed :
All unofficial tests use a bad-configured agent with wrong parameters.

`OrionMySqlSink` (Checking `mysql_port`, `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T11:17:01.143CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[120] : [mysql-sink] Invalid configuration (mysql_port=65537) must be between 0 and 65535
time=2016-02-15T11:17:01.144CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[137] : [mysql-sink] Invalid configuration (attr_persistence=rowlum) must be 'row' or 'column'
time=2016-02-15T11:17:01.145CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [mysql-sink] Invalid configuration (data_model=dm-by-entitry)
time=2016-02-15T11:17:01.151CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [mysql-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T11:17:01.151CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [mysql-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:17:01.223CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [mysql-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionCKANSink` (Checking `ckan_port`, `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`): 
```
time=2016-02-15T11:19:40.813CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[124] : [ckan-sink] Invalid configuration (ckan_port=100000) must be between 0 and 65535
time=2016-02-15T11:19:40.813CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[138] : [ckan-sink] Invalid configuration (attr_persistence=frow) must be 'row' or 'column'
time=2016-02-15T11:19:40.828CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [ckan-sink] Invalid configuration (data_model=dm-by-sentity)
time=2016-02-15T11:19:40.829CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [ckan-sink] Invalid configuration (batch_size=-8) must be upper than 0
time=2016-02-15T11:19:40.829CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [ckan-sink] Invalid configuration (batch_timeout=-1) must be upper than 0
time=2016-02-15T11:19:41.245CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [ckan-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionDynamoDBSink` (Checking `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T11:24:18.078CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionDynamoDBSink[87] : [dynamodb-sink] Invalid configuration (attr_persistence=strow) must be 'row' or 'column'
time=2016-02-15T11:24:18.079CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [dynamodb-sink] Invalid configuration (data_model=dm-by-frentity)
time=2016-02-15T11:24:18.084CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [dynamodb-sink] Invalid configuration (batch_size=-12) must be upper than 0
time=2016-02-15T11:24:18.085CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [dynamodb-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:24:18.934CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [dynamodb-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionKafkaSink` (Checking `partitions`, `replication_factor`, `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`): 
```
time=2016-02-15T11:28:23.539CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionKafkaSink[101] : [kafka-sink] Invalid configuration (partitions=0) must be upper than 0
time=2016-02-15T11:28:23.540CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionKafkaSink[104] : [kafka-sink] Invalid configuration (replication_factor=0) must be upper than 0
time=2016-02-15T11:28:23.541CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [kafka-sink] Invalid configuration (data_model=dm-by-frentity)
time=2016-02-15T11:28:23.541CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [kafka-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T11:28:23.546CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [kafka-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:28:23.891CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [kafka-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionMongoSink` (Checking `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T11:40:19.404CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[132] : [mongo-sink] Invalid configuration (attr_persistence=crow) must be 'row' or 'column'
time=2016-02-15T11:40:19.405CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [mongo-sink] Invalid configuration (data_model=dm-by-sentity)
time=2016-02-15T11:40:19.406CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [mongo-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T11:40:19.406CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [mongo-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:40:19.478CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [mongo-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionSTHSink` (Checking `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T11:50:01.346CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[134] : [sth-sink] Invalid configuration (attr_persistence=null) must be 'row' or 'column'
time=2016-02-15T11:50:01.347CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [sth-sink] Invalid configuration (data_model=dm-by-afrentity)
time=2016-02-15T11:50:01.347CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [sth-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T11:50:01.348CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [sth-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:50:01.428CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [sth-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionHDFSSink` (Checking `hdfs_port`, `hive.server_version`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T11:58:13.031CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[244] : [hdfs-sink] Invalid configuration (hdfs_port=100000) must be between 0 and 65535
time=2016-02-15T11:58:13.033CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[374] : [hdfs-sink] Invalid configuration (hive.server_version=3) must be '1' for HiveServer1 or '2' for HiveServer2
time=2016-02-15T11:58:13.042CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [hdfs-sink] Invalid configuration (data_model=dm-by-frentity)
time=2016-02-15T11:58:13.043CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [hdfs-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T11:58:13.044CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [hdfs-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T11:58:13.395CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [hdfs-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```
`OrionPostgreSQLSink` (Checking `postgresql_port`, `attr_persistence`, `data_model`, `batch_size`, `batch_timeout`):
```
time=2016-02-15T12:31:37.408CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[129] : [postgresql-sink] Invalid configuration (postgresql_port=123306) must be between 0 and 65535
time=2016-02-15T12:31:37.422CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[148] : [postgresql-sink] Invalid configuration (attr_persistence=columnas) must be 'row' or 'column'
time=2016-02-15T12:31:37.423CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [postgresql-sink] Invalid configuration (data_model=dm-by-frentity)
time=2016-02-15T12:31:37.423CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [postgresql-sink] Invalid configuration (batch_size=0) must be upper than 0
time=2016-02-15T12:31:37.424CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[183] : [postgresql-sink] Invalid configuration (batch_timeout=0) must be upper than 0
time=2016-02-15T12:31:37.579CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[196] : [postgresql-sink] Startup completed. Nevertheless, there are errors in the configuration, thus this sink will not run the expected logic
```

* Assignee @frbattid 