### PR TITLE
feature/745_fix_status_codes

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRules.java
@@ -46,7 +46,7 @@ public class GroupingRules {
      * @param groupingRulesFileName
      */
     public GroupingRules(String groupingRulesFileName) {
-        groupingRules = null;
+        groupingRules = new LinkedList<GroupingRule>();
         lastIndex = 0;
         
         // read the grouping rules file
@@ -77,34 +77,26 @@ public class GroupingRules {
     } // GroupingRules
     
     /**
-     * Gets if the object representing the grouping rules is empty.
-     * @return True if empty, otherwise false
-     */
-    public boolean isEmpty() {
-        return this.groupingRules == null || this.groupingRules.size() == 0;
-    } // isEmpty
-    
-    /**
      * Gets the rule matching the given context element for the given service path.
      * @param contextElement
      * @param servicePath
      * @return
      */
     public GroupingRule getMatchingRule(ContextElement contextElement, String servicePath) {
-        if (groupingRules != null) {
-            for (GroupingRule rule : groupingRules) {
-                String concat = concatenateFields(rule.getFields(), contextElement, servicePath);
-                Matcher matcher = rule.getPattern().matcher(concat);
-
-                if (matcher.matches()) {
-                    return rule;
-                } // if
-            } // for
-
+        if (groupingRules == null) {
             return null;
-        } else {
-            return null;
-        } // if else
+        } // if
+        
+        for (GroupingRule rule : groupingRules) {
+            String concat = concatenateFields(rule.getFields(), contextElement, servicePath);
+            Matcher matcher = rule.getPattern().matcher(concat);
+
+            if (matcher.matches()) {
+                return rule;
+            } // if
+        } // for
+
+        return null;
     } // getMatchingRule
     
     /**
@@ -123,6 +115,10 @@ public class GroupingRules {
      * @return True, if the rule was deleted, otherwise false
      */
     public boolean deleteRule(long id) {
+        if (groupingRules == null) {
+            return false;
+        } // if
+        
         for (int i = 0; i < groupingRules.size(); i++) {
             GroupingRule groupingRule = groupingRules.get(i);
             
@@ -142,6 +138,10 @@ public class GroupingRules {
      * @return True, if the rule was updated, otherwise false
      */
     public boolean updateRule(long id, GroupingRule rule) {
+        if (groupingRules == null) {
+            return false;
+        } // if
+        
         for (int i = 0; i < groupingRules.size(); i++) {
             GroupingRule groupingRule = groupingRules.get(i);
             
@@ -158,14 +158,22 @@ public class GroupingRules {
     
     /**
      * Gets a stringified version of the grouping rules.
+     * @param asField
      * @return A stringified version of the grouping rules
      */
-    @Override
-    public String toString() {
+    public String toString(boolean asField) {
         if (groupingRules == null) {
-            return "{\"grouping_rules\": []}";
+            if (asField) {
+                return "\"grouping_rules\": []";
+            } else {
+                return "{\"grouping_rules\": []}";
+            } // if else
         } else {
-            return "{\"grouping_rules\": " + groupingRules.toString() + "}";
+            if (asField) {
+                return "\"grouping_rules\": " + groupingRules.toString();
+            } else {
+                return "{\"grouping_rules\": " + groupingRules.toString() + "}";
+            } // if else
         } // if else
     } // toString
     

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -286,28 +286,24 @@ public class ManagementInterface extends AbstractHandler {
         response.setContentType("json;charset=utf-8");
         
         if (groupingRulesConfFile == null) {
-            response.getWriter().println("404 - Missing configuration file for Grouping Rules");
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Missing configuration file for Grouping Rules\"}");
             LOGGER.error("Missing configuration file for Grouping Rules");
             return;
         } // if
         
         if (!new File(groupingRulesConfFile).exists()) {
-            response.getWriter().println("404 - Configuration file for Grouing Rules not found. Details: "
-                    + groupingRulesConfFile);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Configuration file for Grouing Rules not found. Details: "
+                    + groupingRulesConfFile + "\"}");
             LOGGER.error("Configuration file for Grouing Rules not found. Details: " + groupingRulesConfFile);
             return;
         } // if
         
         GroupingRules groupingRules = new GroupingRules(groupingRulesConfFile);
-        String rulesStr = groupingRules.toString();
-        
-        if (rulesStr.startsWith("404")) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-        } else {
-            response.setStatus(HttpServletResponse.SC_OK);
-        } // if else
-        
-        response.getWriter().println(rulesStr);
+        String rulesStr = groupingRules.toString(true);
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().println("{\"success\":\"true\"," + rulesStr + "}");
     } // handleGetGroupingRules
     
     private void handlePostGroupingRules(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -323,7 +319,6 @@ public class ManagementInterface extends AbstractHandler {
         } // while
         
         reader.close();
-        LOGGER.debug("Grouping rule to be added: " + ruleStr);
 
         // check the Json syntax of the new rule
         JSONParser jsonParser = new JSONParser();
@@ -333,7 +328,9 @@ public class ManagementInterface extends AbstractHandler {
             rule = (JSONObject) jsonParser.parse(ruleStr);
         } catch (ParseException e) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            response.getWriter().println("400 - Parse error, invalid Json syntax. Details: " + e.getMessage());
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Parse error, invalid Json syntax. Details: "
+                    + e.getMessage() + "\"}");
             LOGGER.error("Parse error, invalid Json syntax. Details: " + e.getMessage());
             return;
         } // try catch
@@ -347,41 +344,46 @@ public class ManagementInterface extends AbstractHandler {
             
             switch (err) {
                 case 1:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is missing");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is missing\"}");
                     LOGGER.warn("Invalid grouping rule, some field is missing");
                     return;
                 case 2:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is empty");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is empty\"}");
                     LOGGER.warn("Invalid grouping rule, some field is empty");
                     return;
                 case 3:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is not allowed");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is not allowed\"}");
                     LOGGER.warn("Invalid grouping rule, some field is not allowed");
                     return;
                 default:
-                    response.getWriter().println("400 - Invalid grouping rule");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule\"}");
                     LOGGER.warn("Invalid grouping rule");
                     return;
             } // swtich
         } // if
         
         if (groupingRulesConfFile == null) {
-            response.getWriter().println("404 - Missing configuration file for Grouping Rules");
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Missing configuration file for Grouping Rules\"}");
             LOGGER.error("Missing configuration file for Grouping Rules");
             return;
         } // if
         
         if (!new File(groupingRulesConfFile).exists()) {
-            response.getWriter().println("404 - Configuration file for Grouing Rules not found. Details: "
-                    + groupingRulesConfFile);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Configuration file for Grouing Rules not found. Details: "
+                    + groupingRulesConfFile + "\"}");
             LOGGER.error("Configuration file for Grouing Rules not found. Details: " + groupingRulesConfFile);
             return;
         } // if
         
         GroupingRules groupingRules = new GroupingRules(groupingRulesConfFile);
         groupingRules.addRule(new GroupingRule(rule));
