### PR TITLE
bug/781_avoid_generalized_hive_encoding

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [BUG] Fix wrong data_model configured for OrionPostgreSQLSink in agent.conf.template (#774)
 - [HARDENING] Remove the persistOne method from all the sinks (#609)
 - [HARDENING] Invalidate the sink if the data_model parameter is wrong (and prepare the code for further parameter checks) (#718)
+- [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -530,7 +530,7 @@ public class OrionHDFSSink extends OrionSink {
             super.initialize(cygnusEvent);
             hiveFields = Utils.encodeHive(Constants.RECV_TIME_TS) + " bigint,"
                     + Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string,"
                     + Utils.encodeHive(Constants.ATTR_NAME) + " string,"
@@ -571,15 +571,15 @@ public class OrionHDFSSink extends OrionSink {
                 
                 // create a line and aggregate it
                 String line = "{"
-                    + "\"" + Utils.encodeHive(Constants.RECV_TIME_TS) + "\":\"" + recvTimeTs / 1000 + "\","
-                    + "\"" + Utils.encodeHive(Constants.RECV_TIME) + "\":\"" + recvTime + "\","
+                    + "\"" + Constants.RECV_TIME_TS + "\":\"" + recvTimeTs / 1000 + "\","
+                    + "\"" + Constants.RECV_TIME + "\":\"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\":\"" + servicePath + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_ID) + "\":\"" + entityId + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_TYPE) + "\":\"" + entityType + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_NAME) + "\":\"" + attrName + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_TYPE) + "\":\"" + attrType + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_VALUE) + "\":" + attrValue + ","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_MD) + "\":" + attrMetadata
+                    + "\"" + Constants.ENTITY_ID + "\":\"" + entityId + "\","
+                    + "\"" + Constants.ENTITY_TYPE + "\":\"" + entityType + "\","
+                    + "\"" + Constants.ATTR_NAME + "\":\"" + attrName + "\","
+                    + "\"" + Constants.ATTR_TYPE + "\":\"" + attrType + "\","
+                    + "\"" + Constants.ATTR_VALUE + "\":" + attrValue + ","
+                    + "\"" + Constants.ATTR_MD + "\":" + attrMetadata
                     + "}";
                 
                 if (aggregation.isEmpty()) {
@@ -603,7 +603,7 @@ public class OrionHDFSSink extends OrionSink {
             
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
             
@@ -643,10 +643,10 @@ public class OrionHDFSSink extends OrionSink {
                 return;
             } // if
             
-            String line = "{\"" + Utils.encodeHive(Constants.RECV_TIME) + "\":\"" + recvTime + "\","
+            String line = "{\"" + Constants.RECV_TIME + "\":\"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\":\"" + servicePath + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_ID) + "\":\"" + entityId + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_TYPE) + "\":\"" + entityType + "\"";
+                    + "\"" + Constants.ENTITY_ID + "\":\"" + entityId + "\","
+                    + "\"" + Constants.ENTITY_TYPE + "\":\"" + entityType + "\"";
             
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
@@ -657,8 +657,7 @@ public class OrionHDFSSink extends OrionSink {
                         + attrType + ")");
                 
                 // create part of the line with the current attribute (a.k.a. a column)
-                line += ", \"" + Utils.encodeHive(attrName) + "\":" + attrValue + ", \""
-                        + Utils.encodeHive(attrName) + "_md\":" + attrMetadata;
+                line += ", \"" + attrName + "\":" + attrValue + ", \"" + attrName + "_md\":" + attrMetadata;
             } // for
             
             // now, aggregate the line
