### PR TITLE
hardening/365_fix_default_parameters

### DIFF
--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -163,14 +163,14 @@ cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.OrionMySQLSi
 # cygnusagent.sinks.mysql-sink.mysql_host = localhost
 # the port where the MySQL server listes for incomming connections
 # cygnusagent.sinks.mysql-sink.mysql_port = 3306
-# a valid user in the MySQL server
-cygnusagent.sinks.mysql-sink.mysql_username = root
-# password for the user above
-cygnusagent.sinks.mysql-sink.mysql_password = xxxxxxxxxxxxx
+# a valid user in the MySQL server (empty user by default)
+# cygnusagent.sinks.mysql-sink.mysql_username =
+# password for the user above (empty user by default)
+# cygnusagent.sinks.mysql-sink.mysql_password =
 # how the attributes are stored, either per row either per column (row, column)
 # cygnusagent.sinks.mysql-sink.attr_persistence = row
-# select the table type from table-by-destination and table-by-service-path
-cygnusagent.sinks.mysql-sink.table_type = table-by-destination
+# select the data model from dm-by-entity and dm-by-service-path
+# cygnusagent.sinks.mysql-sink.table_type = dm-by-entity
 # number of notifications to be included within a processing batch
 # cygnusagent.sinks.mysql-sink.batch_size = 1
 # timeout for batch accumulation
@@ -192,12 +192,12 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.OrionPo
 # cygnusagent.sinks.postgresql-sink.postgresql_host = localhost
 # the port where the PostgreSQL server listens for incomming connections
 # cygnusagent.sinks.postgresql-sink.postgresql_port = 5432
-# the name of the postgresql database
-cygnusagent.sinks.postgresql-sink.postgresql_database = postgres
-# a valid user in the PostgreSQL server
-cygnusagent.sinks.postgresql-sink.postgresql_username = root
-# password for the user above
-cygnusagent.sinks.postgresql-sink.postgresql_password = xxxxxxxxxxxxx
+# the name of the postgresql database (postgres is the default database)
+# cygnusagent.sinks.postgresql-sink.postgresql_database = postgres
+# a valid user in the PostgreSQL server (empty user as default)
+# cygnusagent.sinks.postgresql-sink.postgresql_username =
+# password for the user above (empty password as default)
+# cygnusagent.sinks.postgresql-sink.postgresql_password = 
 # how the attributes are stored, either per row either per column (row, column)
 # cygnusagent.sinks.postgresql-sink.attr_persistence = row
 # Must be dm-by-service-path or dm-by-entity

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -165,7 +165,7 @@ cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.OrionMySQLSi
 # cygnusagent.sinks.mysql-sink.mysql_port = 3306
 # a valid user in the MySQL server (empty user by default)
 # cygnusagent.sinks.mysql-sink.mysql_username =
-# password for the user above (empty user by default)
+# password for the user above (empty password by default)
 # cygnusagent.sinks.mysql-sink.mysql_password =
 # how the attributes are stored, either per row either per column (row, column)
 # cygnusagent.sinks.mysql-sink.attr_persistence = row
@@ -197,7 +197,7 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.OrionPo
 # a valid user in the PostgreSQL server (empty user as default)
 # cygnusagent.sinks.postgresql-sink.postgresql_username =
 # password for the user above (empty password as default)
-# cygnusagent.sinks.postgresql-sink.postgresql_password = 
+# cygnusagent.sinks.postgresql-sink.postgresql_password =
 # how the attributes are stored, either per row either per column (row, column)
 # cygnusagent.sinks.postgresql-sink.attr_persistence = row
 # Must be dm-by-service-path or dm-by-entity

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -132,8 +132,11 @@ public class OrionCKANSink extends OrionSink {
         orionUrl = context.getString("orion_url", "http://localhost:1026");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (orion_url=" + orionUrl + ")");
         String attrPersistenceStr = context.getString("attr_persistence");
-
-        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+        
+        if (attrPersistenceStr == null) {
+            rowAttrPersistence = true;
+        }
+        else if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
             rowAttrPersistence = attrPersistenceStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + attrPersistenceStr + ")");
