### PR TITLE
bug/781_avoid_generalized_hive_encoding_0.11.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [BUG] Fix the name of the fiware service path field (#764)
 - [BUG] Fix of the Cygnus installation using yum (#652)
+- [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)

--- a/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
@@ -145,7 +145,8 @@ public class HDFSBackendImplBinary implements HDFSBackend {
             case JSONCOLUMN:
             case JSONROW:
                 query = "create external table if not exists " + tableName + " (" + fields + ") row format serde "
-                        + "'org.openx.data.jsonserde.JsonSerDe' location '/user/"
+                        + "'org.openx.data.jsonserde.JsonSerDe' with serdeproperties "
+                        + "(\"dots.in.keys\" = \"true\") location '/user/"
                         + (serviceAsNamespace ? "" : (hdfsUser + "/")) + dirPath + "'";
                 break;
             case CSVCOLUMN:

--- a/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
@@ -23,7 +23,6 @@ import com.telefonica.iot.cygnus.backends.http.HttpBackend;
 import com.telefonica.iot.cygnus.backends.http.JsonResponse;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
 import org.apache.http.Header;
@@ -210,7 +209,8 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
             case JSONCOLUMN:
             case JSONROW:
                 query = "create external table if not exists " + tableName + " (" + fields + ") row format serde "
-                        + "'org.openx.data.jsonserde.JsonSerDe' location '/user/"
+                        + "'org.openx.data.jsonserde.JsonSerDe' with serdeproperties "
+                        + "(\"dots.in.keys\" = \"true\") location '/user/"
                         + (serviceAsNamespace ? "" : (hdfsUser + "/")) + dirPath + "'";
                 break;
             case CSVCOLUMN:

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -511,7 +511,7 @@ public class OrionHDFSSink extends OrionSink {
             super.initialize(cygnusEvent);
             hiveFields = Utils.encodeHive(Constants.RECV_TIME_TS) + " bigint,"
                     + Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string,"
                     + Utils.encodeHive(Constants.ATTR_NAME) + " string,"
@@ -552,15 +552,15 @@ public class OrionHDFSSink extends OrionSink {
                 
                 // create a line and aggregate it
                 String line = "{"
-                    + "\"" + Utils.encodeHive(Constants.RECV_TIME_TS) + "\":\"" + recvTimeTs / 1000 + "\","
-                    + "\"" + Utils.encodeHive(Constants.RECV_TIME) + "\":\"" + recvTime + "\","
+                    + "\"" + Constants.RECV_TIME_TS + "\":\"" + recvTimeTs / 1000 + "\","
+                    + "\"" + Constants.RECV_TIME + "\":\"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\":\"" + servicePath + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_ID) + "\":\"" + entityId + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_TYPE) + "\":\"" + entityType + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_NAME) + "\":\"" + attrName + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_TYPE) + "\":\"" + attrType + "\","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_VALUE) + "\":" + attrValue + ","
-                    + "\"" + Utils.encodeHive(Constants.ATTR_MD) + "\":" + attrMetadata
+                    + "\"" + Constants.ENTITY_ID + "\":\"" + entityId + "\","
+                    + "\"" + Constants.ENTITY_TYPE + "\":\"" + entityType + "\","
+                    + "\"" + Constants.ATTR_NAME + "\":\"" + attrName + "\","
+                    + "\"" + Constants.ATTR_TYPE + "\":\"" + attrType + "\","
+                    + "\"" + Constants.ATTR_VALUE + "\":" + attrValue + ","
+                    + "\"" + Constants.ATTR_MD + "\":" + attrMetadata
                     + "}";
                 
                 if (aggregation.isEmpty()) {
@@ -584,7 +584,7 @@ public class OrionHDFSSink extends OrionSink {
             
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
             
@@ -624,10 +624,10 @@ public class OrionHDFSSink extends OrionSink {
                 return;
             } // if
             
-            String line = "{\"" + Utils.encodeHive(Constants.RECV_TIME) + "\":\"" + recvTime + "\","
+            String line = "{\"" + Constants.RECV_TIME + "\":\"" + recvTime + "\","
                     + "\"" + Constants.FIWARE_SERVICE_PATH + "\":\"" + servicePath + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_ID) + "\":\"" + entityId + "\","
-                    + "\"" + Utils.encodeHive(Constants.ENTITY_TYPE) + "\":\"" + entityType + "\"";
+                    + "\"" + Constants.ENTITY_ID + "\":\"" + entityId + "\","
+                    + "\"" + Constants.ENTITY_TYPE + "\":\"" + entityType + "\"";
             
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
@@ -638,8 +638,7 @@ public class OrionHDFSSink extends OrionSink {
                         + attrType + ")");
                 
                 // create part of the line with the current attribute (a.k.a. a column)
-                line += ", \"" + Utils.encodeHive(attrName) + "\":" + attrValue + ", \""
-                        + Utils.encodeHive(attrName) + "_md\":" + attrMetadata;
+                line += ", \"" + attrName + "\":" + attrValue + ", \"" + attrName + "_md\":" + attrMetadata;
             } // for
             
             // now, aggregate the line
