### PR TITLE
bug/643_error_cache_two_resources_same_name_different_pkg

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -19,3 +19,4 @@
 - [BUG] Fix the generalized Hive-like encoding style used in OrionHDFSSink (#781)
 - [HARDENING] Relocate attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)
 - [BUG] Fix recvTime in OrionMongoSink (#796)
+- [BUG] Fix the OrionCKANSink cache when to resources in different packages have the same name (#643)

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -92,10 +92,10 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                 cache.setOrgId(orgName, orgId);
                 String pkgId = createPackage(pkgName, orgId);
                 cache.addPkg(orgName, pkgName);
-                cache.setPkgId(pkgName, pkgId);
+                cache.setPkgId(orgName, pkgName, pkgId);
                 String resId = createResource(resName, pkgId);
                 cache.addRes(orgName, pkgName, resName);
-                cache.setResId(resName, resId);
+                cache.setResId(orgName, pkgName, resName, resId);
                 createDataStore(resId);
                 createView(resId);
                 return resId;
@@ -113,10 +113,10 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             if (createEnabled) {
                 String pkgId = createPackage(pkgName, cache.getOrgId(orgName));
                 cache.addPkg(orgName, pkgName);
-                cache.setPkgId(pkgName, pkgId);
+                cache.setPkgId(orgName, pkgName, pkgId);
                 String resId = createResource(resName, pkgId);
                 cache.addRes(orgName, pkgName, resName);
-                cache.setResId(resName, resId);
+                cache.setResId(orgName, pkgName, resName, resId);
                 createDataStore(resId);
                 createView(resId);
                 return resId;
@@ -132,9 +132,9 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                     + pkgName + ", resName=" + resName + ")");
             
             if (createEnabled) {
-                String resId = this.createResource(resName, cache.getPkgId(pkgName));
+                String resId = this.createResource(resName, cache.getPkgId(orgName, pkgName));
                 cache.addRes(orgName, pkgName, resName);
-                cache.setResId(resName, resId);
+                cache.setResId(orgName, pkgName, resName, resId);
                 createDataStore(resId);
                 createView(resId);
                 return resId;
@@ -146,7 +146,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         LOGGER.debug("The resource was cached (orgName=" + orgName + ", pkgName=" + pkgName + ", resName="
                 + resName + ")");
         
-        return cache.getResId(resName);
+        return cache.getResId(orgName, pkgName, resName);
     } // resourceLookupOrCreate
 
     /**

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -357,7 +357,7 @@ public class CKANCache extends HttpBackend {
             // put the package in the tree and in the packages map
             String pkgId = pkg.get("id").toString();
             tree.get(orgName).put(pkgName, new ArrayList<String>());
-            pkgMap.put(pkgName, pkgId);
+            this.setPkgId(orgName, pkgName, pkgId);
             LOGGER.debug("Package found in CKAN, now cached (orgName=" + orgName + " -> pkgName/pkgId=" + pkgName
                     + "/" + pkgId + ")");
             
@@ -405,7 +405,7 @@ public class CKANCache extends HttpBackend {
             } // if
             
             tree.get(orgName).get(pkgName).add(resourceName);
-            resMap.put(resourceName, resourceId);
+            this.setResId(orgName, pkgName, resourceName, resourceId);
             LOGGER.debug("Resource found in CKAN, now cached (orgName=" + orgName + " -> pkgName=" + pkgName
                     + " -> " + "resourceName/resourceId=" + resourceName + "/" + resourceId + ")");
         } // while

--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -71,20 +71,23 @@ public class CKANCache extends HttpBackend {
     
     /**
      * Gets the package id, given its name.
+     * @param orgName
      * @param pkgName
      * @return
      */
-    public String getPkgId(String pkgName) {
-        return pkgMap.get(pkgName);
+    public String getPkgId(String orgName, String pkgName) {
+        return pkgMap.get(orgName + "_" + pkgName);
     } // getPkgId
 
     /**
      * Gets the resource id, given its name.
+     * @param orgName
+     * @param pkgName
      * @param resName
      * @return
      */
-    public String getResId(String resName) {
-        return resMap.get(resName);
+    public String getResId(String orgName, String pkgName, String resName) {
+        return resMap.get(orgName + "_" + pkgName + "_" + resName);
     } // getResId
 
     /**
@@ -98,20 +101,23 @@ public class CKANCache extends HttpBackend {
     
     /**
      * Sets the package id, given its name.
+     * @param orgName
      * @param pkgName Package name
      * @param pkgId Package id
      */
-    public void setPkgId(String pkgName, String pkgId) {
-        pkgMap.put(pkgName, pkgId);
+    public void setPkgId(String orgName, String pkgName, String pkgId) {
+        pkgMap.put(orgName + "_" + pkgName, pkgId);
     } // setPkgId
 
     /**
      * Sets the resource id, given its name.
+     * @param orgName
+     * @param pkgName
      * @param resName Resource name
      * @param resId Resource id
      */
-    public void setResId(String resName, String resId) {
-        resMap.put(resName, resId);
+    public void setResId(String orgName, String pkgName, String resName, String resId) {
+        resMap.put(orgName + "_" + pkgName + "_" + resName, resId);
     } // setResId
     
     /**

--- a/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -18,7 +18,6 @@
 
 package com.telefonica.iot.cygnus.backends.ckan;
 
-import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import java.util.HashMap;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.HttpClient;
@@ -83,8 +82,8 @@ public class CKANBackendImplTest {
         when(mockCache.isCachedPkg(orgName, pkgName)).thenReturn(true);
         when(mockCache.isCachedRes(orgName, pkgName, resName)).thenReturn(true);
         when(mockCache.getOrgId(orgName)).thenReturn("org_id");
-        when(mockCache.getPkgId(pkgName)).thenReturn("pkg_id");
-        when(mockCache.getResId(resName)).thenReturn("res_id");
+        when(mockCache.getPkgId(orgName, pkgName)).thenReturn("pkg_id");
+        when(mockCache.getResId(orgName, pkgName, resName)).thenReturn("res_id");
         BasicHttpResponse response = new BasicHttpResponse(new ProtocolVersion("http", 1, 1), 200, "ok");
         response.setEntity(new StringEntity("{\"result\": {\"whatever\":\"whatever\"}}"));
         when(mockHttpClient.execute(Mockito.any(HttpUriRequest.class))).thenReturn(response);

--- a/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -75,8 +75,8 @@ public class CKANCacheTest {
 
         // set up the behaviour of the mocked classes
         when(orgMap.get(orgName)).thenReturn(orgId);
-        when(pkgMap.get(pkgName)).thenReturn(pkgId);
-        when(resMap.get(resName)).thenReturn(resId);
+        when(pkgMap.get(orgName + "_" + pkgName)).thenReturn(pkgId);
+        when(resMap.get(orgName + "_" + pkgName + "_" + resName)).thenReturn(resId);
         
         ArrayList<String> ress = new ArrayList<String>();
         ress.add(resName);
@@ -103,7 +103,7 @@ public class CKANCacheTest {
     public void testGetPkgId() {
         System.out.println("Testing CKANCache.getPkgId");
         cache.setPkgMap(pkgMap);
-        assertEquals(pkgId, cache.getPkgId(pkgName));
+        assertEquals(pkgId, cache.getPkgId(orgName, pkgName));
     } // testGetPkgId
     
     /**
@@ -113,7 +113,7 @@ public class CKANCacheTest {
     public void testGetResId() {
         System.out.println("Testing CKANCache.getResId");
         cache.setResMap(resMap);
-        assertEquals(resId, cache.getResId(resName));
+        assertEquals(resId, cache.getResId(orgName, pkgName, resName));
     } // testGetResId
     
     /**
@@ -132,8 +132,8 @@ public class CKANCacheTest {
     @Test
     public void testSetPkgId() {
         System.out.println("Testing CKANCache.setPkgId");
-        cache.setPkgId(pkgName, pkgId);
-        assertEquals(pkgId, cache.getPkgId(pkgName));
+        cache.setPkgId(orgName, pkgName, pkgId);
+        assertEquals(pkgId, cache.getPkgId(orgName, pkgName));
     } // testSetPkgId
     
     /**
@@ -142,8 +142,8 @@ public class CKANCacheTest {
     @Test
     public void testSetResId() {
         System.out.println("Testing CKANCache.setResId");
-        cache.setResId(resName, resId);
-        assertEquals(resId, cache.getResId(resName));
+        cache.setResId(orgName, pkgName, resName, resId);
+        assertEquals(resId, cache.getResId(orgName, pkgName, resName));
     } // testSetResId
     
     /**


### PR DESCRIPTION
* Fixes issue #643 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Previous cache loading through 3 notifications about 3 already created packages (`testckan4`, `testckan5` and `testckan6`) within an already created organization (`frb`). Each package contains an already created resource (`55e3b6d8-29fe-4500-9170-bb491d2f57a2`, `b4b494ba-e885-47e7-9a65-da02050316f1` and `71723d5e-1aa9-4e8a-8f1f-bc683a6f9339`, respectively) regarding the same entity (`Room1` of type `Room`):
```
time=2016-02-18T14:19:44.106CET | lvl=DEBUG | trans=1455801573-824-0000000000 | svc=frb | subsvc=testckan4 | function=wire | comp=Cygnus | msg=org.apache.http.impl.conn.Wire[86] :  >> "{ "resource_id": "55e3b6d8-29fe-4500-9170-bb491d2f57a2", "records": [ {"recvTimeTs": "1455801580","recvTime": "2016-02-18T13:19:40.521Z","fiwareServicePath": "testckan4","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"} ], "method": "insert", "force": "true" }"
time=2016-02-18T14:19:44.371CET | lvl=DEBUG | trans=1455801573-824-0000000000 | svc=frb | subsvc=testckan4 | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_upsert", "success": true, "result": {"records": [{"attrType": "centigrade", "recvTime": "2016-02-18T13:19:40.521Z", "recvTimeTs": "1455801580", "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "testckan4", "entityId": "Room1"}], "method": "insert", "resource_id": "55e3b6d8-29fe-4500-9170-bb491d2f57a2"}}
..
time=2016-02-18T14:20:25.814CET | lvl=DEBUG | trans=1455801573-824-0000000001 | svc=frb | subsvc=testckan5 | function=wire | comp=Cygnus | msg=org.apache.http.impl.conn.Wire[86] :  >> "{ "resource_id": "b4b494ba-e885-47e7-9a65-da02050316f1", "records": [ {"recvTimeTs": "1455801621","recvTime": "2016-02-18T13:20:21.795Z","fiwareServicePath": "testckan5","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"} ], "method": "insert", "force": "true" }"
time=2016-02-18T14:20:26.080CET | lvl=DEBUG | trans=1455801573-824-0000000001 | svc=frb | subsvc=testckan5 | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_upsert", "success": true, "result": {"records": [{"attrType": "centigrade", "recvTime": "2016-02-18T13:20:21.795Z", "recvTimeTs": "1455801621", "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "testckan5", "entityId": "Room1"}], "method": "insert", "resource_id": "b4b494ba-e885-47e7-9a65-da02050316f1"}}
..
time=2016-02-18T14:22:14.567CET | lvl=DEBUG | trans=1455801573-824-0000000002 | svc=frb | subsvc=testckan6 | function=wire | comp=Cygnus | msg=org.apache.http.impl.conn.Wire[86] :  >> "{ "resource_id": "71723d5e-1aa9-4e8a-8f1f-bc683a6f9339", "records": [ {"recvTimeTs": "1455801723","recvTime": "2016-02-18T13:22:03.613Z","fiwareServicePath": "testckan6","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"} ], "method": "insert", "force": "true" }"
time=2016-02-18T14:22:14.879CET | lvl=DEBUG | trans=1455801573-824-0000000002 | svc=frb | subsvc=testckan6 | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_upsert", "success": true, "result": {"records": [{"attrType": "centigrade", "recvTime": "2016-02-18T13:22:03.613Z", "recvTimeTs": "1455801723", "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "testckan6", "entityId": "Room1"}], "method": "insert", "resource_id": "71723d5e-1aa9-4e8a-8f1f-bc683a6f9339"}}
```
Now, another insertion is done, package name `testckan5`, resource id `b4b494ba-e885-47e7-9a65-da02050316f1`:
```
time=2016-02-18T14:24:21.742CET | lvl=DEBUG | trans=1455801573-824-0000000003 | svc=frb | subsvc=testckan5 | function=wire | comp=Cygnus | msg=org.apache.http.impl.conn.Wire[86] :  >> "{ "resource_id": "b4b494ba-e885-47e7-9a65-da02050316f1", "records": [ {"recvTimeTs": "1455801850","recvTime": "2016-02-18T13:24:10.283Z","fiwareServicePath": "testckan5","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"} ], "method": "insert", "force": "true" }"
time=2016-02-18T14:24:22.009CET | lvl=DEBUG | trans=1455801573-824-0000000003 | svc=frb | subsvc=testckan5 | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_upsert", "success": true, "result": {"records": [{"attrType": "centigrade", "recvTime": "2016-02-18T13:24:10.283Z", "recvTimeTs": "1455801850", "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "testckan5", "entityId": "Room1"}], "method": "insert", "resource_id": "b4b494ba-e885-47e7-9a65-da02050316f1"}}
```
* Assignee @pcoello25