### PR TITLE
hardening/737_use_native_counters_in_channel_stats

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusChannel.java
@@ -61,11 +61,4 @@ public interface CygnusChannel {
      */
     long getNumTakesFail();
     
-    /**
-     * Rollbacks the number of events when a transaction is rollbacked as well. This method is necessary because when
-     * a transaction is rollbacked the "put" method is not used but some kind of internal re-linking is done at the
-     * chanel; thus, the number of events is not increased, which must be deliberatedly done by issuing this method.
-     */
-    void rollback();
-    
 } // CygnusChannel

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusFileChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusFileChannel.java
@@ -20,7 +20,6 @@ package com.telefonica.iot.cygnus.channels;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.lang.reflect.Field;
 import java.util.Date;
-import org.apache.flume.Context;
 import org.apache.flume.channel.file.FileChannel;
 import org.apache.flume.instrumentation.ChannelCounter;
 
@@ -35,26 +34,7 @@ public class CygnusFileChannel extends FileChannel implements CygnusChannel {
     private static final CygnusLogger LOGGER = new CygnusLogger(CygnusFileChannel.class);
     private long setupTime;
     private ChannelCounter channelCounterRef;
-    
-    @Override
-    public void configure(Context context) {
-        super.configure(context);
-        
-        try {
-            Field f = FileChannel.class.getDeclaredField("channelCounter");
-            f.setAccessible(true);
-            channelCounterRef = (ChannelCounter) f.get(this);
-        } catch (NoSuchFieldException e) {
-            LOGGER.error(e.getMessage());
-        } catch (SecurityException e) {
-            LOGGER.error(e.getMessage());
-        } catch (IllegalArgumentException e) {
-            LOGGER.error(e.getMessage());
-        } catch (IllegalAccessException e) {
-            LOGGER.error(e.getMessage());
-        } // try catch
-    } // configure
-    
+
     @Override
     protected void initialize() {
         super.initialize();
@@ -93,7 +73,7 @@ public class CygnusFileChannel extends FileChannel implements CygnusChannel {
     
     @Override
     public long getNumPutsFail() {
-        return channelCounterRef.getEventPutAttemptCount();
+        return channelCounterRef.getEventPutAttemptCount() - channelCounterRef.getEventPutSuccessCount();
     } // getNumPutsFail
     
     @Override
@@ -103,7 +83,7 @@ public class CygnusFileChannel extends FileChannel implements CygnusChannel {
     
     @Override
     public long getNumTakesFail() {
-        return channelCounterRef.getEventTakeAttemptCount();
+        return channelCounterRef.getEventTakeAttemptCount() - channelCounterRef.getEventTakeSuccessCount();
     } // getNumTakesFail
     
 } // CygnusFileChannel

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
@@ -20,7 +20,6 @@ package com.telefonica.iot.cygnus.channels;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.lang.reflect.Field;
 import java.util.Date;
-import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.instrumentation.ChannelCounter;
 
@@ -35,25 +34,6 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
     private static final CygnusLogger LOGGER = new CygnusLogger(CygnusMemoryChannel.class);
     private long setupTime;
     private ChannelCounter channelCounterRef;
-    
-    @Override
-    public void configure(Context context) {
-        super.configure(context);
-        
-        try {
-            Field f = MemoryChannel.class.getDeclaredField("channelCounter");
-            f.setAccessible(true);
-            channelCounterRef = (ChannelCounter) f.get(this);
-        } catch (NoSuchFieldException e) {
-            LOGGER.error(e.getMessage());
-        } catch (SecurityException e) {
-            LOGGER.error(e.getMessage());
-        } catch (IllegalArgumentException e) {
-            LOGGER.error(e.getMessage());
-        } catch (IllegalAccessException e) {
-            LOGGER.error(e.getMessage());
-        } // try catch
-    } // configure
     
     @Override
     protected void initialize() {
@@ -93,7 +73,7 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
     
     @Override
     public long getNumPutsFail() {
-        return channelCounterRef.getEventPutAttemptCount();
+        return channelCounterRef.getEventPutAttemptCount() - channelCounterRef.getEventPutSuccessCount();
     } // getNumPutsFail
     
     @Override
@@ -103,7 +83,7 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
     
     @Override
     public long getNumTakesFail() {
-        return channelCounterRef.getEventTakeAttemptCount();
+        return channelCounterRef.getEventTakeAttemptCount() - channelCounterRef.getEventTakeSuccessCount();
     } // getNumTakesFail
 
 } // CygnusMemoryChannel

--- a/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
+++ b/src/main/java/com/telefonica/iot/cygnus/channels/CygnusMemoryChannel.java
@@ -17,10 +17,12 @@
  */
 package com.telefonica.iot.cygnus.channels;
 
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import java.lang.reflect.Field;
 import java.util.Date;
 import org.apache.flume.Context;
-import org.apache.flume.Event;
 import org.apache.flume.channel.MemoryChannel;
+import org.apache.flume.instrumentation.ChannelCounter;
 
 /**
  * CygnusMemoryChannel is an extension of Flume's MemoryChannel. Basically, it is the same channel but having methods
@@ -30,59 +32,50 @@ import org.apache.flume.channel.MemoryChannel;
  */
 public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel {
     
+    private static final CygnusLogger LOGGER = new CygnusLogger(CygnusMemoryChannel.class);
     private long setupTime;
-    private long numEvents;
-    private long numPutsOK;
-    private long numPutsFail;
-    private long numTakesOK;
-    private long numTakesFail;
-    private long capacity;
+    private ChannelCounter channelCounterRef;
     
     @Override
     public void configure(Context context) {
         super.configure(context);
-        capacity = context.getInteger("capacity");
+        
+        try {
+            Field f = MemoryChannel.class.getDeclaredField("channelCounter");
+            f.setAccessible(true);
+            channelCounterRef = (ChannelCounter) f.get(this);
+        } catch (NoSuchFieldException e) {
+            LOGGER.error(e.getMessage());
+        } catch (SecurityException e) {
+            LOGGER.error(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            LOGGER.error(e.getMessage());
+        } catch (IllegalAccessException e) {
+            LOGGER.error(e.getMessage());
+        } // try catch
     } // configure
     
     @Override
     protected void initialize() {
         super.initialize();
+        
+        try {
+            Field f = MemoryChannel.class.getDeclaredField("channelCounter");
+            f.setAccessible(true);
+            channelCounterRef = (ChannelCounter) f.get(this);
+        } catch (NoSuchFieldException e) {
+            LOGGER.error(e.getMessage());
+        } catch (SecurityException e) {
+            LOGGER.error(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            LOGGER.error(e.getMessage());
+        } catch (IllegalAccessException e) {
+            LOGGER.error(e.getMessage());
+        } // try catch
+        
         setupTime = new Date().getTime();
-        numEvents = 0;
-        numPutsOK = 0;
-        numPutsFail = 0;
-        numTakesOK = 0;
-        numTakesFail = 0;
     } // initialize
-    
-    @Override
-    public void put(Event event) {
-        if (numEvents != capacity) {
-            numEvents++;
-            numPutsOK++;
-        } else {
-            numPutsFail++;
-        } // if else
-        
-        // independently of the remaining capacity, call the super version of the method in order to behave as a
-        // MemoryChannel (exceptions, errors, etc)
-        super.put(event);
-    } // put
-    
-    @Override
-    public Event take() {
-        Event event = super.take();
-        
-        if (event != null) {
-            numEvents--;
-            numTakesOK++;
-        } else {
-            numTakesFail++;
-        } // if else
-        
-        return event;
-    } // take
-    
+
     @Override
     public long getSetupTime() {
         return setupTime;
@@ -90,32 +83,27 @@ public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel 
     
     @Override
     public long getNumEvents() {
-        return numEvents;
+        return channelCounterRef.getChannelSize();
     } // getNumEvents
     
     @Override
     public long getNumPutsOK() {
-        return numPutsOK;
+        return channelCounterRef.getEventPutSuccessCount();
     } // getNumPutsOK
     
     @Override
     public long getNumPutsFail() {
-        return numPutsFail;
+        return channelCounterRef.getEventPutAttemptCount();
     } // getNumPutsFail
     
     @Override
     public long getNumTakesOK() {
-        return numTakesOK;
+        return channelCounterRef.getEventTakeSuccessCount();
     } // getNumTakesOK
     
     @Override
     public long getNumTakesFail() {
-        return numTakesFail;
+        return channelCounterRef.getEventTakeAttemptCount();
     } // getNumTakesFail
-    
-    @Override
-    public void rollback() {
-        numEvents++;
-    } // rollback
-    
+
 } // CygnusMemoryChannel


### PR DESCRIPTION
* Partially implements issue #737 
    * Thus, no CHANGES_NEXT_RELEASE update is required
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/v1/stats" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   503  100   503    0     0  76876      0 --:--:-- --:--:-- --:--:-- 83833
{
    "stats": {
        "channels": [
            {
                "name": "mysql-channel",
                "num_events": 1,
                "num_puts_failed": 0,
                "num_puts_ok": 112,
                "num_takes_failed": 113,
                "num_takes_ok": 0,
                "setup_time": "2016-02-29T09:43:48.869Z",
                "status": "START"
            }
        ],
        "sinks": [
            {
                "name": "mysql-sink",
                "num_persisted_events": 0,
                "num_processed_events": 112,
                "setup_time": "2016-02-29T09:43:48.784Z",
                "status": "START"
            }
        ],
        "sources": [
            {
                "name": "http-source",
                "num_processed_events": 112,
                "num_received_events": 112,
                "setup_time": "2016-02-29T09:43:48.731Z",
                "status": "START"
            }
        ]
    },
    "success": "true"
}
```
* Assignee @pcoello25