### PR TITLE
hardening/877_improve_elements_naming_root_subservice_0.13.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [BUG] Fix the way a set of notified attributes are processed in OrionMySQLSink, no order must be assumed (#855)
 - [FEATURE] When notified, use the TimeInstant metadata instead of the reception time (#859)
+- [HARDENING] Improve the different elements naming when notified/default service path is / (#877)

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -43,9 +43,9 @@ cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.Ori
 # URL target
 # cygnusagent.sources.http-source.handler.notification_target = /notify
 # Default service (service semantic depends on the persistence sink)
-# cygnusagent.sources.http-source.handler.default_service = def_serv
+# cygnusagent.sources.http-source.handler.default_service = default
 # Default service path (service path semantic depends on the persistence sink)
-# cygnusagent.sources.http-source.handler.default_service_path = def_serv_path
+# cygnusagent.sources.http-source.handler.default_service_path = /
 # Number of channel re-injection retries before a Flume event is definitely discarded (-1 means infinite retries)
 cygnusagent.sources.http-source.handler.events_ttl = 10
 # Source interceptors, do not change

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -132,7 +132,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
             notificationTarget = "/" + notificationTarget;
         } // if
         
-        defaultService = Utils.encode(context.getString(Constants.PARAM_DEFAULT_SERVICE, "def_serv"));
+        defaultService = context.getString(Constants.PARAM_DEFAULT_SERVICE, "def_serv");
         
         if (defaultService.length() > Constants.SERVICE_HEADER_MAX_LEN) {
             LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE + "' parameter length greater than "
@@ -142,7 +142,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
         } // if
         
         LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE + "=" + defaultService + ")");
-        defaultServicePath = Utils.encode(context.getString(Constants.PARAM_DEFAULT_SERVICE_PATH, "def_serv_path"));
+        defaultServicePath = context.getString(Constants.PARAM_DEFAULT_SERVICE_PATH, "def_serv_path");
         
         if (defaultServicePath.length() > Constants.SERVICE_PATH_HEADER_MAX_LEN) {
             LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH + "' parameter length greater "
@@ -200,7 +200,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
                     throw new HTTPBadRequestException("'fiware-service' header length greater than "
                             + Constants.SERVICE_HEADER_MAX_LEN + ")");
                 } else {
-                    service = Utils.encode(headerValue);
+                    service = headerValue;
                 } // if else
             } else if (headerName.equals(Constants.HTTP_HEADER_FIWARE_SERVICE_PATH)) {
                 if (headerValue.length() > Constants.SERVICE_PATH_HEADER_MAX_LEN) {
@@ -208,8 +208,11 @@ public class OrionRestHandler implements HTTPSourceHandler {
                             + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
                     throw new HTTPBadRequestException("'fiware-servicePath' header length greater than "
                             + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
+                } else if (!headerValue.startsWith("/")) {
+                    LOGGER.warn("Bad HTTP notification ('fiware-servicePath' heacder value must start with '/'");
+                    throw new HTTPBadRequestException("'fiware-servicePath' header value must start with '/'");
                 } else {
-                    servicePath = Utils.encode(headerValue);
+                    servicePath = headerValue;
                 } // if else
             } // if else if
         } // while

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -431,7 +431,7 @@ public class OrionCKANSink extends OrionSink {
      * @throws Exception
      */
     private String buildOrgName(String fiwareService) throws Exception {
-        String orgName = fiwareService;
+        String orgName = Utils.encode(fiwareService);
 
         if (orgName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building orgName=fiwareService (" + orgName + ") and its length is "
@@ -452,10 +452,10 @@ public class OrionCKANSink extends OrionSink {
     private String buildPkgName(String fiwareService, String fiwareServicePath) throws Exception {
         String pkgName;
 
-        if (fiwareServicePath.length() == 0) {
-            pkgName = fiwareService;
+        if (fiwareServicePath.equals("/")) {
+            pkgName = Utils.encode(fiwareService);
         } else {
-            pkgName = fiwareService + "_" + fiwareServicePath;
+            pkgName = Utils.encode(fiwareService) + "_" + Utils.encode(fiwareServicePath);
         } // if else
 
         if (pkgName.length() > Constants.MAX_NAME_LEN) {
@@ -473,7 +473,7 @@ public class OrionCKANSink extends OrionSink {
      * @throws Exception
      */
     private String buildResName(String destination) throws Exception {
-        String resName = destination;
+        String resName = Utils.encode(destination);
 
         if (resName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building resName=destination (" + resName + ") and its length is greater "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -337,10 +337,11 @@ public class OrionDynamoDBSink extends OrionSink {
 
         switch (dataModel) {
             case DMBYENTITY:
-                tableName = service + "_" + servicePath + "_" + destination;
+                tableName = Utils.encode(service) + (servicePath.equals("/") ? "" : "_" + Utils.encode(servicePath))
+                        + "_" + Utils.encode(destination);
                 break;
             case DMBYSERVICEPATH:
-                tableName = service + "_" + servicePath;
+                tableName = Utils.encode(service) + (servicePath.equals("/") ? "" : "_" + Utils.encode(servicePath));
                 break;
             default:
                 throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -32,7 +32,6 @@ import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.apache.flume.Context;
@@ -261,7 +260,6 @@ public class OrionHDFSSink extends OrionSink {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (cosmos_port=" + port + ")"
                         + " -- DEPRECATED, use hdfs_port instead");
             }  // if else
-            
         } else {
             port = "14000";
             LOGGER.debug("[" + this.getName() + "] Defaulting to hdfs_port=14000");
@@ -376,7 +374,6 @@ public class OrionHDFSSink extends OrionSink {
             } else {
                 LOGGER.debug("[" + this.getName() + "] Reading configuration (hive.port=" + hivePort + ")");
             }  // if else
-            
         } else if (hivePortOld != null && hivePortOld.length() > 0) {
             hivePort = hivePortOld;
             intHivePort = Integer.parseInt(hivePort);
@@ -636,7 +633,7 @@ public class OrionHDFSSink extends OrionSink {
             firstLevel = buildFirstLevel(service);
             secondLevel = buildSecondLevel(servicePath);
             thirdLevel = buildThirdLevel(destination);
-            hdfsFolder = firstLevel + "/" + secondLevel + "/" + thirdLevel;
+            hdfsFolder = firstLevel + (servicePath.equals("/") ? "/" : "/" + secondLevel + "/") + thirdLevel;
             hdfsFile = hdfsFolder + "/" + thirdLevel + ".txt";
         } // initialize
 
@@ -1152,7 +1149,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildFirstLevel(String fiwareService) throws Exception {
-        String firstLevel = fiwareService;
+        String firstLevel = Utils.encode(fiwareService);
 
         if (firstLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building firstLevel=fiwareService (fiwareService=" + fiwareService + ") "
@@ -1171,7 +1168,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildSecondLevel(String fiwareServicePath) throws Exception {
-        String secondLevel = fiwareServicePath;
+        String secondLevel = Utils.encode(fiwareServicePath);
 
         if (secondLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building secondLevel=fiwareServicePath (" + fiwareServicePath + ") and "
@@ -1189,7 +1186,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildThirdLevel(String destination) throws Exception {
-        String thirdLevel = destination;
+        String thirdLevel = Utils.encode(destination);
 
         if (thirdLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevel=destination (" + destination + ") and its length is "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
@@ -22,6 +22,7 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.Constants;
+import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
 import java.util.Properties;
 import kafka.admin.AdminUtils;
@@ -222,16 +223,21 @@ public class OrionKafkaSink extends OrionSink {
 
             switch (dataModel) {
                 case DMBYSERVICE:
-                    name = service;
+                    name = Utils.encode(service);
                     break;
                 case DMBYSERVICEPATH:
-                    name = servicePath;
+                    if (servicePath.equals("/")) {
+                        throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                                + "dm-by-service-path data model");
+                    } // if
+                    
+                    name = Utils.encode(servicePath);
                     break;
                 case DMBYENTITY:
-                    name = entity;
+                    name = Utils.encode(entity);
                     break;
                 case DMBYATTRIBUTE:
-                    name = attribute;
+                    name = Utils.encode(attribute);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -178,7 +178,7 @@ public abstract class OrionMongoBaseSink extends OrionSink {
      * @throws Exception
      */
     protected String buildDbName(String fiwareService) throws Exception {
-        String dbName = dbPrefix + fiwareService;
+        String dbName = dbPrefix + Utils.encode(fiwareService);
 
         if (dbName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building dbName=fiwareService (" + dbName + ") and its length is greater "
@@ -209,13 +209,19 @@ public abstract class OrionMongoBaseSink extends OrionSink {
 
         switch (dataModel) {
             case DMBYSERVICEPATH:
-                collectionName = fiwareServicePath;
+                if (fiwareServicePath.equals("/")) {
+                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                            + "dm-by-service-path data model");
+                } // if
+                
+                collectionName = Utils.encodeSTH(fiwareServicePath);
                 break;
             case DMBYENTITY:
-                collectionName = fiwareServicePath + "_" + entity;
+                collectionName = Utils.encodeSTH(fiwareServicePath) + "_" + Utils.encode(entity);
                 break;
             case DMBYATTRIBUTE:
-                collectionName = fiwareServicePath + "_" + entity + "_" + attribute;
+                collectionName = Utils.encodeSTH(fiwareServicePath) + "_" + Utils.encode(entity)
+                        + "_" + Utils.encode(attribute);
                 break;
             default:
                 // this should never be reached

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoSink.java
@@ -155,7 +155,7 @@ public class OrionMongoSink extends OrionMongoBaseSink {
             entity = cygnusEvent.getEntity();
             attribute = cygnusEvent.getAttribute();
             dbName = buildDbName(service);
-            collectionName = buildCollectionName(dbName, "/" + servicePath, entity, attribute, false, null, null,
+            collectionName = buildCollectionName(dbName, servicePath, entity, attribute, false, null, null,
                     service);
         } // initialize
         

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -297,7 +297,7 @@ public class OrionMySQLSink extends OrionSink {
         } // initialize
         
         private String buildDbName() throws Exception {
-            String name = service;
+            String name = Utils.encode(service);
 
             if (name.length() > Constants.MAX_NAME_LEN) {
                 throw new CygnusBadConfiguration("Building database name '" + name
@@ -312,13 +312,19 @@ public class OrionMySQLSink extends OrionSink {
 
             switch(dataModel) {
                 case DMBYSERVICEPATH:
-                    name = servicePath;
+                    if (servicePath.equals("/")) {
+                        throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                                + "dm-by-service-path data model");
+                    } // if
+                    
+                    name = Utils.encode(servicePath);
                     break;
                 case DMBYENTITY:
-                    name = servicePath + '_' + entity;
+                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity);
                     break;
                 case DMBYATTRIBUTE:
-                    name = servicePath + '_' + entity + '_' + attribute;
+                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity)
+                            + '_' + Utils.encode(attribute);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -261,7 +261,7 @@ public class OrionPostgreSQLSink extends OrionSink {
         } // initialize
 
         private String buildSchemaName() throws Exception {
-            String name = service;
+            String name = Utils.encode(service);
 
             if (name.length() > Constants.MAX_NAME_LEN) {
                 throw new CygnusBadConfiguration("Building schema name '" + name
@@ -276,13 +276,19 @@ public class OrionPostgreSQLSink extends OrionSink {
 
             switch(dataModel) {
                 case DMBYSERVICEPATH:
-                    name = servicePath;
+                    if (servicePath.equals("/")) {
+                        throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                                + "dm-by-service-path data model");
+                    } // if
+                    
+                    name = Utils.encode(servicePath);
                     break;
                 case DMBYENTITY:
-                    name = servicePath + '_' + entity;
+                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity);
                     break;
                 case DMBYATTRIBUTE:
-                    name = servicePath + '_' + entity + '_' + attribute;
+                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity)
+                            + '_' + Utils.encode(attribute);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSTHSink.java
@@ -68,7 +68,7 @@ public class OrionSTHSink extends OrionMongoBaseSink {
         // get some values from the event
         Long notifiedRecvTimeTs = event.getRecvTimeTs();
         String fiwareService = event.getService();
-        String fiwareServicePath = "/" + event.getServicePath(); // this sink uses the removed initial slash
+        String fiwareServicePath = event.getServicePath();
         String destination = event.getEntity();
         ContextElement contextElement = event.getContextElement();
 

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -49,6 +50,9 @@ import org.w3c.dom.NodeList;
 public final class Utils {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(Utils.class);
+    private static final Pattern ENCODEPATTERN = Pattern.compile("[^a-zA-Z0-9\\.\\-]");
+    private static final Pattern ENCODESTHPATTERN = Pattern.compile("[^a-zA-Z0-9\\.\\-\\/]");
+    private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final DateTimeFormatter FORMATTER1 = DateTimeFormat.forPattern(
             "yyyy-MM-dd'T'hh:mm:ss'Z'").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER2 = DateTimeFormat.forPattern(
@@ -66,14 +70,24 @@ public final class Utils {
     
     /**
      * Encodes a string replacing all the non alphanumeric characters by '_' (except by '-' and '.').
+     * This should be only called when building a persistence element name, such as table names, file paths, etc.
      * 
      * @param in
      * @return The encoded version of the input string.
      */
     public static String encode(String in) {
-        String res = in.replaceAll("[^a-zA-Z0-9\\.\\-]", "_");
-        return (res.startsWith("_") ? res.substring(1, res.length()) : res);
+        return ENCODEPATTERN.matcher(in).replaceAll("_");
     } // encode
+    
+    /**
+     * Encodes a string replacing all the non alphanumeric characters by '_' (except by '-', '.' and '/').
+     * This should be only called when building a STH persistence element names.
+     * @param in
+     * @return The encoded version of the input string.
+     */
+    public static String encodeSTH(String in) {
+        return ENCODESTHPATTERN.matcher(in).replaceAll("_");
+    } // encodeSTH
     
     /**
      * Encodes a string replacing all the non alphanumeric characters by '_'.

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -59,7 +59,7 @@ public class OrionRestHandlerTest {
     // constants
     private final String configuredNotificationTarget = "/notify";
     private final String configuredDefaultService = "a.SERV_with-rare chars%@";
-    private final String configuredDefaultServicePath = "a.SERVPATH_with-rare chars%@";
+    private final String configuredDefaultServicePath = "/a.SERVPATH_with-rare chars%@";
     private final String rootServicePath = "/";
     private final String[] notificationHeaderNamesStr = {"user-agent", "content-type", "fiware-service",
         "fiware-servicepath"};
@@ -68,7 +68,7 @@ public class OrionRestHandlerTest {
     private final String notificationRequestMethod = "POST";
     private final String notificationUserAgent = "whatever/0.12.7";
     private final String notificationService = "a.SERV_with-rare chars%@";
-    private final String notificationServicePath = "a.SERVPATH_with-rare chars%@";
+    private final String notificationServicePath = "/a.SERVPATH_with-rare chars%@";
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -112,8 +112,8 @@ public class OrionRestHandlerTest {
         System.out.println("Testing 'configure' method from class 'OrionRestHandler'");
         handler.configure(context);
         assertEquals(configuredNotificationTarget, handler.getNotificationTarget());
-        assertEquals(TestUtils.encode(configuredDefaultService), handler.getDefaultService());
-        assertEquals(TestUtils.encode(configuredDefaultServicePath), handler.getDefaultServicePath());
+        assertEquals(configuredDefaultService, handler.getDefaultService());
+        assertEquals(configuredDefaultServicePath, handler.getDefaultServicePath());
     } // testConfigure
 
     /**
@@ -135,11 +135,9 @@ public class OrionRestHandlerTest {
             assertTrue(eventHeaders.get("content-type").equals("application/json")
                     || eventHeaders.get("content-type").equals("application/xml"));
             assertTrue(eventHeaders.containsKey(TestConstants.HEADER_NOTIFIED_SERVICE));
-            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE),
-                    TestUtils.encode(notificationService));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE), notificationService);
             assertTrue(eventHeaders.containsKey(TestConstants.HEADER_NOTIFIED_SERVICE_PATH));
-            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE_PATH),
-                    TestUtils.encode(notificationServicePath));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE_PATH), notificationServicePath);
             assertTrue(eventMessage.length != 0);
         } catch (Exception e) {
             fail(e.getMessage());
@@ -160,11 +158,9 @@ public class OrionRestHandlerTest {
             assertTrue(eventHeaders.get("content-type").equals("application/json")
                     || eventHeaders.get("content-type").equals("application/xml"));
             assertTrue(eventHeaders.containsKey(TestConstants.HEADER_NOTIFIED_SERVICE));
-            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE),
-                    TestUtils.encode(notificationService));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE), notificationService);
             assertTrue(eventHeaders.containsKey(TestConstants.HEADER_NOTIFIED_SERVICE_PATH));
-            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE_PATH),
-                    TestUtils.encode(rootServicePath));
+            assertEquals(eventHeaders.get(TestConstants.HEADER_NOTIFIED_SERVICE_PATH), rootServicePath);
             assertTrue(eventMessage.length != 0);
         } catch (Exception e) {
             fail(e.getMessage());


### PR DESCRIPTION
* Implements issue #877 (twin of PR https://github.com/telefonicaid/fiware-cygnus/pull/883)
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Notification sent:
```
time=2016-03-28T12:29:01.776CEST | lvl=INFO | trans=1459160937-570-0000000000 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[261] : Received data ({  "subscriptionId" : "56e2ad4e8001ff5e0a5260ec",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "type" : "cosa1",        "isPattern" : "false",        "id" : "z0011",        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "111",            "metadatas" : [              {                "name" : "TimeInstant",                "type" : "recvTime",                "value" : "2015-12-12T11:11:11.111Z"              }            ]          }        ]      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
```

`OrionHDFSSink` (dm-by-entity):
```
time=2016-03-28T12:29:28.005CEST | lvl=INFO | trans=1459160937-570-0000000000 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[1058] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (default/z0011_cosa1/z0011_cosa1.txt), Data ({"recvTime":"2016-03-28T10:29:01.814Z","fiwareServicePath":"/","entityId":"z0011","entityType":"cosa1", "temperature":"111", "temperature_md":[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]})
```

`OrionCKANSink` (dm-by-entity):
```
time=2016-03-28T12:31:59.081CEST | lvl=INFO | trans=1459161114-692-0000000000 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionCKANSink[417] : [ckan-sink] Persisting data at OrionCKANSink (orgName=default, pkgName=default, resName=z0011_cosa1, data={"recvTimeTs": "1459161119","recvTime": "2016-03-28T10:31:59.6Z","fiwareServicePath": "/","entityId": "z0011","entityType": "cosa1","attrName": "temperature","attrType": "centigrade","attrValue": "111","attrMd": [{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]})
```

`OrionMySQLSink` (dm-by-service-path and dm-by-entity, respectively):
```
time=2016-03-28T12:34:09.961CEST | lvl=WARN | trans=1459161218-915-0000000000 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[428] : Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
..
time=2016-03-28T12:35:27.823CEST | lvl=INFO | trans=1459161297-633-0000000000 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[495] : [mysql-sink] Persisting data at OrionMySQLSink. Database (default), Table (z0011_cosa1), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1459161301628','2016-03-28T10:35:01.628Z','/','z0011','cosa1','temperature','centigrade','111','[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]'))
```

`OrionMongoSink` (dm-by-entity):
```
time=2016-03-28T12:36:31.629CEST | lvl=INFO | trans=1459161382-258-0000000000 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[328] : [mongo-sink] Persisting data at OrionMongoSink. Database: sth_default, Collection: sth_/_z0011_cosa1, Data: [Document{{recvTime=Sat Dec 12 12:11:11 CET 2015, attrName=temperature, attrType=centigrade, attrValue=111}}]
```

`OrionSTHSink` (dm-by-entity):
```
time=2016-03-28T12:37:30.099CEST | lvl=INFO | trans=1459161444-708-0000000000 | svc=default | subsvc=/ | function=persistOne | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSTHSink[159] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_default, Collection: sth_/_z0011_cosa1.aggr, Data: 1449918671111,2015-12-12T11:11:11.111Z,z0011,cosa1,temperature,cosa1,111,[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]
```
* Assignee @pcoello25 , but LGTM from @XavierVal is also required.