### PR TITLE
feature/807_add_put_log_level_to_api

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,3 +14,4 @@
 - [FEATURE] When configured, ignore white space-based string attributes (#678)
 - [BUG] Fix processing of splited Http responses in HttpBackend (#875)
 - [HARDENING] Improve the different elements naming when notified/default service path is / (#877)
+- [FEATURE] Add implementation for /admin/log route (#807)

--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -8,6 +8,7 @@ Content:
 * [POST `/v1/groupingrules`](#section5)
 * [PUT `/v1/groupingrules`](#section6)
 * [DELETE `/v1/groupingrules`](#section7)
+* [PUT `/admin/log`](#section8)
 
 ##<a name="section1"></a>`GET /v1/version`
 Gets the version of the running software, including the last Git commit:
@@ -211,5 +212,31 @@ Response:
 ```
 {"success":"true"}
 ```
+
+[Top](#top)
+
+##<a name="section8"></a>`PUT /admin/log`
+Updates the logging level of Cygnus, given the logging level as a query parameter.
+
+Valid logging levels are `DEBUG`, `INFO`, `WARNING` (`WARN` also works), `ERROR` and `FATAL`.
+
+```
+PUT http://<cygnus_host>:<management_port>/admin/log?level=<log_level>
+```
+
+Responses:
+
+```
+200 OK
+```
+
+```
+400 Bad Request
+{"error":"Invalid log level"}
+```
+
+```
+400 Bad Request
+{"error":"
 
 [Top](#top)

--- a/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -43,6 +43,8 @@ import org.apache.flume.SinkRunner;
 import org.apache.flume.Source;
 import org.apache.flume.SourceRunner;
 import org.apache.flume.source.http.HTTPSourceHandler;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -131,6 +133,8 @@ public class ManagementInterface extends AbstractHandler {
                     handlePutStats(response);
                 } else if (uri.equals("/v1/groupingrules")) {
                     handlePutGroupingRules(request, response);
+                } else if (uri.equals("/admin/log")) {
+                    handlePutAdminLog(request, response);
                 } else {
                     response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
                     response.getWriter().println(method + " " + uri + " Not implemented");
@@ -596,6 +600,50 @@ public class ManagementInterface extends AbstractHandler {
             LOGGER.error("The specified rule ID does not exist. Details: id=" + id);
         } // if else
     } // handlePutGroupingRules
+    
+    private void handlePutAdminLog(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("json;charset=utf-8");
+        
+        // get the parameters to be updated
+        String logLevel = request.getParameter("level");
+        
+        if (logLevel != null) {
+            if (logLevel.equals("DEBUG")) {
+                LogManager.getRootLogger().setLevel(Level.DEBUG);
+                response.setStatus(HttpServletResponse.SC_OK);
+                //response.getWriter().println("{\"success\":\"true\"}");
+                LOGGER.info("log4j logging level updated to " + logLevel);
+            } else if (logLevel.equals("INFO")) {
+                LogManager.getRootLogger().setLevel(Level.INFO);
+                response.setStatus(HttpServletResponse.SC_OK);
+                //response.getWriter().println("{\"success\":\"true\"}");
+                LOGGER.info("log4j logging level updated to " + logLevel);
+            } else if (logLevel.equals("WARNING") || logLevel.equals("WARN")) {
+                LogManager.getRootLogger().setLevel(Level.WARN);
+                response.setStatus(HttpServletResponse.SC_OK);
+                //response.getWriter().println("{\"success\":\"true\"}");
+                LOGGER.info("log4j logging level updated to " + logLevel);
+            } else if (logLevel.equals("ERROR")) {
+                LogManager.getRootLogger().setLevel(Level.ERROR);
+                response.setStatus(HttpServletResponse.SC_OK);
+                //response.getWriter().println("{\"success\":\"true\"}");
+                LOGGER.info("log4j logging level updated to " + logLevel);
+            } else if (logLevel.equals("FATAL")) {
+                LogManager.getRootLogger().setLevel(Level.FATAL);
+                response.setStatus(HttpServletResponse.SC_OK);
+                //response.getWriter().println("{\"success\":\"true\"}");
+                LOGGER.info("log4j logging level updated to " + logLevel);
+            } else {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.getWriter().println("{\"error\":\"Invalid log level\"}");
+                LOGGER.error("Invalid log level '" + logLevel + "'");
+            } // if else
+        } else {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("{\"error\":\"Log level missing\"}");
+            LOGGER.error("Log level missing in the request");
+        } // if else
+    } // handlePutAdminLog
     
     private void handleDeleteGroupingRules(HttpServletRequest request, HttpServletResponse response)
         throws IOException {


### PR DESCRIPTION
* Implements issue #807 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ ./start_cygnus_mysql.sh INFO console
..
$ ./notification-json-md2.sh http://localhost:5050/notify default /
..
time=2016-03-29T07:06:41.982CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[250] : Starting transaction (1459227982-658-0000000000)
time=2016-03-29T07:06:41.983CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[266] : Received data ({  "subscriptionId" : "56e2ad4e8001ff5e0a5260ec",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "type" : "cosa1",        "isPattern" : "false",        "id" : "z0011",        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "111",            "metadatas" : [              {                "name" : "TimeInstant",                "type" : "recvTime",                "value" : "2015-12-12T11:11:11.111Z"              }            ]          }        ]      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-03-29T07:06:42.006CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[288] : Event put in the channel, id=383390915
time=2016-03-29T07:06:52.840CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[350] : Batch accumulation time reached, the batch will be processed as it is
time=2016-03-29T07:06:52.840CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[402] : Batch completed, persisting it
time=2016-03-29T07:06:52.842CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[495] : [mysql-sink] Persisting data at OrionMySQLSink. Database (default), Table (z0011_cosa1), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1459228002006','2016-03-29T05:06:42.6Z','/','z0011','cosa1','temperature','centigrade','111','[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]'))
time=2016-03-29T07:06:55.046CEST | lvl=INFO | trans=1459227982-658-0000000000 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[406] : Finishing transaction (1459227982-658-0000000000)
..
$ curl -X PUT "http://localhost:8081/admin/log?level=ERROR"
..
time=2016-03-29T07:07:24.281CEST | lvl=INFO | trans= | svc= | subsvc= | function=handle | comp=Cygnus | msg=com.telefonica.iot.cygnus.management.ManagementInterface[110] : Management interface request. Method: PUT, URI: /admin/log
..
$ ./notification-json-md2.sh http://localhost:5050/notify default /
..
<no logs are traced>
..
$ curl -X PUT "http://localhost:8081/admin/log?level=DEBUG"
..
time=2016-03-29T07:08:32.971CEST | lvl=INFO | trans= | svc= | subsvc= | function=handlePutAdminLog | comp=Cygnus | msg=com.telefonica.iot.cygnus.management.ManagementInterface[615] : log4j logging level updated to DEBUG
..
$ ./notification-json-md2.sh http://localhost:5050/notify default /
..
time=2016-03-29T07:09:08.687CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header host received with value localhost:5050
time=2016-03-29T07:09:08.687CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header content-type received with value application/json
time=2016-03-29T07:09:08.687CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header accept received with value application/json
time=2016-03-29T07:09:08.688CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header user-agent received with value orion/0.10.0
time=2016-03-29T07:09:08.688CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header fiware-service received with value default
time=2016-03-29T07:09:08.688CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header fiware-servicepath received with value /
time=2016-03-29T07:09:08.688CEST | lvl=DEBUG | trans=1459227982-658-0000000001 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[203] : Header content-length received with value 658
time=2016-03-29T07:09:08.688CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[250] : Starting transaction (1459227982-658-0000000002)
time=2016-03-29T07:09:08.689CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[266] : Received data ({  "subscriptionId" : "56e2ad4e8001ff5e0a5260ec",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "type" : "cosa1",        "isPattern" : "false",        "id" : "z0011",        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "111",            "metadatas" : [              {                "name" : "TimeInstant",                "type" : "recvTime",                "value" : "2015-12-12T11:11:11.111Z"              }            ]          }        ]      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-03-29T07:09:08.689CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[271] : Adding flume event header (name=content-type, value=application/json)
time=2016-03-29T07:09:08.689CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[274] : Adding flume event header (name=fiware-service, value=default)
time=2016-03-29T07:09:08.689CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[278] : Adding flume event header (name=fiware-servicepath, value=/)
time=2016-03-29T07:09:08.690CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[281] : Adding flume event header (name=transactionId, value=1459227982-658-0000000002)
time=2016-03-29T07:09:08.690CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[288] : Event put in the channel, id=1366357632
time=2016-03-29T07:09:11.450CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[386] : Event got from the channel (id=1366357632, headers={grouped-entities=z0011_cosa1, grouped-servicepaths=/, fiware-servicepath=/, notified-servicepaths=/, content-type=application/json, fiware-service=default, transactionId=1459227982-658-0000000002, notified-entities=z0011_cosa1, timestamp=1459228148690}, bodyLength=658)
time=2016-03-29T07:09:22.809CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider$FileWatcherRunnable[126] : Checking file:/Users/frb/devel/fiware/fiware-cygnus/conf/agent_mysql.conf for changes
time=2016-03-29T07:09:22.853CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=run | comp=Cygnus | msg=com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$ConfigurationReader[229] : The configuration has not changed
time=2016-03-29T07:09:26.464CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[350] : Batch accumulation time reached, the batch will be processed as it is
time=2016-03-29T07:09:26.465CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[402] : Batch completed, persisting it
time=2016-03-29T07:09:26.465CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=persistBatch | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[171] : [mysql-sink] Processing sub-batch regarding the default_/_z0011_cosa1 destination
time=2016-03-29T07:09:26.465CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=aggregate | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink$RowAggregator[375] : [mysql-sink] Processing context element (id=z0011, type=cosa1)
time=2016-03-29T07:09:26.465CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=aggregate | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink$RowAggregator[392] : [mysql-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-03-29T07:09:26.465CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMySQLSink[495] : [mysql-sink] Persisting data at OrionMySQLSink. Database (default), Table (z0011_cosa1), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1459228148690','2016-03-29T05:09:08.690Z','/','z0011','cosa1','temperature','centigrade','111','[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]'))
time=2016-03-29T07:09:26.466CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=createConnection | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver[267] : Connecting to jdbc:mysql://130.206.81.225:3306/?user=cb&password=XXXXXXXXXX
time=2016-03-29T07:09:26.995CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=createDatabase | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[88] : Executing MySQL query 'create database if not exists `default`'
time=2016-03-29T07:09:27.112CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=createTable | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[118] : Executing MySQL query 'create table if not exists `z0011_cosa1` (recvTimeTs text,recvTime text,fiwareServicePath text,entityId text,entityType text,attrName text,attrType text,attrValue text,attrMd text)'
time=2016-03-29T07:09:27.173CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=createConnection | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver[267] : Connecting to jdbc:mysql://130.206.81.225:3306/default?user=cb&password=XXXXXXXXXX
time=2016-03-29T07:09:27.700CEST | lvl=DEBUG | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=insertContextData | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[143] : Executing MySQL query 'insert into `z0011_cosa1` (recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd) values ('1459228148690','2016-03-29T05:09:08.690Z','/','z0011','cosa1','temperature','centigrade','111','[{"name":"TimeInstant","type":"recvTime","value":"2015-12-12T11:11:11.111Z"}]')'
time=2016-03-29T07:09:27.760CEST | lvl=INFO | trans=1459227982-658-0000000002 | svc=default | subsvc=/ | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[406] : Finishing transaction (1459227982-658-0000000002)
```
* Assignee @pcoello25 