### PR TITLE
bug/837_default_db_username_and_pass_of_postgresql_and_mysql

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [BUG] Fix default authentication parameters in OrionMySQLSink and OrionPostgreSQLSink (#837)

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -194,8 +194,8 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.OrionPo
 # cygnusagent.sinks.postgresql-sink.postgresql_port = 5432
 # the name of the postgresql database (postgres is the default database)
 # cygnusagent.sinks.postgresql-sink.postgresql_database = postgres
-# a valid user in the PostgreSQL server (empty user as default)
-# cygnusagent.sinks.postgresql-sink.postgresql_username =
+# a valid user in the PostgreSQL server (postgres as default)
+# cygnusagent.sinks.postgresql-sink.postgresql_username = postgres
 # password for the user above (empty password as default)
 # cygnusagent.sinks.postgresql-sink.postgresql_password =
 # how the attributes are stored, either per row either per column (row, column)

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -163,8 +163,8 @@ cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.OrionMySQLSi
 # cygnusagent.sinks.mysql-sink.mysql_host = localhost
 # the port where the MySQL server listes for incomming connections
 # cygnusagent.sinks.mysql-sink.mysql_port = 3306
-# a valid user in the MySQL server (empty user by default)
-# cygnusagent.sinks.mysql-sink.mysql_username =
+# a valid user in the MySQL server (root by default)
+# cygnusagent.sinks.mysql-sink.mysql_username = root
 # password for the user above (empty password by default)
 # cygnusagent.sinks.mysql-sink.mysql_password =
 # how the attributes are stored, either per row either per column (row, column)

--- a/doc/flume_extensions_catalogue/orion_mysql_sink.md
+++ b/doc/flume_extensions_catalogue/orion_mysql_sink.md
@@ -263,8 +263,8 @@ NOTES:
 | data_model | no | dm-by-entity | <i>dm-by-service-path</i> or <i>dm-by-entity</i>. <i>dm-by-service</i> and <dm-by-attribute</i> are not currently supported. |
 | mysql_host | no | localhost | FQDN/IP address where the MySQL server runs |
 | mysql_port | no | 3306 ||
-| mysql_username | yes | N/A ||
-| mysql_password | yes | N/A ||
+| mysql_username | no | root | `root` is the default username that is created automatically |
+| mysql_password | no | N/A | Empty value as default (no password is created automatically) |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |

--- a/doc/flume_extensions_catalogue/orion_postgresql_sink.md
+++ b/doc/flume_extensions_catalogue/orion_postgresql_sink.md
@@ -150,10 +150,10 @@ NOTES:
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
 | data_model | no | dm-by-entity | <i>dm-by-service-path</i> or <i>dm-by-entity</i>. <i>dm-by-service</i> and <dm-by-attribute</i> are not currently supported. |
 | postgresql_host | no | localhost | FQDN/IP address where the PostgreSQL server runs. |
-| postgresql_port | no | 3306 ||
-| postgresql_database | yes | N/A ||
-| postgresql_username | yes | N/A ||
-| postgresql_password | yes | N/A ||
+| postgresql_port | no | 5432 ||
+| postgresql_database | no | postgres | `postgres` is the default database that is created automatically when install |
+| postgresql_username | no | postgres | `postgres` is the default username that is created automatically when install |
+| postgresql_password | no | N/A | Empty value by default (No password is created when install) |
 | attr_persistence | no | row | <i>row</i> or <i>column</i>. |
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
@@ -172,7 +172,7 @@ A configuration example could be:
     cygnusagent.sinks.postgresql-sink.postgresql_host = 192.168.80.34
     cygnusagent.sinks.postgresql-sink.postgresql_port = 5432
     cygnusagent.sinks.postgresql-sink.postgresql_database = mydatabase
-    cygnusagent.sinks.postgresql-sink.posqtgresql_username = myuser
+    cygnusagent.sinks.postgresql-sink.postgresql_username = myuser
     cygnusagent.sinks.postgresql-sink.postgresql_password = mypassword
     cygnusagent.sinks.postgresql-sink.attr_persistence = row
     cygnusagent.sinks.postgresql-sink.batch_size = 100

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -124,7 +124,7 @@ public class OrionMySQLSink extends OrionSink {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_port=" + mysqlPort + ")");
         }  // if else
         
-        mysqlUsername = context.getString("mysql_username", "");
+        mysqlUsername = context.getString("mysql_username", "root");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_username=" + mysqlUsername + ")");
         // FIXME: mysqlPassword should be read as a SHA1 and decoded here
         mysqlPassword = context.getString("mysql_password", "");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -135,7 +135,7 @@ public class OrionPostgreSQLSink extends OrionSink {
 
         postgresqlDatabase = context.getString("postgresql_database", "postgres");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_database=" + postgresqlDatabase + ")");
-        postgresqlUsername = context.getString("postgresql_username", "");
+        postgresqlUsername = context.getString("postgresql_username", "postgres");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_username=" + postgresqlUsername + ")");
         // FIXME: postgresqlPassword should be read as a SHA1 and decoded here
         postgresqlPassword = context.getString("postgresql_password", "");

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -122,7 +122,7 @@ public class OrionPostgreSQLSink extends OrionSink {
     public void configure(Context context) {
         postgresqlHost = context.getString("postgresql_host", "localhost");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_host=" + postgresqlHost + ")");
-        postgresqlPort = context.getString("postgresql_port", "3306");
+        postgresqlPort = context.getString("postgresql_port", "5432");
         int intPort = Integer.parseInt(postgresqlPort);
 
         if ((intPort <= 0) || (intPort > 65535)) {


### PR DESCRIPTION
* Fix issue https://github.com/telefonicaid/fiware-cygnus/issues/837
* 100% unit tests passed: 
```
Results : Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) teste passed: 
```
MySQL
time=2016-03-01T12:06:50.492CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[128] : [mysql-sink] Reading configuration (mysql_username=root)
time=2016-03-01T12:06:50.492CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[131] : [mysql-sink] Reading configuration (mysql_password=)
time=2016-03-01T12:07:15.315CET | lvl=INFO | trans=1456830410-375-0000000000 | srv=fiwareservice | subsrv=fiwareservicepath | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[470] : [mysql-sink] Persisting data at OrionMySQLSink. Database (fiwareservice), Table (fiwareservicepath_Room1_Room), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1456830435210','2016-03-01T11:07:15.210Z','fiwareservicepath','Room1','Room','humidity','float','1.23','[]'))

PostgreSQL
time=2016-03-01T12:20:49.886CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[137] : [postgresql-sink] Reading configuration (postgresql_database=postgres)
time=2016-03-01T12:20:49.887CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[139] : [postgresql-sink] Reading configuration (postgresql_username=postgres)
time=2016-03-01T12:20:49.887CET | lvl=DEBUG | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[142] : [postgresql-sink] Reading configuration (postgresql_password=)
time=2016-03-01T12:30:20.047CET | lvl=INFO | trans=1456831813-676-0000000000 | srv=fiwareservice | subsrv=fiwareservicepath | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink[486] : [postgresql-sink] Persisting data at OrionPostgreSQLSink. Schema (fiwareservice), Table (fiwareservicepath_room1_room), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1456831819936','2016-03-01T11:30:19.936Z','fiwareservicepath','Room1','Room','humidity','float','1.23','[]'))
```
* Assignee @frbattid 