### PR TITLE
hardening/793_move_attrpersistence_to_orion_mongo_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -17,3 +17,4 @@
 - [HARDENING] Remove the persistOne method from all the sinks (#609)
 - [HARDENING] Invalidate the sink if the data_model parameter is wrong (and prepare the code for further parameter checks) (#718)
 - [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)
+- [HARDENING] Relocation of attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -17,4 +17,4 @@
 - [HARDENING] Remove the persistOne method from all the sinks (#609)
 - [HARDENING] Invalidate the sink if the data_model parameter is wrong (and prepare the code for further parameter checks) (#718)
 - [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)
-- [HARDENING] Relocation of attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)
+- [HARDENING] Relocate attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -41,7 +41,6 @@ public abstract class OrionMongoBaseSink extends OrionSink {
     protected String collectionPrefix;
     protected boolean shouldHash;
     protected MongoBackendImpl backend;
-    protected boolean rowAttrPersistence;
 
     /**
      * Gets the mongo hosts. It is protected since it is used by the tests.
@@ -98,14 +97,6 @@ public abstract class OrionMongoBaseSink extends OrionSink {
     protected MongoBackendImpl getBackend() {
         return backend;
     } // getBackend
-
-    /**
-     * Gets the rowAttrPersistence. It is protected since it is used by the tests.
-     * @return
-     */
-    protected boolean getRowAttrPersistence() {
-        return this.rowAttrPersistence;
-    }
     
     @Override
     public void configure(Context context) {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -122,9 +122,6 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (collection_prefix=" + collectionPrefix + ")");
         shouldHash = context.getBoolean("should_hash", false);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash=" + shouldHash + ")");
-        this.rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
-                + (this.rowAttrPersistence ? "row" : "column") + ")");
         super.configure(context);
     } // configure
     

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -23,6 +23,7 @@ import static com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink.LOGGER;
 import java.util.ArrayList;
 import java.util.Date;
 import org.bson.Document;
+import org.apache.flume.Context;
 
 /**
  * @author frb
@@ -33,6 +34,8 @@ import org.bson.Document;
  */
 public class OrionMongoSink extends OrionMongoBaseSink {
 
+    private boolean rowAttrPersistence;
+    
     /**
      * Constructor.
      */
@@ -68,6 +71,19 @@ public class OrionMongoSink extends OrionMongoBaseSink {
             batch.setPersisted(destination);
         } // for
     } // persistBatch
+    
+    @Override
+    public void configure (Context context) {
+        this.rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
+                + (this.rowAttrPersistence ? "row" : "column") + ")");
+        super.configure(context);
+    } // configure
+    
+    @Override
+    public void start() {
+        super.start();
+    } // start
     
     /**
      * Class for aggregating batches.

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -80,11 +80,6 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         super.configure(context);
     } // configure
     
-    @Override
-    public void start() {
-        super.start();
-    } // start
-    
     /**
      * Class for aggregating batches.
      */


### PR DESCRIPTION
* Fix issue https://github.com/telefonicaid/fiware-cygnus/issues/793
* 100% unit test passed:
```
Results : Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e test passed: 
`OrionMongoSink` (Checking with `attr_persistence` = filas. Result must be `column` persistence with the actual check):
```
time=2016-02-16T14:09:29.381CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[78] : [mongo-sink] Reading configuration (attr_persistence=column)
```
`OrionSTHSink` (Without `attr_persistence`, message doesn't appear):
```
time=2016-02-16T14:12:54.476CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[113] : [sth-sink] Reading configuration (mongo_hosts=localhost:27017)
time=2016-02-16T14:12:54.476CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[115] : [sth-sink] Reading configuration (mongo_username=)
time=2016-02-16T14:12:54.476CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[118] : [sth-sink] Reading configuration (mongo_password=)
time=2016-02-16T14:12:54.476CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[120] : [sth-sink] Reading configuration (db_prefix=sth_)
time=2016-02-16T14:12:54.477CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[122] : [sth-sink] Reading configuration (collection_prefix=sth_)
time=2016-02-16T14:12:54.482CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[124] : [sth-sink] Reading configuration (should_hash=false)
time=2016-02-16T14:12:54.483CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[163] : [sth-sink] Invalid configuration (data_model=dm-by-afrentity)
time=2016-02-16T14:12:54.484CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[168] : [sth-sink] Reading configuration (enable_grouping=true)
time=2016-02-16T14:12:54.484CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[171] : [sth-sink] Reading configuration (batch_size=0)
time=2016-02-16T14:12:54.484CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[174] : [sth-sink] Reading configuration (batch_timeout=0)
```

* Assignee @frbattid