@@ -662,7 +661,7 @@ public class OrionHDFSSink extends OrionSink {
             super.initialize(cygnusEvent);
             hiveFields = Utils.encodeHive(Constants.RECV_TIME_TS) + " bigint,"
                     + Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string,"
                     + Utils.encodeHive(Constants.ATTR_NAME) + " string,"
@@ -780,7 +779,7 @@ public class OrionHDFSSink extends OrionSink {
             
             // particular initialization
             hiveFields = Utils.encodeHive(Constants.RECV_TIME) + " string,"
-                    + Constants.FIWARE_SERVICE_PATH + " string,"
+                    + Utils.encodeHive(Constants.FIWARE_SERVICE_PATH) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_ID) + " string,"
                     + Utils.encodeHive(Constants.ENTITY_TYPE) + " string";
             
@@ -1014,7 +1013,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildThirdLevelMd(String destination, String attrName, String attrType) throws Exception {
-        String thirdLevelMd = destination + "_" + Utils.encodeHive(attrName) + "_" + Utils.encodeHive(attrType);
+        String thirdLevelMd = destination + "_" + attrName + "_" + attrType;
         
         if (thirdLevelMd.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building thirdLevelMd=" + thirdLevelMd + " and its length is "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -960,9 +960,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildFirstLevel(String fiwareService) throws Exception {
         String firstLevel = fiwareService;
         
-        if (firstLevel.length() > Constants.MAX_NAME_LEN) {
+        if (firstLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building firstLevel=fiwareService (fiwareService=" + fiwareService + ") "
-                    + "and its length is greater than " + Constants.MAX_NAME_LEN);
+                    + "and its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
         
         return firstLevel;
@@ -979,9 +979,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildSecondLevel(String fiwareServicePath) throws Exception {
         String secondLevel = fiwareServicePath;
         
-        if (secondLevel.length() > Constants.MAX_NAME_LEN) {
+        if (secondLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building secondLevel=fiwareServicePath (" + fiwareServicePath + ") and "
-                    + "its length is greater than " + Constants.MAX_NAME_LEN);
+                    + "its length is greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
         
         return secondLevel;
@@ -997,9 +997,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildThirdLevel(String destination) throws Exception {
         String thirdLevel = destination;
         
-        if (thirdLevel.length() > Constants.MAX_NAME_LEN) {
+        if (thirdLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevel=destination (" + destination + ") and its length is "
-                    + "greater than " + Constants.MAX_NAME_LEN);
+                    + "greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
 
         return thirdLevel;
@@ -1015,9 +1015,9 @@ public class OrionHDFSSink extends OrionSink {
     private String buildThirdLevelMd(String destination, String attrName, String attrType) throws Exception {
         String thirdLevelMd = destination + "_" + attrName + "_" + attrType;
         
-        if (thirdLevelMd.length() > Constants.MAX_NAME_LEN) {
+        if (thirdLevelMd.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevelMd=" + thirdLevelMd + " and its length is "
-                    + "greater than " + Constants.MAX_NAME_LEN);
+                    + "greater than " + Constants.MAX_NAME_LEN_HDFS);
         } // if
 
         return thirdLevelMd;

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
@@ -63,7 +63,8 @@ public final class Constants {
     public static final int MAX_CONNS = 500;
     public static final int MAX_CONNS_PER_ROUTE = 100;
     public static final int MAX_NAME_LEN = 64;
-    
+    public static final int MAX_NAME_LEN_HDFS = 255;
+
     // Others
     public static final String EMPTY_MD = "[]";
 

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -70,20 +70,45 @@ public class OrionHDFSSinkTest {
     private final Long recvTimeTs = 123456789L;
     private final String normalService = "vehicles";
     private final String abnormalService =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
+            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "longservname";
     private final String normalDefaultServicePath = "4wheels";
     private final String rootServicePath = "";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "longservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "longservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";
+            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "longdestname";
     private final String normalGroupedDestination = "my_cars";
     private final String abnormalGroupedDestination =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";
+            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "longdestname";
     
     // notification constants
     private final String singleContextElementNotification = ""


### PR DESCRIPTION
* Twin of PR https://github.com/telefonicaid/fiware-cygnus/pull/789
* 100% tests passed:
```
Tests run: 72, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
`json-row`:

```
time=2016-02-16T11:52:44.677CET | lvl=INFO | trans=1455619928-887-0000000000 | svc= | subsvc= | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[919] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data ({"recvTimeTs":"1455619956","recvTime":"2016-02-16T10:52:36.541Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS","attrName":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad","attrType":"centigrade","attrValue":"10.673299789428711","attrMd":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]})
time=2016-02-16T11:52:45.908CET | lvl=INFO | trans=1455619928-887-0000000000 | svc= | subsvc= | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[200] : Creating Hive external table=frb_test_hdfs_orl_sou_dh_ssta10_ets_row
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
{"recvTimeTs":"1455619956","recvTime":"2016-02-16T10:52:36.541Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS","attrName":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad","attrType":"centigrade","attrValue":"10.673299789428711","attrMd":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]}
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
recvtimets          	bigint              	from deserializer   
recvtime            	string              	from deserializer   
fiwareservicepath   	string              	from deserializer   
entityid            	string              	from deserializer   
entitytype          	string              	from deserializer   
attrname            	string              	from deserializer   
attrtype            	string              	from deserializer   
attrvalue           	string              	from deserializer   
attrmd              	array<struct<name:string,type:string,value:string>>	from deserializer   
Time taken: 0.221 seconds, Fetched: 9 row(s)
hive> select * from frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
1455619956	2016-02-16T10:52:36.541Z	hdfs	ORL.SOU.DH.SSTA10	ETS	ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad	centigrade	10.673299789428711	[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]
Time taken: 0.57 seconds, Fetched: 1 row(s)
```

`json-column`:

```
time=2016-02-16T11:58:16.977CET | lvl=INFO | trans=1455620262-464-0000000000 | svc= | subsvc= | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[919] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data ({"recvTime":"2016-02-16T10:57:56.940Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad":"10.673299789428711", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_md":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]})
time=2016-02-16T11:59:08.668CET | lvl=INFO | trans=1455620262-464-0000000000 | svc= | subsvc= | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[200] : Creating Hive external table=frb_test_hdfs_orl_sou_dh_ssta10_ets_column
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
{"recvTime":"2016-02-16T10:57:56.940Z","fiwareServicePath":"hdfs","entityId":"ORL.SOU.DH.SSTA10","entityType":"ETS", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad":"10.673299789428711", "ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_md":[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]}
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_column;  
OK
recvtime            	string              	from deserializer   
fiwareservicepath   	string              	from deserializer   
entityid            	string              	from deserializer   
entitytype          	string              	from deserializer   
orl_sou_dh_ssta10_t_hvac_heatload	string              	from deserializer   
orl_sou_dh_ssta10_t_hvac_heatload_md	array<struct<name:string,type:string,value:string>>	from deserializer   
Time taken: 1.095 seconds, Fetched: 6 row(s)
hive> select orl_sou_dh_ssta10_t_hvac_heatload from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42480, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42480
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42480
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 12:01:37,964 Stage-1 map = 0%,  reduce = 0%
2016-02-16 12:01:40,982 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.9 sec
2016-02-16 12:01:41,988 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.9 sec
MapReduce Total cumulative CPU time: 900 msec
Ended Job = job_201507101501_42480
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.9 sec   HDFS Read: 908 HDFS Write: 19 SUCCESS
Total MapReduce CPU Time Spent: 900 msec
OK
10.673299789428711
Time taken: 6.937 seconds, Fetched: 1 row(s)
hive> select orl_sou_dh_ssta10_t_hvac_heatload_md from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42481, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42481
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42481
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 12:02:26,844 Stage-1 map = 0%,  reduce = 0%
2016-02-16 12:02:29,862 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.77 sec
2016-02-16 12:02:30,867 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.77 sec
MapReduce Total cumulative CPU time: 770 msec
Ended Job = job_201507101501_42481
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.77 sec   HDFS Read: 908 HDFS Write: 208 SUCCESS
Total MapReduce CPU Time Spent: 770 msec
OK
[{"name":"dofTimestamp","type":"ms","value":"2016-02-08T23:00:00.000Z"},{"name":"tag","type":"text","value":"ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad"},{"name":"description","type":"text","value":"Electrical heat load"},{"name":"quality","type":"0:GOOD, +0:ERROR","value":"10813440"},{"name":"max","type":"max","value":"null"},{"name":"min","type":"min","value":"null"},{"name":"lcl","type":"lcl","value":"null"},{"name":"ucl","type":"ucl","value":"null"}]
Time taken: 6.765 seconds, Fetched: 1 row(s)
```

`csv-row`:

```
time=2016-02-16T12:07:00.124CET | lvl=INFO | trans=1455620785-686-0000000000 | svc= | subsvc= | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[919] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data (1455620790,2016-02-16T11:06:30.372Z,hdfs,ORL.SOU.DH.SSTA10,ETS,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad,centigrade,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt)
time=2016-02-16T12:07:01.048CET | lvl=INFO | trans=1455620785-686-0000000000 | svc= | subsvc= | function=persistMDAggregations | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting metadata at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt), Data (1455620790372,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455620790372,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455620790372,description,text,Electrical heat load
1455620790372,quality,0:GOOD, +0:ERROR,10813440
1455620790372,max,max,null
1455620790372,min,min,null
1455620790372,lcl,lcl,null
1455620790372,ucl,ucl,null)
time=2016-02-16T12:07:01.715CET | lvl=INFO | trans=1455620785-686-0000000000 | svc= | subsvc= | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[200] : Creating Hive external table=frb_test_hdfs_orl_sou_dh_ssta10_ets_row
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
1455620790,2016-02-16T11:06:30.372Z,hdfs,ORL.SOU.DH.SSTA10,ETS,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad,centigrade,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
1455620790372,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455620790372,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455620790372,description,text,Electrical heat load
1455620790372,quality,0:GOOD, +0:ERROR,10813440
1455620790372,max,max,null
1455620790372,min,min,null
1455620790372,lcl,lcl,null
1455620790372,ucl,ucl,null
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_row;                                           
OK
recvtimets          	bigint              	                    
recvtime            	string              	                    
fiwareservicepath   	string              	                    
entityid            	string              	                    
entitytype          	string              	                    
attrname            	string              	                    
attrtype            	string              	                    
attrvalue           	string              	                    
attrmdfile          	string              	                    
Time taken: 0.965 seconds, Fetched: 9 row(s)
hive> select * from frb_test_hdfs_orl_sou_dh_ssta10_ets_row;
OK
1455620790	2016-02-16T11:06:30.372Z	hdfs	ORL.SOU.DH.SSTA10	ETS	ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad	centigrade	10.673299789428711	hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
Time taken: 0.447 seconds, Fetched: 1 row(s)
```

`csv-column`:

```
time=2016-02-16T12:09:33.543CET | lvl=INFO | trans=1455620938-373-0000000000 | svc= | subsvc= | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[919] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt), Data (2016-02-16T11:09:04.453Z,hdfs,ORL.SOU.DH.SSTA10,ETS,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt)
time=2016-02-16T12:09:34.487CET | lvl=INFO | trans=1455620938-373-0000000000 | svc= | subsvc= | function=persistMDAggregations | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[937] : [hdfs-sink] Persisting metadata at OrionHDFSSink. HDFS file (test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt), Data (1455620944453,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455620944453,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455620944453,description,text,Electrical heat load
1455620944453,quality,0:GOOD, +0:ERROR,10813440
1455620944453,max,max,null
1455620944453,min,min,null
1455620944453,lcl,lcl,null
1455620944453,ucl,ucl,null)
time=2016-02-16T12:09:35.356CET | lvl=INFO | trans=1455620938-373-0000000000 | svc= | subsvc= | function=provisionHiveTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[200] : Creating Hive external table=frb_test_hdfs_orl_sou_dh_ssta10_ets_column
..
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets/orl.sou.dh.ssta10_ets.txt
2016-02-16T11:09:04.453Z,hdfs,ORL.SOU.DH.SSTA10,ETS,10.673299789428711,hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
$ hadoop fs -cat test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
1455620944453,dofTimestamp,ms,2016-02-08T23:00:00.000Z
1455620944453,tag,text,ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad
1455620944453,description,text,Electrical heat load
1455620944453,quality,0:GOOD, +0:ERROR,10813440
1455620944453,max,max,null
1455620944453,min,min,null
1455620944453,lcl,lcl,null
1455620944453,ucl,ucl,null
..
hive> describe frb_test_hdfs_orl_sou_dh_ssta10_ets_column;  
OK
recvtime            	string              	                    
fiwareservicepath   	string              	                    
entityid            	string              	                    
entitytype          	string              	                    
orl_sou_dh_ssta10_t_hvac_heatload	string              	                    
orl_sou_dh_ssta10_t_hvac_heatload_md_file	string              	                    
Time taken: 0.825 seconds, Fetched: 6 row(s)
hive> select * from orl_sou_dh_ssta10_t_hvac_heatload;
FAILED: SemanticException [Error 10001]: Line 1:14 Table not found 'orl_sou_dh_ssta10_t_hvac_heatload'
hive> select orl_sou_dh_ssta10_t_hvac_heatload from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42483, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42483
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42483
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 12:11:13,169 Stage-1 map = 0%,  reduce = 0%
2016-02-16 12:11:15,190 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.95 sec
2016-02-16 12:11:17,211 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.95 sec
MapReduce Total cumulative CPU time: 950 msec
Ended Job = job_201507101501_42483
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.95 sec   HDFS Read: 479 HDFS Write: 19 SUCCESS
Total MapReduce CPU Time Spent: 950 msec
OK
10.673299789428711
Time taken: 9.161 seconds, Fetched: 1 row(s)
hive> select orl_sou_dh_ssta10_t_hvac_heatload_md_file from frb_test_hdfs_orl_sou_dh_ssta10_ets_column;
Total jobs = 1
Launching Job 1 out of 1
Number of reduce tasks is set to 0 since there's no reduce operator
Starting Job = job_201507101501_42484, Tracking URL = http://cosmosmaster-gi:50030/jobdetails.jsp?jobid=job_201507101501_42484
Kill Command = /usr/lib/hadoop-0.20/bin/hadoop job  -kill job_201507101501_42484
Hadoop job information for Stage-1: number of mappers: 1; number of reducers: 0
2016-02-16 12:12:00,928 Stage-1 map = 0%,  reduce = 0%
2016-02-16 12:12:02,953 Stage-1 map = 100%,  reduce = 0%, Cumulative CPU 0.78 sec
2016-02-16 12:12:05,990 Stage-1 map = 100%,  reduce = 100%, Cumulative CPU 0.78 sec
MapReduce Total cumulative CPU time: 780 msec
Ended Job = job_201507101501_42484
MapReduce Jobs Launched: 
Job 0: Map: 1   Cumulative CPU: 0.78 sec   HDFS Read: 479 HDFS Write: 165 SUCCESS
Total MapReduce CPU Time Spent: 780 msec
OK
hdfs:///user/frb/test/hdfs/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade/orl.sou.dh.ssta10_ets_ORL.SOU.DH.SSTA10.T.HVAC.HeatLoad_centigrade.txt
Time taken: 8.941 seconds, Fetched: 1 row(s)
```
* Assignee @mcarracedo 