-        String rulesStr = groupingRules.toString();
-        LOGGER.debug("Grouping rules after adding the new rule: " + rulesStr);
+        String rulesStr = groupingRules.toString(false);
         
         // write the configuration
         PrintWriter writer = new PrintWriter(new FileWriter(groupingRulesConfFile));
@@ -390,6 +392,7 @@ public class ManagementInterface extends AbstractHandler {
         writer.close();
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().println("{\"success\":\"true\"}");
+        LOGGER.debug("Rule added. Grouping rules after adding the new rule: " + rulesStr);
     } // handlePostGroupingRules
     
     private void handlePutGroupingRules(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -408,8 +411,6 @@ public class ManagementInterface extends AbstractHandler {
         
         // get the rule ID to be updated
         long id = new Long(request.getParameter("id"));
-        
-        LOGGER.debug("Grouping rule with id " + id + " will be updated with: " + ruleStr);
 
         // check the Json syntax of the new rule
         JSONParser jsonParser = new JSONParser();
@@ -419,7 +420,8 @@ public class ManagementInterface extends AbstractHandler {
             rule = (JSONObject) jsonParser.parse(ruleStr);
         } catch (ParseException e) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            response.getWriter().println("400 - Parse error, invalid Json syntax. Details: " + e.getMessage());
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Parse error, invalid Json syntax. Details: " + e.getMessage() + "\"}");
             LOGGER.error("Parse error, invalid Json syntax. Details: " + e.getMessage());
             return;
         } // try catch
