### PR TITLE
hardening/752_collection_size_input_value

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,4 +22,3 @@
 - [HARDENING] Relocate attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)
 - [BUG] Fix recvTime in OrionMongoSink (#796)
 - [BUG] Fix fiware service path field in OrionCKANSink, row mode (#800)
-- [BUG] Fix input value for collection_size and initialization for data_expiration in OrionMongoSink and OrionMongoBaseSink (#803)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,3 +22,4 @@
 - [HARDENING] Relocate attr_persistence check from OrionMongoBaseSink to OrionMongoSink (#793)
 - [BUG] Fix recvTime in OrionMongoSink (#796)
 - [BUG] Fix fiware service path field in OrionCKANSink, row mode (#800)
+- [BUG] Fix input value for collection_size and initialization for data_expiration in OrionMongoSink and OrionMongoBaseSink (#803)

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -125,7 +125,7 @@ public abstract class OrionMongoBaseSink extends OrionSink {
                 + shouldHashStr + ") -- Must be 'true' or 'false'");
         }  // if else
 
-        dataExpiration = context.getLong("data_expiration");
+        dataExpiration = context.getLong("data_expiration", 0L);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiration=" + dataExpiration + ")");
         
         super.configure(context);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -54,7 +54,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
     public void configure(Context context) {
         collectionsSize = context.getLong("collections_size", 0L);
         
-        if (collectionsSize < 4096) {
+        if ((collectionsSize > 0) && (collectionsSize < 4096)) {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (collections_size="
                     + collectionsSize + ") -- Must be greater than or equal to 4096");


### PR DESCRIPTION
* Fix a minor issue of https://github.com/telefonicaid/fiware-cygnus/issues/752
* 100% Unit test passed: 
```
Results : Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e test passed: 

Before:
```
time=2016-02-18T11:56:55.506CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[62] : [mongo-sink] Invalid configuration (collections_size=0) -- Must be greather than 0
```
After: 
```
time=2016-02-18T12:00:55.506CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[62] : [mongo-sink] Reading configuration (collections_size=0)
```
Besides, check for `data_expiration`:
```
time=2016-02-18T12:00:55.513CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[129] : [mongo-sink] Reading configuration (data_expiration=0)
```