@@ -681,7 +680,7 @@ public class OrionHDFSSink extends OrionSink {
             super.initialize(cygnusEvent);
             hiveFields = Utils.encodeHive(Constants.RECV_TIME_TS) + " bigint,"
                     + Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string,"
                     + Utils.encodeHive(Constants.ATTR_NAME) + " string,"
@@ -798,7 +797,7 @@ public class OrionHDFSSink extends OrionSink {
             
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
             
@@ -1081,7 +1080,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildThirdLevelMd(String destination, String attrName, String attrType) throws Exception {
-        String thirdLevelMd = destination + "_" + Utils.encodeHive(attrName) + "_" + Utils.encodeHive(attrType);
+        String thirdLevelMd = destination + "_" + attrName + "_" + attrType;
         
         if (thirdLevelMd.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building thirdLevelMd=" + thirdLevelMd + " and its length is "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -997,7 +997,8 @@ public class OrionHDFSSink extends OrionSink {
             case JSONCOLUMN:
             case JSONROW:
                 query = "create external table if not exists " + dbName + "." + tableName + " (" + fields
-                        + ") row format serde " + "'org.openx.data.jsonserde.JsonSerDe' location '/user/"
+                        + ") row format serde " + "'org.openx.data.jsonserde.JsonSerDe' with serdeproperties "
+                        + "(\"dots.in.keys\" = \"true\") location '/user/"
                         + (serviceAsNamespace ? "" : (username + "/")) + dirPath + "'";
                 break;
             case CSVCOLUMN:
@@ -1011,6 +1012,8 @@ public class OrionHDFSSink extends OrionSink {
         } // switch
 
         // execute the query
+        LOGGER.debug("Doing Hive query: '" + query + "'");
+        
         if (!hiveClient.doCreateTable(query)) {
             LOGGER.warn("The HiveQL external table could not be created, but Cygnus can continue working... "
                     + "Check your Hive/Shark installation");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -1030,9 +1030,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildFirstLevel(String fiwareService) throws Exception {
         String firstLevel = fiwareService;
         
-        if (firstLevel.length() > Constants.MAX_NAME_LEN) {
+        if (firstLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building firstLevel=fiwareService (fiwareService=" + fiwareService + ") "
-                    + "and its length is greater than " + Constants.MAX_NAME_LEN);
+                    + "and its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
         
         return firstLevel;
@@ -1049,9 +1049,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildSecondLevel(String fiwareServicePath) throws Exception {
         String secondLevel = fiwareServicePath;
         
-        if (secondLevel.length() > Constants.MAX_NAME_LEN) {
+        if (secondLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building secondLevel=fiwareServicePath (" + fiwareServicePath + ") and "
-                    + "its length is greater than " + Constants.MAX_NAME_LEN);
+                    + "its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
         
         return secondLevel;
@@ -1067,9 +1067,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildThirdLevel(String destination) throws Exception {
         String thirdLevel = destination;
         
-        if (thirdLevel.length() > Constants.MAX_NAME_LEN) {
+        if (thirdLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevel=destination (" + destination + ") and its length is "
-                    + "greater than " + Constants.MAX_NAME_LEN);
+                    + "greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
 
         return thirdLevel;
@@ -1085,9 +1085,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildThirdLevelMd(String destination, String attrName, String attrType) throws Exception {
         String thirdLevelMd = destination + "_" + attrName + "_" + attrType;
         
-        if (thirdLevelMd.length() > Constants.MAX_NAME_LEN) {
+        if (thirdLevelMd.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevelMd=" + thirdLevelMd + " and its length is "
-                    + "greater than " + Constants.MAX_NAME_LEN);
+                    + "greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
 
         return thirdLevelMd;

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
@@ -63,6 +63,7 @@ public final class Constants {
     public static final int MAX_CONNS                   = 500;
     public static final int MAX_CONNS_PER_ROUTE         = 100;
     public static final int MAX_NAME_LEN                = 64;
+    public static final int MAX_NAME_LEN_HDFS           = 255;
     public static final int SERVICE_HEADER_MAX_LEN      = 50;
     public static final int SERVICE_PATH_HEADER_MAX_LEN = 50;
     


### PR DESCRIPTION
* Fixes issue #781 (into develop)
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Subscription:

```
{
  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
  "originator" : "localhost",
  "contextResponses" : [
    {
      "contextElement" : {
        "attributes" : [
          {
            "name" : "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad",
            "type" : "centigrade",
            "value" : "10.673299789428711",
            "metadatas": [{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]
          }
        ],
        "type" : "ETS",
        "isPattern" : "false",
        "id" : "ORL.SOU.DH.SSTA10"
      },
      "statusCode" : {
        "code" : "200",
        "reasonPhrase" : "OK"
      }
    }
  ]
}
```

`json-row`:

```
time=2016-02-15T17:06:27.686CET | lvl=INFO | trans=1455552357-95-0000000000 | svc=test | subsvc=hdfs | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data ({"recvTimeTs":"1455552370","recvTime":"2016-02-15T16:06:10.819Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS","attrName":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad","attrType":"centigrade","attrValue":"10.673299789428711","attrMd":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]})
time=2016-02-15T17:06:28.339CET | lvl=INFO | trans=1455552357-95-0000000000 | svc=test | subsvc=hdfs | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[988] : Creating Hive external table 'frb_test_hdfs_orl_sou_dh_ssta10_ets_row' in database 'default'
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
{"recvTimeTs":"1455552370","recvTime":"2016-02-15T16:06:10.819Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS","attrName":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad","attrType":"centigrade","attrValue":"10.673299789428711","attrMd":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]}
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
recvtimets          	bigint              	from deserializer   
recvtime            	string              	from deserializer   
fiwareservicepath   	string              	from deserializer   
entityid            	string              	from deserializer   
entitytype          	string              	from deserializer   
attrname            	string              	from deserializer   
attrtype            	string              	from deserializer   
attrvalue           	string              	from deserializer   
attrmd              	array<struct<name:string,type:string,value:string>>	from deserializer   
Time taken: 0.254 seconds, Fetched: 9 row(s)
hive> select * from frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
1455552370	2016-02-15T16:06:10.819Z	hdfs	ORL.SOU.DH.SSTA10	ETS	ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad	centigrade	10.673299789428711	[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]
Time taken: 0.742 seconds, Fetched: 1 row(s)
```

`json-column`:

```
time=2016-02-15T17:31:28.120CET | lvl=INFO | trans=1455553857-232-0000000000 | svc=test | subsvc=hdfs | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data ({"recvTime":"2016-02-15T16:31:01.972Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad":"10.673299789428711", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_md":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]})
time=2016-02-15T17:31:28.947CET | lvl=INFO | trans=1455553857-232-0000000000 | svc=test | subsvc=hdfs | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[988] : Creating Hive external table 'frb_test_hdfs_orl_sou_dh_ssta10_ets_column' in database 'default'
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
{"recvTime":"2016-02-15T16:31:01.972Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad":"10.673299789428711", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_md":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]}
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_column;                                                                                                                           OK                                                                                                                                                                                   recvtime                string                  from deserializer                        
fiwareservicepath   	string              	from deserializer   
entityid            	string              	from deserializer   
entitytype          	string              	from deserializer   
orl_sou_dh_ssta10_t_hvac_heatload	string              	from deserializer   
orl_sou_dh_ssta10_t_hvac_heatload_md	array<struct<name:string,type:string,value:string>>	from deserializer   
Time taken: 0.174 seconds, Fetched: 6 row(s)
hive> select ORL_SOU_DH_SSTA10_T_HVAC_HeatLoad from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;   
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42469, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42469
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42469
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 07:39:31,001 Stage-1 map = 0%,  reduce = 0%
2016-02-16 07:39:34,014 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.87 sec
2016-02-16 07:39:35,020 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.87 sec
MapReduce Total cumulative CPU time: 870 msec
Ended Job = job_201507101501_42469
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.87 sec   HDFS Read: 1573 HDFS Write: 38 SUCCESS
Total MapReduce CPU Time Spent: 870 msec
OK
10.673299789428711
Time taken: 7.255 seconds, Fetched: 1 row(s)
hive> select ORL_SOU_DH_SSTA10_T_HVAC_HeatLoad_md from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42470, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42470
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42470
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 07:39:57,088 Stage-1 map = 0%,  reduce = 0%
2016-02-16 07:39:59,099 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.8 sec
2016-02-16 07:40:00,108 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.8 sec
MapReduce Total cumulative CPU time: 800 msec
Ended Job = job_201507101501_42470
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.8 sec   HDFS Read: 1573 HDFS Write: 416 SUCCESS
Total MapReduce CPU Time Spent: 800 msec
OK
[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]
Time taken: 7.007 seconds, Fetched: 1 row(s)
```

`csv-row`:

```
time=2016-02-16T07:59:04.893CET | lvl=INFO | trans=1455605914-357-0000000000 | svc=test | subsvc=hdfs | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data (1455605927,2016-02-16T06:58:47.598Z,hdfs,ORL.SOU.DH.SSTA10,ETS,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad,centigrade,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt)
time=2016-02-16T07:59:06.555CET | lvl=INFO | trans=1455605914-357-0000000000 | svc=test | subsvc=hdfs | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[988] : Creating Hive external table 'frb_test_hdfs_orl_sou_dh_ssta10_ets_row' in database 'default'
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
1455605927,2016-02-16T06:58:47.598Z,hdfs,ORL.SOU.DH.SSTA10,ETS,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad,centigrade,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
1455605927598,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455605927598,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455605927598,description,text,Electrical heat load
1455605927598,quality,0:GOOD, +0:ERROR,10813440
1455605927598,max,max,null
1455605927598,min,min,null
1455605927598,lcl,lcl,null
1455605927598,ucl,ucl,null
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
recvtimets          	bigint              	                    
recvtime            	string              	                    
fiwareservicepath   	string              	                    
entityid            	string              	                    
entitytype          	string              	                    
attrname            	string              	                    
attrtype            	string              	                    
attrvalue           	string              	                    
attrmdfile          	string              	                    
Time taken: 0.278 seconds, Fetched: 9 row(s)
hive> select * from frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
1455605927	2016-02-16T06:58:47.598Z	hdfs	ORL.SOU.DH.SSTA10	ETS	ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad	centigrade	10.673299789428711	hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
Time taken: 0.469 seconds, Fetched: 1 row(s)
```

`csv-column`:

```
time=2016-02-16T08:09:21.953CET | lvl=INFO | trans=1455606529-775-0000000000 | svc=test | subsvc=hdfs | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data (2016-02-16T07:08:55.878Z,hdfs,ORL.SOU.DH.SSTA10,ETS,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt)
time=2016-02-16T08:09:22.738CET | lvl=INFO | trans=1455606529-775-0000000000 | svc=test | subsvc=hdfs | function=persistMDAggregations | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[955] : [hdfs-sink] Persisting metadata at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt), Data (1455606535878,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455606535878,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455606535878,description,text,Electrical heat load
1455606535878,quality,0:GOOD, +0:ERROR,10813440
1455606535878,max,max,null
1455606535878,min,min,null
1455606535878,lcl,lcl,null
1455606535878,ucl,ucl,null)
time=2016-02-16T08:09:23.270CET | lvl=INFO | trans=1455606529-775-0000000000 | svc=test | subsvc=hdfs | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[988] : Creating Hive external table 'frb_test_hdfs_orl_sou_dh_ssta10_ets_column' in database 'default'
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
2016-02-16T07:08:55.878Z,hdfs,ORL.SOU.DH.SSTA10,ETS,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
1455606535878,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455606535878,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455606535878,description,text,Electrical heat load
1455606535878,quality,0:GOOD, +0:ERROR,10813440
1455606535878,max,max,null
1455606535878,min,min,null
1455606535878,lcl,lcl,null
1455606535878,ucl,ucl,null
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
OK
recvtime            	string              	                    
fiwareservicepath   	string              	                    
entityid            	string              	                    
entitytype          	string              	                    
orl_sou_dh_ssta10_t_hvac_heatload	string              	                    
orl_sou_dh_ssta10_t_hvac_heatload_md_file	string              	                    
Time taken: 0.223 seconds, Fetched: 6 row(s)
hive> select * from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
OK
2016-02-16T07:08:55.878Z	hdfs	ORL.SOU.DH.SSTA10	ETS	10.673299789428711	hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
Time taken: 0.426 seconds, Fetched: 1 row(s)
```
* Assignee @pcoello25 