@@ -433,33 +435,39 @@ public class ManagementInterface extends AbstractHandler {
             
             switch (err) {
                 case 1:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is missing");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is missing\"}");
                     LOGGER.warn("Invalid grouping rule, some field is missing");
                     return;
                 case 2:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is empty");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is empty\"}");
                     LOGGER.warn("Invalid grouping rule, some field is empty");
                     return;
                 case 3:
-                    response.getWriter().println("400 - Invalid grouping rule, some field is not allowed");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule, some field is not allowed\"}");
                     LOGGER.warn("Invalid grouping rule, some field is not allowed");
                     return;
                 default:
-                    response.getWriter().println("400 - Invalid grouping rule");
+                    response.getWriter().println("{\"success\":\"false\","
+                            + "\"error\":\"Invalid grouping rule\"}");
                     LOGGER.warn("Invalid grouping rule");
                     return;
             } // swtich
         } // if
         
         if (groupingRulesConfFile == null) {
-            response.getWriter().println("404 - Missing configuration file for Grouping Rules");
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Missing configuration file for Grouping Rules\"}");
             LOGGER.error("Missing configuration file for Grouping Rules");
             return;
         } // if
         
         if (!new File(groupingRulesConfFile).exists()) {
-            response.getWriter().println("404 - Configuration file for Grouing Rules not found. Details: "
-                    + groupingRulesConfFile);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Configuration file for Grouing Rules not found. Details: "
+                    + groupingRulesConfFile + "\"}");
             LOGGER.error("Configuration file for Grouing Rules not found. Details: " + groupingRulesConfFile);
             return;
         } // if
@@ -468,14 +476,17 @@ public class ManagementInterface extends AbstractHandler {
         
         if (groupingRules.updateRule(id, new GroupingRule(rule))) {
             PrintWriter writer = new PrintWriter(new FileWriter(groupingRulesConfFile));
-            writer.println(groupingRules.toString());
+            writer.println(groupingRules.toString(false));
             writer.flush();
             writer.close();
             response.setStatus(HttpServletResponse.SC_OK);
             response.getWriter().println("{\"success\":\"true\"}");
+            LOGGER.debug("Rule updated. Details: id=" + id);
         } else {
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.getWriter().println("{\"success\":\"false\"}");
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"The specified rule ID does not exist. Details: " + id + "\"}");
+            LOGGER.error("The specified rule ID does not exist. Details: id=" + id);
         } // if else
     } // handlePutGroupingRules
     
@@ -487,14 +498,18 @@ public class ManagementInterface extends AbstractHandler {
         long id = new Long(request.getParameter("id"));
         
         if (groupingRulesConfFile == null) {
-            response.getWriter().println("404 - Missing configuration file for Grouping Rules");
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Missing configuration file for Grouping Rules\"");
             LOGGER.error("Missing configuration file for Grouping Rules");
             return;
         } // if
         
         if (!new File(groupingRulesConfFile).exists()) {
-            response.getWriter().println("404 - Configuration file for Grouing Rules not found. Details: "
-                    + groupingRulesConfFile);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"Configuration file for Grouing Rules not found. Details: "
+                    + groupingRulesConfFile + "\"");
             LOGGER.error("Configuration file for Grouing Rules not found. Details: " + groupingRulesConfFile);
             return;
         } // if
@@ -503,14 +518,17 @@ public class ManagementInterface extends AbstractHandler {
         
         if (groupingRules.deleteRule(id)) {
             PrintWriter writer = new PrintWriter(new FileWriter(groupingRulesConfFile));
-            writer.println(groupingRules.toString());
+            writer.println(groupingRules.toString(false));
             writer.flush();
             writer.close();
             response.setStatus(HttpServletResponse.SC_OK);
             response.getWriter().println("{\"success\":\"true\"}");
+            LOGGER.debug("Rule deleted. Details: id=" + id);
         } else {
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.getWriter().println("{\"success\":\"false\"}");
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println("{\"success\":\"false\","
+                    + "\"error\":\"The specified rule ID does not exist. Details: " + id + "\"}");
+            LOGGER.error("The specified rule ID does not exist. Details: id=" + id);
         } // if else
     } // handleDeleteGroupingRules
     


