### PR TITLE
feature/678_ignore_white_space_based_string_values

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,3 +11,4 @@
 - [HARDENING] Add docker and support badges to the README (#858)
 - [HARDENING] Add a management API method for reseting the statistics (#851)
 - [HARDENING] Remove deprecated configuration parameters in OrionHDFSSink (#868)
+- [HARDENING] When configured, ignore white space-based string attributes (#678)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,4 +11,4 @@
 - [HARDENING] Add docker and support badges to the README (#858)
 - [HARDENING] Add a management API method for reseting the statistics (#851)
 - [HARDENING] Remove deprecated configuration parameters in OrionHDFSSink (#868)
-- [HARDENING] When configured, ignore white space-based string attributes (#678)
+- [FEATURE] When configured, ignore white space-based string attributes (#678)

--- a/README.md
+++ b/README.md
@@ -263,18 +263,20 @@ Detailed information regarding Cygnus can be found in the [Installation and Admi
   <tr><td>OrionDynamoDBSink</td><td>First implementation</td><td>0.11.0</td></tr>
   <tr><td rowspan="2">OrionKafkaSink</td><td>First implementation</td><td>0.9.0</td></tr>
   <tr><td>Batching mechanims</td><td>0.11.0</td></tr>
-  <tr><td rowspan="4">OrionMongoSink</td><td>First implementation</td><td>0.8.0</td></tr>
+  <tr><td rowspan="5">OrionMongoSink</td><td>First implementation</td><td>0.8.0</td></tr>
   <tr><td>Hash based collections</td><td>0.8.1</td></tr>
   <tr><td>Batching support</td><td>0.12.0</td></tr>
   <tr><td>Time and size-based data management policies</td><td>0.13.0</td></tr>
+  <tr><td>Ignore white space-based attribute values</td><td>0.14.0</td></tr>
   <tr><td rowspan="2">OrionMySQLSink</td><td>First implementation</td><td>0.2.0</td></tr>
   <tr><td>Batching mechanism</td><td>0.10.0</td></tr>
-  <tr><td rowspan="6">OrionSTHSink</td><td>First implementation</td><td>0.8.0</td></tr>
+  <tr><td rowspan="7">OrionSTHSink</td><td>First implementation</td><td>0.8.0</td></tr>
   <tr><td>Hash based collections</td><td>0.8.1</td></tr>
   <tr><td>TimeInstant metadata as reception time</td><td>0.12.0</td></tr>
   <tr><td>Batching mechanism</td><td>0.13.0</td></tr>
   <tr><td>Time and size-based data management policies</td><td>0.13.0</td></tr>
   <tr><td>String-based aggregation (occurrences)</td><td>0.14.0</td></tr>
+  <tr><td>Ignore white space-based attribute values</td><td>0.14.0</td></tr>
   <tr><td>OrionPostgreSQLSink</td><td>First implementation</td><td>0.12.0</d></tr>
   <tr><td rowspan="2">OrionTestSink</td><td>First implementation</td><td>0.7.0</td></tr>
   <tr><td>Batching mechanism</td><td>0.12.0</td></tr>

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -247,6 +247,8 @@ cygnusagent.sinks.mongo-sink.channel = mongo-channel
 # cygnusagent.sinks.mongo-sink.collection_size = 0
 # The oldest data (according to insertion time) will be removed if the number of documents in the data collections goes beyond the specified value. Set to 0 if not wanting this policy
 # cygnusagent.sinks.mongo-sink.max_documents = 0
+# true if white space-based attribute values must be ignored
+# cygnusagent.sinks.mongo-sink.ignore_white_spaces = true
 
 # ============================================
 # OrionSTHSink configuration
@@ -280,6 +282,8 @@ cygnusagent.sinks.sth-sink.channel = sth-channel
 # cygnusagent.sinks.sth-sink.batch_ttl = 10
 # Collections will be removed if older than the value specified in seconds. Set to 0 if not wanting this policy.
 # cygnusagent.sinks.sth-sink.data_expiration = 0
+# true if white space-based attribute values must be ignored
+# cygnusagent.sinks.sth-sink.ignore_white_spaces = true
 
 #=============================================
 # OrionKafkaSink configuration

--- a/doc/flume_extensions_catalogue/orion_mongo_sink.md
+++ b/doc/flume_extensions_catalogue/orion_mongo_sink.md
@@ -214,6 +214,7 @@ NOTE: `mongo` is the MongoDB CLI for querying the data.
 | data_expiration | no | 0 | Collections will be removed if older than the value specified in seconds. The reference of time is the one stored in the `recvTime` property. Set to 0 if not wanting this policy. |
 | collections_size | no | 0 | The oldest data (according to insertion time) will be removed if the size of the data collection gets bigger than the value specified in bytes. Notice that the size-based truncation policy takes precedence over the time-based one. Set to 0 if not wanting this policy. Minimum value (different than 0) is 4096 bytes. |
 | max_documents | no | 0 | The oldest data (according to insertion time) will be removed if the number of documents in the data collections goes beyond the specified value. Set to 0 if not wanting this policy. |
+| ignore\_white\_spaces | no | true | <i>true</i> if exclusively white space-based attribute values must be ignored, <i>false</i> otherwise. |
 
 A configuration example could be:
 
@@ -239,6 +240,7 @@ A configuration example could be:
     cygnusagent.sinks.mongo-sink.data_expiration = 0
     cygnusagent.sinks.mongo-sink.collections_size = 0
     cygnusagent.sinks.mongo-sink.max_documents = 0
+    cygnusagent.sinks.mongo-sink.ignore_white_spaces = true
 
 [Top](#top)
 

--- a/doc/flume_extensions_catalogue/orion_sth_sink.md
+++ b/doc/flume_extensions_catalogue/orion_sth_sink.md
@@ -234,6 +234,7 @@ NOTES:
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
 | data_expiration | no | 0 | Collections will be removed if older than the value specified in seconds. The reference of time is the one stored in the `_id.origin` property. Set to 0 if not wanting this policy. |
+| ignore\_white\_spaces | no | true | <i>true</i> if exclusively white space-based attribute values must be ignored, <i>false</i> otherwise. |
 
 A configuration example could be:
 
@@ -255,6 +256,7 @@ A configuration example could be:
     cygnusagent.sinks.sth-sink.batch_timeout = 30
     cygnusagent.sinks.sth-sink.batch_ttl = 10
     cygnusagent.sinks.sth-sink.data_expiration = 0
+    cygnusagent.sinks.sth-sink.ignore_white_spaces = true
 
 [Top](#top)
 

--- a/doc/installation_and_administration_guide/cygnus_agent_conf.md
+++ b/doc/installation_and_administration_guide/cygnus_agent_conf.md
@@ -273,6 +273,8 @@ cygnusagent.sinks.mongo-sink.batch_size = 100
 cygunsagent.sinks.mongo-sink.batch_timeout = 30
 # number of retries upon persistence error
 cygnusagent.sinks.mongo-sink.batch_ttl = 10
+# true if white space-based attribute values must be ignored
+cygnusagent.sinks.mongo-sink.ignore_white_spaces = true
 
 # ============================================
 # OrionSTHSink configuration
@@ -302,6 +304,8 @@ cygnusagent.sinks.sth-sink.batch_size = 100
 cygnusagent.sinks.sth-sink.batch_timeout = 30
 # number of retries upon persistence error
 cygnusagent.sinks.sth-sink.batch_ttl = 10
+# true if white space-based attribute values must be ignored
+cygnusagent.sinks.sth-sink.ignore_white_spaces = true
 
 #=============================================
 # OrionKafkaSink configuration

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -42,6 +42,7 @@ public abstract class OrionMongoBaseSink extends OrionSink {
     protected boolean shouldHash;
     protected MongoBackendImpl backend;
     protected long dataExpiration;
+    protected boolean ignoreWhiteSpaces;
 
     /**
      * Gets the mongo hosts. It is protected since it is used by the tests.
@@ -127,6 +128,18 @@ public abstract class OrionMongoBaseSink extends OrionSink {
 
         dataExpiration = context.getLong("data_expiration", 0L);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (data_expiration=" + dataExpiration + ")");
+        
+        String ignoreWhiteSpacesStr = context.getString("ignore_white_spaces", "true");
+        
+        if (ignoreWhiteSpacesStr.equals("true") || ignoreWhiteSpacesStr.equals("false")) {
+            ignoreWhiteSpaces = Boolean.valueOf(ignoreWhiteSpacesStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (ignore_white_spaces="
+                + ignoreWhiteSpacesStr + ")");
+        }  else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (ignore_white_spaces="
+                + ignoreWhiteSpacesStr + ") -- Must be 'true' or 'false'");
+        }  // if else
         
         super.configure(context);
     } // configure

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -200,6 +200,11 @@ public class OrionMongoSink extends OrionMongoBaseSink {
                 String attrValue = contextAttribute.getContextValue(false);
                 String attrMetadata = contextAttribute.getContextMetadata();
                 
+                // check if the attribute value is based on white spaces
+                if (ignoreWhiteSpaces && attrValue.trim().length() == 0) {
+                    continue;
+                } // if
+                
                 // check if the metadata contains a TimeInstant value; use the notified reception time instead
                 Long recvTimeTs;
 
@@ -285,6 +290,12 @@ public class OrionMongoSink extends OrionMongoBaseSink {
                 String attrName = contextAttribute.getName();
                 String attrType = contextAttribute.getType();
                 String attrValue = contextAttribute.getContextValue(false);
+                
+                // check if the attribute value is based on white spaces
+                if (ignoreWhiteSpaces && attrValue.trim().length() == 0) {
+                    continue;
+                } // if
+                
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
                 doc.append(attrName, attrValue);
@@ -323,6 +334,11 @@ public class OrionMongoSink extends OrionMongoBaseSink {
     
     private void persistAggregation(MongoDBAggregator aggregator) throws Exception {
         ArrayList<Document> aggregation = aggregator.getAggregation();
+        
+        if (aggregation.isEmpty()) {
+            return;
+        } // if
+        
         String dbName = aggregator.getDbName(enableLowercase);
         String collectionName = aggregator.getCollectionName(enableLowercase);
         LOGGER.info("[" + this.getName() + "] Persisting data at OrionMongoSink. Database: "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -119,6 +119,12 @@ public class OrionSTHSink extends OrionMongoBaseSink {
             String attrType = contextAttribute.getType();
             String attrValue = contextAttribute.getContextValue(false);
             String attrMetadata = contextAttribute.getContextMetadata();
+            
+            // check if the attribute value is based on white spaces
+            if (ignoreWhiteSpaces && attrValue.trim().length() == 0) {
+                continue;
+            } // if
+            
             LOGGER.debug("[" + this.getName() + "] Processing context attribute (name=" + attrName + ", type="
                     + attrType + ")");
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -152,7 +152,7 @@ public class OrionSTHSink extends OrionMongoBaseSink {
             // insert the data
             LOGGER.info("[" + this.getName() + "] Persisting data at OrionSTHSink. Database: " + dbName
                     + ", Collection: " + collectionName + ", Data: " + recvTimeTs + ","
-                    + entityId + "," + entityType + "," + attrName + "," + entityType + "," + attrValue + ","
+                    + entityId + "," + entityType + "," + attrName + "," + attrType + "," + attrValue + ","
                     + attrMetadata);
             backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs,
                     entityId, entityType, attrName, attrType, attrValue, attrMetadata);


### PR DESCRIPTION
* Implements issue #678 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

`OrionMongoSink`:
```
time=2016-03-17T07:43:05.307CET | lvl=INFO | trans=1458196908-636-0000000000 | svc=test | subsvc=testwhitespaces | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[263] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "test_attr_1",            "type" : "string",            "value" : "       "          },          {            "name" : "test_attr_2",            "type" : "string",            "value" : "this is a tring"          }        ],        "type" : "test_type",        "isPattern" : "false",        "id" : "test_ID"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
time=2016-03-17T07:43:10.411CET | lvl=INFO | trans=1458196908-636-0000000000 | svc=test | subsvc=testwhitespaces | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[344] : [mongo-sink] Persisting data at OrionMongoSink. Database: sth_test, Collection: sth_/testwhitespaces_test_ID_test_type, Data: [Document{{recvTime=Thu Mar 17 07:43:05 CET 2016, attrName=test_attr_2, attrType=string, attrValue=this is a tring}}]
..
..
> use sth_test;
switched to db sth_test
> db['sth_/testwhitespaces_test_ID_test_type'].find()
{ "_id" : ObjectId("56ea51ff1a11ca9264dc3d08"), "recvTime" : ISODate("2016-03-17T06:43:05.308Z"), "attrName" : "test_attr_2", "attrType" : "string", "attrValue" : "this is a tring" }
```

`OrionSTHSink`:
```
time=2016-03-17T09:30:41.730CET | lvl=INFO | trans=1458203436-759-0000000000 | svc=test | subsvc=testwhitespaces | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[263] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "test_attr_1",            "type" : "string",            "value" : "       "          },          {            "name" : "test_attr_2",            "type" : "string",            "value" : "this is a tring"          }        ],        "type" : "test_type",        "isPattern" : "false",        "id" : "test_ID"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
time=2016-03-17T09:30:43.110CET | lvl=INFO | trans=1458203436-759-0000000000 | svc=test | subsvc=testwhitespaces | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[153] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_test, Collection: sth_/testwhitespaces_test_ID_test_type.aggr, Data: 1458203441754,test_ID,test_type,test_attr_2,test_type,this is a tring,[]
..
..
> use sth_test;
switched to db sth_test
> db['sth_/testwhitespaces_test_ID_test_type.aggr'].find()
{ "_id" : { "attrName" : "test_attr_2", "origin" : ISODate("2016-01-01T00:00:00Z"), "resolution" : "month", "range" : "year" }, "points" : [ { "offset" : 1, "samples" : 0, "occur" : {  } }, { "offset" : 2, "samples" : 0, "occur" : { "this is a tring" : 1 } }, { "offset" : 3, "samples" : 1, "occur" : {  } }, { "offset" : 4, "samples" : 0, "occur" : {  } }, { "offset" : 5, "samples" : 0, "occur" : {  } }, { "offset" : 6, "samples" : 0, "occur" : {  } }, { "offset" : 7, "samples" : 0, "occur" : {  } }, { "offset" : 8, "samples" : 0, "occur" : {  } }, { "offset" : 9, "samples" : 0, "occur" : {  } }, { "offset" : 10, "samples" : 0, "occur" : {  } }, { "offset" : 11, "samples" : 0, "occur" : {  } }, { "offset" : 12, "samples" : 0, "occur" : {  } } ], "attrType" : "string" }
```
* Assignee @pcoello25 