### PR TITLE
bug/796_wrong_recvtime_orionmongosink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,3 +18,4 @@
 - [HARDENING] Invalidate the sink if the data_model parameter is wrong (and prepare the code for further parameter checks) (#718)
 - [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)
 - [HARDENING] Relocate attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)
+- [BUG] Fix recvTime in OrionMongoSink (#796)

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -169,7 +169,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         
         private Document createDoc(long recvTimeTs, String entityId, String entityType, String attrName,
                 String attrType, String attrValue) {
-            Document doc = new Document("recvTime", new Date(recvTimeTs * 1000));
+            Document doc = new Document("recvTime", new Date(recvTimeTs));
         
             switch (dataModel) {
                 case DMBYSERVICEPATH:
@@ -243,7 +243,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         } // aggregate
         
         private Document createDoc(long recvTimeTs, String entityId, String entityType) {
-            Document doc = new Document("recvTime", new Date(recvTimeTs * 1000));
+            Document doc = new Document("recvTime", new Date(recvTimeTs));
 
             switch (dataModel) {
                 case DMBYSERVICEPATH:


### PR DESCRIPTION
* Fixes issue #796 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
time=2016-02-17T09:07:53.657CET | lvl=INFO | trans=1455696413-414-0000000000 | svc=test | subsvc=sth | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[277] : [mongo-sink] Persisting data at OrionMongoSink. Database: sth_test, Collection: sth_/sth_room1_room, Data: [Document{{recvTime=Wed Feb 17 09:07:35 CET 2016, temperature=26.5}}]
..
> use sth_test;
switched to db sth_test
> db['sth_/sth_room1_room'].find()
{ "_id" : ObjectId("56c42a5a26f014395af8f5f1"), "recvTime" : ISODate("2016-02-17T08:07:35.966Z"), "temperature" : "26.5" }
```
* Assignee @pcoello25