@@ -145,7 +148,10 @@ public class OrionCKANSink extends OrionSink {
 
         String sslStr = context.getString("ssl");
         
-        if (sslStr.equals("true") || sslStr.equals("false")) {
+        if (sslStr == null) {
+            ssl = false;
+        }
+        else if (sslStr.equals("true") || sslStr.equals("false")) {
             ssl = Boolean.valueOf(sslStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl="
                 + sslStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -131,12 +131,9 @@ public class OrionCKANSink extends OrionSink {
 
         orionUrl = context.getString("orion_url", "http://localhost:1026");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (orion_url=" + orionUrl + ")");
-        String attrPersistenceStr = context.getString("attr_persistence");
+        String attrPersistenceStr = context.getString("attr_persistence", "row");
         
-        if (attrPersistenceStr == null) {
-            rowAttrPersistence = true;
-        }
-        else if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
             rowAttrPersistence = attrPersistenceStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + attrPersistenceStr + ")");
@@ -146,12 +143,9 @@ public class OrionCKANSink extends OrionSink {
                 + attrPersistenceStr + ") -- Must be 'row' or 'column'");
         }  // if else
 
-        String sslStr = context.getString("ssl");
+        String sslStr = context.getString("ssl", "false");
         
-        if (sslStr == null) {
-            ssl = false;
-        }
-        else if (sslStr.equals("true") || sslStr.equals("false")) {
+        if (sslStr.equals("true") || sslStr.equals("false")) {
             ssl = Boolean.valueOf(sslStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (ssl="
                 + sslStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -81,7 +81,7 @@ public class OrionDynamoDBSink extends OrionSink {
         secretAccessKey = context.getString("secret_access_key");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (secret_access_key=" + secretAccessKey + ")");
         
-        String regionStr = context.getString("region");
+        String regionStr = context.getString("region", "eu-west-1");
 
         try {
             Regions regionReg = Regions.valueOf(regionStr.replaceAll("-", "").toUpperCase());
@@ -95,8 +95,8 @@ public class OrionDynamoDBSink extends OrionSink {
                     + "'ap-northeast-1', 'ap-northeast1', 'ap-shouteast-1', 'ap-shouteast-2' or 'sa-east-1'");
         } // catch
         
-        String attrPersistRowStr = context.getString("attr_persistence");
-
+        String attrPersistRowStr = context.getString("attr_persistence", "row");
+        
         if (attrPersistRowStr.equals("row") || attrPersistRowStr.equals("column")) {
             attrPersistenceRow = attrPersistRowStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -336,7 +336,10 @@ public class OrionHDFSSink extends OrionSink {
         // Hive configuration
         String enableHiveStr = context.getString("hive");
         
-        if (enableHiveStr.equals("true") || enableHiveStr.equals("false")) {
+        if (enableHiveStr == null) {
+            enableHive = true;
+        }
+        else if (enableHiveStr.equals("true") || enableHiveStr.equals("false")) {
             enableHive = Boolean.valueOf(enableHiveStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (enableHive="
                 + enableHiveStr + ")");
@@ -431,6 +434,10 @@ public class OrionHDFSSink extends OrionSink {
 
         String hiveDBTypeStr = context.getString("hive.db_type");
         
+        if (hiveDBTypeStr == null) {
+            hiveDBTypeStr = "default-db"; 
+       }
+        
         try {
             hiveDBType = HiveDBType.valueOf(hiveDBTypeStr.replaceAll("-", "").toUpperCase());
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type="
@@ -444,7 +451,10 @@ public class OrionHDFSSink extends OrionSink {
         // Kerberos configuration
         String enableKrb5Str = context.getString("krb5_auth");
         
-        if (enableKrb5Str.equals("true") || enableKrb5Str.equals("false")) {
+        if (enableKrb5Str == null) {
+            enableKrb5 = false;
+        }
+        else if (enableKrb5Str.equals("true") || enableKrb5Str.equals("false")) {
             enableKrb5 = Boolean.valueOf(enableKrb5Str);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_auth="
                 + enableKrb5Str + ")");
@@ -466,7 +476,10 @@ public class OrionHDFSSink extends OrionSink {
 
         String serviceAsNamespaceStr = context.getString("service_as_namespace");
         
-        if (serviceAsNamespaceStr.equals("true") || serviceAsNamespaceStr.equals("false")) {
+        if (serviceAsNamespaceStr == null) {
+            serviceAsNamespace = false;
+        }
+        else if (serviceAsNamespaceStr.equals("true") || serviceAsNamespaceStr.equals("false")) {
             serviceAsNamespace = Boolean.valueOf(serviceAsNamespaceStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type="
                 + serviceAsNamespaceStr + ")");
@@ -477,6 +490,10 @@ public class OrionHDFSSink extends OrionSink {
         }  // if else
         
         String backendImplStr = context.getString("backend_impl");
+        
+        if (backendImplStr == null) {
+            backendImplStr = "rest";
+        }
         
         try {
             backendImpl = BackendImpl.valueOf(backendImplStr.toUpperCase());

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -334,12 +334,9 @@ public class OrionHDFSSink extends OrionSink {
         } // if else if
 
         // Hive configuration
-        String enableHiveStr = context.getString("hive");
+        String enableHiveStr = context.getString("hive", "true");
         
-        if (enableHiveStr == null) {
-            enableHive = true;
-        }
-        else if (enableHiveStr.equals("true") || enableHiveStr.equals("false")) {
+        if (enableHiveStr.equals("true") || enableHiveStr.equals("false")) {
             enableHive = Boolean.valueOf(enableHiveStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (enableHive="
                 + enableHiveStr + ")");
@@ -432,11 +429,7 @@ public class OrionHDFSSink extends OrionSink {
             LOGGER.debug("[" + this.getName() + "] Defaulting to hive.server_version=2");
         } // if else
 
-        String hiveDBTypeStr = context.getString("hive.db_type");
-        
-        if (hiveDBTypeStr == null) {
-            hiveDBTypeStr = "default-db"; 
-       }
+        String hiveDBTypeStr = context.getString("hive.db_type", "default-db");
         
         try {
             hiveDBType = HiveDBType.valueOf(hiveDBTypeStr.replaceAll("-", "").toUpperCase());
@@ -449,12 +442,9 @@ public class OrionHDFSSink extends OrionSink {
         }  // try catch
 
         // Kerberos configuration
-        String enableKrb5Str = context.getString("krb5_auth");
+        String enableKrb5Str = context.getString("krb5_auth", "false");
         
-        if (enableKrb5Str == null) {
-            enableKrb5 = false;
-        }
-        else if (enableKrb5Str.equals("true") || enableKrb5Str.equals("false")) {
+        if (enableKrb5Str.equals("true") || enableKrb5Str.equals("false")) {
             enableKrb5 = Boolean.valueOf(enableKrb5Str);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_auth="
                 + enableKrb5Str + ")");
@@ -474,12 +464,9 @@ public class OrionHDFSSink extends OrionSink {
         krb5ConfFile = context.getString("krb5_auth.krb5_conf_file", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (krb5_conf_file=" + krb5ConfFile + ")");
 
-        String serviceAsNamespaceStr = context.getString("service_as_namespace");
+        String serviceAsNamespaceStr = context.getString("service_as_namespace", "false");
         
-        if (serviceAsNamespaceStr == null) {
-            serviceAsNamespace = false;
-        }
-        else if (serviceAsNamespaceStr.equals("true") || serviceAsNamespaceStr.equals("false")) {
+        if (serviceAsNamespaceStr.equals("true") || serviceAsNamespaceStr.equals("false")) {
             serviceAsNamespace = Boolean.valueOf(serviceAsNamespaceStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.db_type="
                 + serviceAsNamespaceStr + ")");
@@ -489,12 +476,8 @@ public class OrionHDFSSink extends OrionSink {
                 + serviceAsNamespaceStr + ") -- Must be 'true' or 'false'");
         }  // if else
         
-        String backendImplStr = context.getString("backend_impl");
-        
-        if (backendImplStr == null) {
-            backendImplStr = "rest";
-        }
-        
+        String backendImplStr = context.getString("backend_impl", "rest");
+
         try {
             backendImpl = BackendImpl.valueOf(backendImplStr.toUpperCase());
             LOGGER.debug("[" + this.getName() + "] Reading configuration (backend_impl="

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -115,7 +115,10 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         
         String shouldHashStr = context.getString("should_hash");
         
-        if (shouldHashStr.equals("true") || shouldHashStr.equals("false")) {
+        if (shouldHashStr == null) {
+            shouldHash = false;
+        }
+        else if (shouldHashStr.equals("true") || shouldHashStr.equals("false")) {
             shouldHash = Boolean.valueOf(shouldHashStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash="
                 + shouldHashStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -113,12 +113,9 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         collectionPrefix = Utils.encode(context.getString("collection_prefix", "sth_"));
         LOGGER.debug("[" + this.getName() + "] Reading configuration (collection_prefix=" + collectionPrefix + ")");
         
-        String shouldHashStr = context.getString("should_hash");
+        String shouldHashStr = context.getString("should_hash", "false");
         
-        if (shouldHashStr == null) {
-            shouldHash = false;
-        }
-        else if (shouldHashStr.equals("true") || shouldHashStr.equals("false")) {
+        if (shouldHashStr.equals("true") || shouldHashStr.equals("false")) {
             shouldHash = Boolean.valueOf(shouldHashStr);
             LOGGER.debug("[" + this.getName() + "] Reading configuration (should_hash="
                 + shouldHashStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -65,12 +65,9 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         maxDocuments = context.getLong("max_documents", 0L);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (max_documents=" + maxDocuments + ")");
         
-        String attrPersistenceStr = context.getString("attr_persistence");
+        String attrPersistenceStr = context.getString("attr_persistence", "row");
         
-        if (attrPersistenceStr == null) {
-            rowAttrPersistence = true;
-        }
-        else if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
             rowAttrPersistence = attrPersistenceStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + attrPersistenceStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -67,7 +67,10 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         
         String attrPersistenceStr = context.getString("attr_persistence");
         
-        if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
+        if (attrPersistenceStr == null) {
+            rowAttrPersistence = true;
+        }
+        else if (attrPersistenceStr.equals("row") || attrPersistenceStr.equals("column")) {
             rowAttrPersistence = attrPersistenceStr.equals("row");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + attrPersistenceStr + ")");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -130,12 +130,9 @@ public class OrionMySQLSink extends OrionSink {
         mysqlPassword = context.getString("mysql_password", "unknown");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_password=" + mysqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        String persistence = context.getString("attr_persistence");
+        String persistence = context.getString("attr_persistence", "row");
         
-        if (persistence == null) {
-            rowAttrPersistence = true;
-        }
-        else if (persistence.equals("row") || persistence.equals("column")) {
+        if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -124,10 +124,10 @@ public class OrionMySQLSink extends OrionSink {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + mysqlPort + ")");
         }  // if else
         
-        mysqlUsername = context.getString("mysql_username", "opendata");
+        mysqlUsername = context.getString("mysql_username", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_username=" + mysqlUsername + ")");
         // FIXME: mysqlPassword should be read as a SHA1 and decoded here
-        mysqlPassword = context.getString("mysql_password", "unknown");
+        mysqlPassword = context.getString("mysql_password", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_password=" + mysqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence", "row");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -132,7 +132,10 @@ public class OrionMySQLSink extends OrionSink {
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence");
         
-        if (persistence.equals("row") || persistence.equals("column")) {
+        if (persistence == null) {
+            rowAttrPersistence = true;
+        }
+        else if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -135,10 +135,10 @@ public class OrionPostgreSQLSink extends OrionSink {
 
         postgresqlDatabase = context.getString("postgresql_database", "postgres");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_database=" + postgresqlDatabase + ")");
-        postgresqlUsername = context.getString("postgresql_username", "opendata");
+        postgresqlUsername = context.getString("postgresql_username", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_username=" + postgresqlUsername + ")");
         // FIXME: postgresqlPassword should be read as a SHA1 and decoded here
-        postgresqlPassword = context.getString("postgresql_password", "unknown");
+        postgresqlPassword = context.getString("postgresql_password", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_password=" + postgresqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence", "row");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -141,12 +141,9 @@ public class OrionPostgreSQLSink extends OrionSink {
         postgresqlPassword = context.getString("postgresql_password", "unknown");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_password=" + postgresqlPassword + ")");
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
-        String persistence = context.getString("attr_persistence");
+        String persistence = context.getString("attr_persistence", "row");
 
-        if (persistence == null) {
-            rowAttrPersistence = true;
-        }
-        else if (persistence.equals("row") || persistence.equals("column")) {
+        if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -143,7 +143,10 @@ public class OrionPostgreSQLSink extends OrionSink {
         rowAttrPersistence = context.getString("attr_persistence", "row").equals("row");
         String persistence = context.getString("attr_persistence");
 
-        if (persistence.equals("row") || persistence.equals("column")) {
+        if (persistence == null) {
+            rowAttrPersistence = true;
+        }
+        else if (persistence.equals("row") || persistence.equals("column")) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_persistence="
                 + persistence + ")");
         } else {


### PR DESCRIPTION
* Fix issue #365 
* 100% unit test passed: 
```
Results : Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) test passed: 
```
CKAN
time=2016-02-29T12:11:58.993CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[177] : [ckan-sink] CKAN persistence backend created
time=2016-02-29T12:11:58.993CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [ckan-sink] Startup completed

MYSQL
time=2016-02-29T12:30:45.161CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[154] : [mysql-sink] MySQL persistence backend created
time=2016-02-29T12:30:45.161CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [mysql-sink] Startup completed

POSTGRESQL
time=2016-02-29T12:36:39.567CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[167] : [postgresql-sink] PostgreSQL persistence backend created
time=2016-02-29T12:36:39.588CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[176] : [postgresql-sink] Startup completed

MONGO
time=2016-02-29T12:51:55.808CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[141] : [mongo-sink] MongoDB persistence backend created
time=2016-02-29T12:51:55.809CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [mongo-sink] Startup completed

STH
time=2016-02-29T12:53:46.140CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink[141] : [sth-sink] MongoDB persistence backend created
time=2016-02-29T12:53:46.141CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [sth-sink] Startup completed

KAFKA
time=2016-02-29T12:57:42.798CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionKafkaSink[131] : [kafka-sink] Kafka persistence backend (KafkaProducer) created
time=2016-02-29T12:57:42.971CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [kafka-sink] Startup completed

DYNAMODB
time=2016-02-29T13:00:56.669CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[154] : [dynamodb-sink] MySQL persistence backend created
time=2016-02-29T13:00:56.669CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [dynamodb-sink] Startup completed

HDFS
time=2016-02-29T13:44:41.131CET | lvl=DEBUG | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[518] : [hdfs-sink] HDFS persistence backend created
time=2016-02-29T13:44:41.133CET | lvl=INFO | trans= | srv= | subsrv= | function=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[236] : [hdfs-sink] Startup completed
```
* PR derived from a re-opened issue: no CHANGES_NEXT_RELEASE update is required
* Assignee: @frbattid 