### PR DESCRIPTION
* Partially implements issue #745 
    * Thus, no CHANGES_NEXT_RELEASE update is required
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
MAC-510380:fiware-cygnus frb$ curl -v -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET /v1/groupingrules HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 142
< Server: Jetty(6.1.26)
< 
{ [142 bytes data]
100   142  100   142    0     0    615      0 --:--:-- --:--:-- --:--:--   617
* Connection #0 to host localhost left intact
{
    "grouping_rules": [
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 1,
            "regex": "Room"
        }
    ],
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -X DELETE "http://localhost:8081/v1/groupingrules?id=2" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    79  100    79    0     0   1380      0 --:--:-- --:--:-- --:--:--  1385
{
    "error": "The specified rule ID does not exist. Details: 2",
    "success": "false"
}
MAC-510380:fiware-cygnus frb$ curl -X DELETE "http://localhost:8081/v1/groupingrules?id=1" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19  100    19    0     0   2326      0 --:--:-- --:--:-- --:--:--  2375
{
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -v -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET /v1/groupingrules HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 40
< Server: Jetty(6.1.26)
< 
{ [40 bytes data]
100    40  100    40    0     0   4103      0 --:--:-- --:--:-- --:--:--  4444
* Connection #0 to host localhost left intact
{
    "grouping_rules": [],
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -v -X PUT "http://localhost:8081/v1/groupingrules?id=3" -d '{"regex":"Room","destination":"otherdest","fiware_service_path":"otherservpath","fields":["entityType"]}' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> PUT /v1/groupingrules?id=3 HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Length: 104
> Content-Type: application/x-www-form-urlencoded
> 
} [104 bytes data]
* upload completely sent off: 104 out of 104 bytes
< HTTP/1.1 404 Not Found
< Content-Type: json;charset=utf-8
< Content-Length: 79
< Server: Jetty(6.1.26)
< 
{ [79 bytes data]
100   183  100    79  100   104   8896  11711 --:--:-- --:--:-- --:--:-- 13000
* Connection #0 to host localhost left intact
{
    "error": "The specified rule ID does not exist. Details: 3",
    "success": "false"
}
MAC-510380:fiware-cygnus frb$ curl -v -X POST "http://localhost:8081/v1/groupingrules" -d '{"regex":"Room","destination":"allrooms","fiware_service_path":"rooms","fields":["entityType"]}' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> POST /v1/groupingrules HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Length: 95
> Content-Type: application/x-www-form-urlencoded
> 
} [95 bytes data]
* upload completely sent off: 95 out of 95 bytes
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 19
< Server: Jetty(6.1.26)
< 
{ [19 bytes data]
100   114  100    19  100    95   1826   9132 --:--:-- --:--:-- --:--:--  9500
* Connection #0 to host localhost left intact
{
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -v -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET /v1/groupingrules HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 142
< Server: Jetty(6.1.26)
< 
{ [142 bytes data]
100   142  100   142    0     0  19204      0 --:--:-- --:--:-- --:--:-- 20285
* Connection #0 to host localhost left intact
{
    "grouping_rules": [
        {
            "destination": "allrooms",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "rooms",
            "id": 1,
            "regex": "Room"
        }
    ],
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -v -X PUT "http://localhost:8081/v1/groupingrules?id=1" -d '{"regex":"Room","destination":"otherdest","fiware_service_path":"otherservpath","fields":["entityType"]}' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> PUT /v1/groupingrules?id=1 HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Length: 104
> Content-Type: application/x-www-form-urlencoded
> 
} [104 bytes data]
* upload completely sent off: 104 out of 104 bytes
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 19
< Server: Jetty(6.1.26)
< 
{ [19 bytes data]
100   123  100    19  100   104   2314  12669 --:--:-- --:--:-- --:--:-- 13000
* Connection #0 to host localhost left intact
{
    "success": "true"
}
MAC-510380:fiware-cygnus frb$ curl -v -X GET "http://localhost:8081/v1/groupingrules" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET /v1/groupingrules HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: json;charset=utf-8
< Content-Length: 151
< Server: Jetty(6.1.26)
< 
{ [151 bytes data]
100   151  100   151    0     0  19431      0 --:--:-- --:--:-- --:--:-- 21571
* Connection #0 to host localhost left intact
{
    "grouping_rules": [
        {
            "destination": "otherdest",
            "fields": [
                "entityType"
            ],
            "fiware_service_path": "otherservpath",
            "id": 1,
            "regex": "Room"
        }
    ],
    "success": "true"
}
```
* Assignee @pcoello25