### PR TITLE
feature/745_fix_errors_in_groupingrules_path_of_mgmt_iface

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
@@ -102,14 +102,15 @@ public class GroupingRule {
     /**
      * Checks if the given Json is valid as grouping rule.
      * @param jsonRule
+     * @param checkExtraFields
      * @return True if the given Json is valid as grouping rule, otherwise false
      */
-    public static int isValid(JSONObject jsonRule) {
+    public static int isValid(JSONObject jsonRule, boolean checkExtraFields) {
         boolean containsFields = false;
         boolean containsRegex = false;
         boolean containsDestination = false;
         boolean containsFiwareServicePath = false;
-        boolean containsOther = false;
+        boolean containsExtraFields = false;
         int fieldsSize = 0;
         int regexLength = 0;
         int destinationLength = 0;
@@ -119,7 +120,7 @@ public class GroupingRule {
         Iterator it = jsonRule.keySet().iterator();
         
         while (it.hasNext()) {
-            String field = (String)it.next();
+            String field = (String) it.next();
             
             if (field.equals("fields")) {
                 containsFields = true;
@@ -134,7 +135,7 @@ public class GroupingRule {
                 containsFiwareServicePath = true;
                 fiwareServicePathLength = ((String) jsonRule.get("fiware_service_path")).length();
             } else {
-                containsOther = true;
+                containsExtraFields = true;
             } // if else
         } // while
         
@@ -149,7 +150,7 @@ public class GroupingRule {
         } // if
         
         // check if the rule has extra fields not allowed
-        if (containsOther) {
+        if (checkExtraFields && containsExtraFields) {
             return 3;
         } // if
 

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
@@ -19,6 +19,7 @@ package com.telefonica.iot.cygnus.interceptors;
 
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.regex.Pattern;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -99,25 +100,57 @@ public class GroupingRule {
     } // getNewFiwareServicePath
     
     /**
-     * Checks if the given Json is valid as grouping rules.
+     * Checks if the given Json is valid as grouping rule.
      * @param jsonRule
      * @return True if the given Json is valid as grouping rule, otherwise false
      */
     public static int isValid(JSONObject jsonRule) {
+        boolean containsFields = false;
+        boolean containsRegex = false;
+        boolean containsDestination = false;
+        boolean containsFiwareServicePath = false;
+        boolean containsOther = false;
+        int fieldsSize = 0;
+        int regexLength = 0;
+        int destinationLength = 0;
+        int fiwareServicePathLength = 0;
+        
+        // iterate on the fields
+        Iterator it = jsonRule.keySet().iterator();
+        
+        while (it.hasNext()) {
+            String field = (String)it.next();
+            
+            if (field.equals("fields")) {
+                containsFields = true;
+                fieldsSize = ((JSONArray) jsonRule.get("fields")).size();
+            } else if (field.equals("regex")) {
+                containsRegex = true;
+                regexLength = ((String) jsonRule.get("regex")).length();
+            } else if (field.equals("destination")) {
+                containsDestination = true;
+                destinationLength = ((String) jsonRule.get("destination")).length();
+            } else if (field.equals("fiware_service_path")) {
+                containsFiwareServicePath = true;
+                fiwareServicePathLength = ((String) jsonRule.get("fiware_service_path")).length();
+            } else {
+                containsOther = true;
+            } // if else
+        } // while
+        
         // check if the rule contains all the required fields
-        if (!jsonRule.containsKey("fields")
-                || !jsonRule.containsKey("regex")
-                || !jsonRule.containsKey("destination")
-                || !jsonRule.containsKey("fiware_service_path")) {
+        if (!containsFields || !containsRegex || !containsDestination || !containsFiwareServicePath) {
             return 1;
         } // if
-
+        
         // check if the rule has any empty field
-        if (((JSONArray) jsonRule.get("fields")).size() == 0
-                || ((String) jsonRule.get("regex")).length() == 0
-                || ((String) jsonRule.get("destination")).length() == 0
-                || ((String) jsonRule.get("fiware_service_path")).length() == 0) {
+        if (fieldsSize == 0 || regexLength == 0 || destinationLength == 0 || fiwareServicePathLength == 0) {
             return 2;
+        } // if
+        
+        // check if the rule has extra fields not allowed
+        if (containsOther) {
+            return 3;
         } // if
 
         return 0;

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
@@ -182,7 +182,7 @@ public class GroupingRules {
 
         for (Object jsonGroupingRule : jsonRules) {
             JSONObject jsonRule = (JSONObject) jsonGroupingRule;
-            int err = GroupingRule.isValid(jsonRule);
+            int err = GroupingRule.isValid(jsonRule, false);
 
             if (err == 0) {
                 GroupingRule rule = new GroupingRule(jsonRule);

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.regex.Matcher;
 import org.json.simple.JSONArray;
@@ -76,6 +75,14 @@ public class GroupingRules {
         setRules(jsonGroupingRules);
         LOGGER.info("Grouping rules regex'es have been compiled");
     } // GroupingRules
+    
+    /**
+     * Gets if the object representing the grouping rules is empty.
+     * @return True if empty, otherwise false
+     */
+    public boolean isEmpty() {
+        return this.groupingRules == null || this.groupingRules.size() == 0;
+    } // isEmpty
     
     /**
      * Gets the rule matching the given context element for the given service path.
@@ -155,7 +162,11 @@ public class GroupingRules {
      */
     @Override
     public String toString() {
-        return "{\"grouping_rules\": " + groupingRules.toString() + "}";
+        if (groupingRules == null) {
+            return "{\"grouping_rules\": []}";
+        } else {
+            return "{\"grouping_rules\": " + groupingRules.toString() + "}";
+        } // if else
     } // toString
     
     /**
@@ -185,6 +196,10 @@ public class GroupingRules {
                         break;
                     case 2:
                         LOGGER.warn("Invalid grouping rule, some field is empty. It will be discarded. Details:"
+                                + jsonRule.toJSONString());
+                        break;
+                    case 3:
+                        LOGGER.warn("Invalid grouping rule, some field is not allowed. It will be discarded. Details:"
                                 + jsonRule.toJSONString());
                         break;
                     default:

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import javax.servlet.ServletException;
@@ -355,6 +354,10 @@ public class ManagementInterface extends AbstractHandler {
                     response.getWriter().println("400 - Invalid grouping rule, some field is empty");
                     LOGGER.warn("Invalid grouping rule, some field is empty");
                     return;
+                case 3:
+                    response.getWriter().println("400 - Invalid grouping rule, some field is not allowed");
+                    LOGGER.warn("Invalid grouping rule, some field is not allowed");
+                    return;
                 default:
                     response.getWriter().println("400 - Invalid grouping rule");
                     LOGGER.warn("Invalid grouping rule");
@@ -436,6 +439,10 @@ public class ManagementInterface extends AbstractHandler {
                 case 2:
                     response.getWriter().println("400 - Invalid grouping rule, some field is empty");
                     LOGGER.warn("Invalid grouping rule, some field is empty");
+                    return;
+                case 3:
+                    response.getWriter().println("400 - Invalid grouping rule, some field is not allowed");
+                    LOGGER.warn("Invalid grouping rule, some field is not allowed");
                     return;
                 default:
                     response.getWriter().println("400 - Invalid grouping rule");

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -340,7 +340,7 @@ public class ManagementInterface extends AbstractHandler {
 
         // check if the rule is valid (it could be a valid Json document,
         // but not a Json document describing a rule)
-        int err = GroupingRule.isValid(rule);
+        int err = GroupingRule.isValid(rule, true);
         
         if (err > 0) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -426,7 +426,7 @@ public class ManagementInterface extends AbstractHandler {
 
         // check if the rule is valid (it could be a valid Json document,
         // but not a Json document describing a rule)
-        int err = GroupingRule.isValid(rule);
+        int err = GroupingRule.isValid(rule, true);
         
         if (err > 0) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);


### PR DESCRIPTION
* Partially implements issue #745 
    * Thus, no CHANGES_NEXT_RELEASE update is required
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/v1/groupingrules"
{"grouping_rules": []}
$ curl -X POST "http://localhost:8081/v1/groupingrules" -d '{"id":1,"regex":"Room","destination":"allrooms","fiware_service_path":"rooms","fields":["entityType"]}'
400 - Invalid grouping rule, some field is not allowed
```
* Assignee @pcoello25