### PR TITLE
feature/859_use_time_instant_metadata_mongo_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - [BUG] Fix the way a set of notified attributes are processed in OrionMySQLSink, no order must be assumed (#855)
 - [FEATURE] Remove support for XML notifications in all sinks and in the documentation (#448)
 - [BUG] Fix wrong class name in configuration section of OrionSTHSink.md (#852)
+- [FEATURE] When notified, use the TimeInstant metadata instead of the reception time (#859)

--- a/doc/flume_extensions_catalogue/orion_mongo_sink.md
+++ b/doc/flume_extensions_catalogue/orion_mongo_sink.md
@@ -11,9 +11,10 @@ Content:
     * [Important notes](#section2.3)
          * [Hashing based collections](#section2.3.1)
          * [About batching](#section2.3.2)
-* [Programmers guide](#section4)
-    * [`OrionMongoSink` class](#section4.1)
-    * [`MongoBackend` class](#section4.2)
+         * [About `recvTime` and `TimeInstant` metadata](#section2.3.3)
+* [Programmers guide](#section3)
+    * [`OrionMongoSink` class](#section3.1)
+    * [`MongoBackend` class](#section3.2)
 
 ##<a name="section1"></a>Functionality
 `com.iot.telefonica.cygnus.sinks.OrionMongoSink`, or simply `OrionMongosink` is a sink designed to persist NGSI-like context data events within a MongoDB server. Usually, such a context data is notified by a [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance, but could be any other system speaking the <i>NGSI language</i>.
@@ -265,8 +266,13 @@ By default, `OrionMongoSink` has a configured batch size and batch accumulation 
 
 [Top](#top)
 
-##<a name="section4"></a>Programmers guide
-###<a name="section4.1"></a>`OrionSTHSink` class
+###<a name="section2.3.3"></a>About `recvTime` and `TimeInstant` metadata
+By default, `OrionMongoSink` stores the notification reception timestamp. Nevertheless, if (and only if) working in `row` mode and a metadata named `TimeInstant` is notified, then such metadata value is used instead of the reception timestamp. This is useful when wanting to persist a measure generation time (which is thus notified as a `TimeInstant` metadata) instead of the reception time.
+
+[Top](#top)
+
+##<a name="section3"></a>Programmers guide
+###<a name="section3.1"></a>`OrionSTHSink` class
 `OrionMongoSink` extends `OrionMongoBaseSink`, which as any other NGSI-like sink, extends the base `OrionSink`. The methods that are extended are:
 
     void persistBatch(Batch batch) throws Exception;
@@ -283,7 +289,7 @@ A complete configuration as the described above is read from the given `Context`
 
 [Top](#top)
 
-###<a name="section4.2"></a>`MongoBackend` class
+###<a name="section3.2"></a>`MongoBackend` class
 This is a convenience backend class for MongoDB that provides methods to persist the context data both in raw of aggregated format. Relevant methods regarding raw format are:
 
     public void createDatabase(String dbName) throws Exception;

--- a/doc/flume_extensions_catalogue/orion_sth_sink.md
+++ b/doc/flume_extensions_catalogue/orion_sth_sink.md
@@ -11,9 +11,10 @@ Content:
     * [Important notes](#section2.3)
         * [Hashing based collections](#section2.3.1)
         * [About batching](#section2.3.2)
-* [Implementation details](#section4)
-    * [`OrionSTHSink` class](#section4.1)
-    * [`MongoBackend` class](#section4.2)
+        * [About `recvTime` and `TimeInstant` metadata](#section2.3.3)
+* [Implementation details](#section3)
+    * [`OrionSTHSink` class](#section3.1)
+    * [`MongoBackend` class](#section3.2)
 
 ##<a name="section1"></a>Functionality
 `com.iot.telefonica.cygnus.sinks.OrionSTHSink`, or simply `OrionSTHSink` is a sink designed to persist NGSI-like context data events within a MongoDB server in an aggregated way. Usually, such a context data is notified by a [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance, but could be any other system speaking the <i>NGSI language</i>.
@@ -270,8 +271,11 @@ Thus, `OrionSTHSink` does not implement a real batching mechanism as usual. Plea
 
 [Top](#top)
 
-##<a name="section4"></a>Programmers guide
-###<a name="section4.1"></a>`OrionSTHSink` class
+###<a name="section2.3.3"></a>About `recvTime` and `TimeInstant` metadata
+By default, `OrionSTHSink` stores the notification reception timestamp. Nevertheless, if a metadata named `TimeInstant` is notified, then such metadata value is used instead of the reception timestamp. This is useful when wanting to persist a measure generation time (which is thus notified as a `TimeInstant` metadata) instead of the reception time.
+
+##<a name="section3"></a>Programmers guide
+###<a name="section3.1"></a>`OrionSTHSink` class
 `OrionSTHSink` extends `OrionMongoBaseSink`, which as any other NGSI-like sink, extends the base `OrionSink`. The methods that are extended are:
 
     void persistBatch(Batch batch) throws Exception;
@@ -288,7 +292,7 @@ A complete configuration as the described above is read from the given `Context`
 
 [Top](#top)
 
-###<a name="section4.2"></a>`MongoBackend` class
+###<a name="section3.2"></a>`MongoBackend` class
 This is a convenience backend class for MongoDB that provides methods to persist the context data both in raw of aggregated format. Relevant methods regarding raw format are:
 
     public void createDatabase(String dbName) throws Exception;

--- a/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackend.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackend.java
@@ -72,7 +72,6 @@ public interface MongoBackend {
      * @param dbName
      * @param collectionName
      * @param recvTimeTs
-     * @param recvTime
      * @param entityId
      * @param entityType
      * @param attrName
@@ -81,7 +80,7 @@ public interface MongoBackend {
      * @param attrMd
      * @throws Exception
      */
-    void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs, String recvTime,
+    void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs,
             String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd)
         throws Exception;
     

--- a/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -191,7 +191,6 @@ public class MongoBackendImpl implements MongoBackend {
      * @param dbName
      * @param collectionName
      * @param recvTimeTs
-     * @param recvTime
      * @param entityId
      * @param entityType
      * @param attrName
@@ -201,14 +200,14 @@ public class MongoBackendImpl implements MongoBackend {
      * @throws Exception
      */
     @Override
-    public void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs, String recvTime,
+    public void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs,
             String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd)
         throws Exception {
         // preprocess some values
         double value = new Double(attrValue);
         GregorianCalendar calendar = new GregorianCalendar();
         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-        calendar.setTimeInMillis(recvTimeTs * 1000);
+        calendar.setTimeInMillis(recvTimeTs);
         
         // insert the data in an aggregated fashion for each resolution type
         insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -20,6 +20,7 @@ package com.telefonica.iot.cygnus.sinks;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import static com.telefonica.iot.cygnus.sinks.OrionMongoBaseSink.LOGGER;
+import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
 import java.util.Date;
 import org.bson.Document;
@@ -175,7 +176,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
         @Override
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
-            long recvTimeTs = cygnusEvent.getRecvTimeTs();
+            long notifiedRecvTimeTs = cygnusEvent.getRecvTimeTs();
 
             // get the event body
             ContextElement contextElement = cygnusEvent.getContextElement();
@@ -197,6 +198,19 @@ public class OrionMongoSink extends OrionMongoBaseSink {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
                 String attrValue = contextAttribute.getContextValue(false);
+                String attrMetadata = contextAttribute.getContextMetadata();
+                
+                // check if the metadata contains a TimeInstant value; use the notified reception time instead
+                Long recvTimeTs;
+
+                Long timeInstant = Utils.getTimeInstant(attrMetadata);
+
+                if (timeInstant != null) {
+                    recvTimeTs = timeInstant;
+                } else {
+                    recvTimeTs = notifiedRecvTimeTs;
+                } // if else
+                
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
                 Document doc = createDoc(recvTimeTs, entityId, entityType, attrName, attrType, attrValue);

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -157,10 +157,10 @@ public class OrionSTHSink extends OrionMongoBaseSink {
 
             // insert the data
             LOGGER.info("[" + this.getName() + "] Persisting data at OrionSTHSink. Database: " + dbName
-                    + ", Collection: " + collectionName + ", Data: " + recvTimeTs / 1000 + "," + recvTime + ","
+                    + ", Collection: " + collectionName + ", Data: " + recvTimeTs + "," + recvTime + ","
                     + entityId + "," + entityType + "," + attrName + "," + entityType + "," + attrValue + ","
                     + attrMetadata);
-            backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs / 1000, recvTime,
+            backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs,
                     entityId, entityType, attrName, attrType, attrValue, attrMetadata);
         } // for
     } // persistOne

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -135,7 +135,7 @@ public class OrionSTHSink extends OrionMongoBaseSink {
             Long recvTimeTs;
             String recvTime;
 
-            Long timeInstant = getTimeInstant(attrMetadata);
+            Long timeInstant = Utils.getTimeInstant(attrMetadata);
 
             if (timeInstant != null) {
                 recvTimeTs = timeInstant;
@@ -164,24 +164,5 @@ public class OrionSTHSink extends OrionMongoBaseSink {
                     entityId, entityType, attrName, attrType, attrValue, attrMetadata);
         } // for
     } // persistOne
-    
-    private Long getTimeInstant(String metadata) throws Exception {
-        Long res = null;
-        JSONParser parser = new JSONParser();
-        JSONArray mds = (JSONArray) parser.parse(metadata);
-        
-        for (Object mdObject : mds) {
-            JSONObject md = (JSONObject) mdObject;
-            String mdName = (String) md.get("name");
-            
-            if (mdName.equals("TimeInstant")) {
-                String mdValue = (String) md.get("value");
-                res = new Long(mdValue);
-                break;
-            } // if
-        } // for
-        
-        return res;
-    } // getTimeInstant
     
 } // OrionSTHSink

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -32,6 +32,9 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -200,5 +203,24 @@ public final class Utils {
         
         return true;
     } // isANumber
+    
+    public static Long getTimeInstant(String metadata) throws Exception {
+        Long res = null;
+        JSONParser parser = new JSONParser();
+        JSONArray mds = (JSONArray) parser.parse(metadata);
+        
+        for (Object mdObject : mds) {
+            JSONObject md = (JSONObject) mdObject;
+            String mdName = (String) md.get("name");
+            
+            if (mdName.equals("TimeInstant")) {
+                String mdValue = (String) md.get("value");
+                res = new Long(mdValue);
+                break;
+            } // if
+        } // for
+        
+        return res;
+    } // getTimeInstant
         
 } // Utils

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
@@ -168,7 +168,7 @@ public class OrionSTHSinkTest {
         doNothing().doThrow(new Exception()).when(mockMongoBackend).createDatabase(dbName);
         doNothing().doThrow(new Exception()).when(mockMongoBackend).createCollection(dbName, collectionName, 0);
         doNothing().doThrow(new Exception()).when(mockMongoBackend).insertContextDataAggregated(dbName, collectionName,
-                recvTimeTs, recvTime, entityId, entityType, attrName, attrType, attrValue, attrMd);
+                recvTimeTs, entityId, entityType, attrName, attrType, attrValue, attrMd);
     } // setUp
     
     /**


### PR DESCRIPTION
* Implements issue #859 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Raw format:
```
time=2016-03-11T09:11:31.893CET | lvl=INFO | trans=1457683887-399-0000000000 | svc=test | subsvc=timeinstant | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[247] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "pressure",            "type" : "mmhg",            "value" : "720",            "metadatas": [              {                "name": "TimeInstant",                "type": "string",                "value": "1999-06-23 12:34:02.012"              }            ]          },          {            "name" : "humidity",            "type" : "percentage",            "value" : "42",            "metadatas": [  ]          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
..
time=2016-03-11T09:11:37.027CET | lvl=INFO | trans=1457683887-399-0000000000 | svc=test | subsvc=timeinstant | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[328] : [mongo-sink] Persisting data at OrionMongoSink. Database: sth_test, Collection: sth_/timeinstant_Room1_Room, Data: [Document{{recvTime=Fri Mar 11 09:11:31 CET 2016, attrName=temperature, attrType=centigrade, attrValue=26.5}}, Document{{recvTime=Wed Jun 23 00:34:02 CEST 1999, attrName=pressure, attrType=mmhg, attrValue=720}}, Document{{recvTime=Fri Mar 11 09:11:31 CET 2016, attrName=humidity, attrType=percentage, attrValue=42}}]
..
..
> db['sth_/timeinstant_Room1_Room'].find()
{ "_id" : ObjectId("56e27db91ed9d409c8e94576"), "recvTime" : ISODate("2016-03-11T08:11:31.897Z"), "attrName" : "temperature", "attrType" : "centigrade", "attrValue" : "26.5" }
{ "_id" : ObjectId("56e27db91ed9d409c8e94577"), "recvTime" : ISODate("1999-06-22T22:34:02.012Z"), "attrName" : "pressure", "attrType" : "mmhg", "attrValue" : "720" }
{ "_id" : ObjectId("56e27db91ed9d409c8e94578"), "recvTime" : ISODate("2016-03-11T08:11:31.897Z"), "attrName" : "humidity", "attrType" : "percentage", "attrValue" : "42" }
```

Aggregated format (it is tested since the Utils.getTimeInstant() function has changed):
```
time=2016-03-11T09:50:13.986CET | lvl=INFO | trans=1457686210-434-0000000000 | svc=test | subsvc=timeinstant | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[247] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "pressure",            "type" : "mmhg",            "value" : "720",            "metadatas": [              {                "name": "TimeInstant",                "type": "string",                "value": "1999-06-23 12:34:02.012"              }            ]          },          {            "name" : "humidity",            "type" : "percentage",            "value" : "42",            "metadatas": [  ]          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
..
time=2016-03-11T09:50:15.241CET | lvl=INFO | trans=1457686210-434-0000000000 | svc=test | subsvc=timeinstant | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[159] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_test, Collection: sth_/timeinstant_Room1_Room.aggr, Data: 1457686213988,2016-03-11T08:50:13.988Z,Room1,Room,temperature,Room,26.5,[]
time=2016-03-11T09:50:15.530CET | lvl=INFO | trans=1457686210-434-0000000000 | svc=test | subsvc=timeinstant | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[159] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_test, Collection: sth_/timeinstant_Room1_Room.aggr, Data: 930090842012,1999-06-22T22:34:02.12Z,Room1,Room,pressure,Room,720,[{"name":"TimeInstant","type":"string","value":"1999-06-23 12:34:02.012"}]
time=2016-03-11T09:50:15.598CET | lvl=INFO | trans=1457686210-434-0000000000 | svc=test | subsvc=timeinstant | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[159] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_test, Collection: sth_/timeinstant_Room1_Room.aggr, Data: 1457686213988,2016-03-11T08:50:13.988Z,Room1,Room,humidity,Room,42,[]
..
..
{ "_id" : { "attrName" : "temperature", "origin" : ISODate("2016-01-01T00:00:00Z"), "resolution" : "month", "range" : "year" }, "points" : [ { "offset" : 1, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 2, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 3, "samples" : 1, "sum" : 26.5, "sum2" : 702.25, "min" : 26.5, "max" : 26.5 }, { "offset" : 4, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 5, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 6, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 7, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 8, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 9, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 10, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 11, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 12, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity } ], "attrType" : "centigrade" }
{ "_id" : { "attrName" : "pressure", "origin" : ISODate("1999-01-01T00:00:00Z"), "resolution" : "month", "range" : "year" }, "points" : [ { "offset" : 1, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 2, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 3, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 4, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 5, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 6, "samples" : 1, "sum" : 720, "sum2" : 518400, "min" : 720, "max" : 720 }, { "offset" : 7, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 8, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 9, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 10, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 11, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 12, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity } ], "attrType" : "mmhg" }
{ "_id" : { "attrName" : "humidity", "origin" : ISODate("2016-01-01T00:00:00Z"), "resolution" : "month", "range" : "year" }, "points" : [ { "offset" : 1, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 2, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 3, "samples" : 1, "sum" : 42, "sum2" : 1764, "min" : 42, "max" : 42 }, { "offset" : 4, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 5, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 6, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 7, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 8, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 9, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 10, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 11, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity }, { "offset" : 12, "samples" : 0, "sum" : 0, "sum2" : 0, "min" : Infinity, "max" : -Infinity } ], "attrType" : "percentage" }
```
* Assignee @pcoello25