### PR TITLE
bug/826_relax_threads_defunction_supervision

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -29,3 +29,4 @@
 - [FEATURE] Add enable_lowercase parameter to all sinks (#815)
 - [BUG] Fix the shared variables within OrionRESTHandler (#823)
 - [HARDENING] Comment default configuration parameters in documentation and configuration template (#365)
+- [BUG] Fix threads defunction supervision in CygnusApplication (#826)

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -416,7 +416,7 @@ public class CygnusApplication extends Application {
                     if ((t.getState() == State.TERMINATED || !t.isAlive())
                             && !t.getName().equals("main") && !t.getName().contains("@qtp")) {
                         LOGGER.error("Thread found not alive, exiting Cygnus. ID=" + t.getId()
-                                + ", name=" + t.getName() + ", " + Arrays.toString(t.getStackTrace()));
+                                + ", name=" + t.getName());
                         System.exit(-1);
                     } // if
                 } // for

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -31,7 +31,6 @@ import com.telefonica.iot.cygnus.management.ManagementInterface;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -411,14 +411,13 @@ public class CygnusApplication extends Application {
             
             while (true) {
                 for (Thread t: threadArray) {
-                    // exit Cygnus if some thread (except for the main one) is found to be not alive or in a terminated
-                    // state
-                    if (t.getState() == State.TERMINATED || !t.isAlive()) {
-                        if (!t.getName().equals("main") && !t.getName().contains("@qtp")) {
-                            LOGGER.error("Thread found not alive, exiting Cygnus. ID=" + t.getId()
-                                    + ", name=" + t.getName() + ", " + Arrays.toString(t.getStackTrace()));
-                            System.exit(-1);
-                        } // if
+                    // exit Cygnus if some thread (except for the main one and threads from the Jetty
+                    // QueuedThreadPool (@qtp)) is found to be not alive or in a terminated state
+                    if ((t.getState() == State.TERMINATED || !t.isAlive())
+                            && !t.getName().equals("main") && !t.getName().contains("@qtp")) {
+                        LOGGER.error("Thread found not alive, exiting Cygnus. ID=" + t.getId()
+                                + ", name=" + t.getName() + ", " + Arrays.toString(t.getStackTrace()));
+                        System.exit(-1);
                     } // if
                 } // for
                 

--- a/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -31,6 +31,7 @@ import com.telefonica.iot.cygnus.management.ManagementInterface;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -403,24 +404,21 @@ public class CygnusApplication extends Application {
      */
     private static class YAFS extends Thread {
         
-        private final Thread[] threadArray;
-        
-        /**
-         * Constructor.
-         */
-        public YAFS() {
-            Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-            threadArray = threadSet.toArray(new Thread[threadSet.size()]);
-        } // YAFS
-        
         @Override
         public void run() {
+            Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+            Thread[] threadArray = threadSet.toArray(new Thread[threadSet.size()]);
+            
             while (true) {
                 for (Thread t: threadArray) {
                     // exit Cygnus if some thread (except for the main one) is found to be not alive or in a terminated
                     // state
-                    if (!t.getName().equals("main") && (t.getState() == State.TERMINATED || !t.isAlive())) {
-                        System.exit(-1);
+                    if (t.getState() == State.TERMINATED || !t.isAlive()) {
+                        if (!t.getName().equals("main") && !t.getName().contains("@qtp")) {
+                            LOGGER.error("Thread found not alive, exiting Cygnus. ID=" + t.getId()
+                                    + ", name=" + t.getName() + ", " + Arrays.toString(t.getStackTrace()));
+                            System.exit(-1);
+                        } // if
                     } // if
                 } // for
                 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -387,6 +387,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
 
         try {
             if (accumulator.getAccIndex() != 0) {
+                LOGGER.info("Batch completed, persisting it");
                 persistBatch(accumulator.getBatch());
             } // if
 


### PR DESCRIPTION
* Fixes issue #826 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed at the e2e VM when receiving notifications from Smart Santander:
```
$ curl -X GET "http://localhost:8081/v1/stats" |python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
102   819  102   819    0     0   196k      0 --:--:-- --:--:-- --:--:--     0
{
    "stats": {
        "channels": [
            {
                "name": "sth-channel", 
                "num_events": 0, 
                "num_puts_failed": 0, 
                "num_puts_ok": 1132, 
                "num_takes_failed": 8, 
                "num_takes_ok": 1132, 
                "setup_time": "2016-02-26T15:06:07.615Z", 
                "status": "START"
            }, 
            {
                "name": "mongo-channel", 
                "num_events": 0, 
                "num_puts_failed": 0, 
                "num_puts_ok": 1132, 
                "num_takes_failed": 9, 
                "num_takes_ok": 1132, 
                "setup_time": "2016-02-26T15:06:07.615Z", 
                "status": "START"
            }
        ], 
        "sinks": [
            {
                "name": "mongo-sink", 
                "num_persisted_events": 1100, 
                "num_processed_events": 1132, 
                "setup_time": "2016-02-26T15:06:07.526Z", 
                "status": "START"
            }, 
            {
                "name": "sth-sink", 
                "num_persisted_events": 1100, 
                "num_processed_events": 1132, 
                "setup_time": "2016-02-26T15:06:07.533Z", 
                "status": "START"
            }
        ], 
        "sources": [
            {
                "name": "http-source", 
                "num_processed_events": 1132, 
                "num_received_events": 1131, 
                "setup_time": "2016-02-26T15:06:07.465Z", 
                "status": "START"
            }
        ]
    }, 
    "success": "true"
}
```
* Assignee @pcoello25