### PR TITLE
hardening/890_fix_the_java_version_problem

### DIFF
--- a/docker/0.Dockerfile.jar-compiler
+++ b/docker/0.Dockerfile.jar-compiler
@@ -32,7 +32,7 @@ WORKDIR /tmp
 RUN yum update -y && \
 	yum install -y wget tar which \
 	rpm-build java-1.7.0-openjdk-devel \
-ENV JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.95-2.6.4.0.el7_2.x86_64/jre
+ENV JAVA_HOME /etc/alternatives/jre
 
 
 ###############################################################################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,9 @@ MAINTAINER Herman Junge <herman.junge@telefonica.com>
 ###############################################################################
 
 
-RUN yum update -y
-RUN yum install -y wget tar git java-1.7.0-openjdk.x86_64
-ENV JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.95-2.6.4.0.el7_2.x86_64/jre
+RUN yum update -y && \
+	yum install -y wget tar git java-1.7.0-openjdk.x86_64
+ENV JAVA_HOME /etc/alternatives/jre
 
 
 ###############################################################################


### PR DESCRIPTION
* Fixes issue #890 
* No tests are required
* Assignee @frbattid

Guilty of being a completely **n00b** in Java...

Thing is, `/etc/alternatives/jre` was the solution to all my problems, and you don't need to keep track of fixing the `Dockerfile` everytime the `yum` package changed the solution. Please, do merge :-)