### PR TITLE
feature/807_add_get_admin_log_to_api

### DIFF
--- a/doc/installation_and_administration_guide/management_interface.md
+++ b/doc/installation_and_administration_guide/management_interface.md
@@ -8,7 +8,8 @@ Content:
 * [POST `/v1/groupingrules`](#section5)
 * [PUT `/v1/groupingrules`](#section6)
 * [DELETE `/v1/groupingrules`](#section7)
-* [PUT `/admin/log`](#section8)
+* [GET `/admin/log`](#section8)
+* [PUT `/admin/log`](#section9)
 
 ##<a name="section1"></a>`GET /v1/version`
 Gets the version of the running software, including the last Git commit:
@@ -215,7 +216,41 @@ Response:
 
 [Top](#top)
 
-##<a name="section8"></a>`PUT /admin/log`
+##<a name="section8"></a>`GET /admin/log`
+Gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts).
+
+```
+GET http://<cygnus_host>:<management_port>/admin/log
+```
+
+Responses:
+
+```
+200 OK
+{
+    "log4j": {
+        "appenders": [
+            {
+                "layout": "...",
+                "name": "..."
+            }
+        ],
+        "level": "..."
+    },
+    "success": "true"
+}
+```
+
+```
+500 Internal Server Error
+{
+    "error": "..."
+}
+```
+
+[Top](#top)
+
+##<a name="section9"></a>`PUT /admin/log`
 Updates the logging level of Cygnus, given the logging level as a query parameter.
 
 Valid logging levels are `DEBUG`, `INFO`, `WARNING` (`WARN` also works), `ERROR` and `FATAL`.


### PR DESCRIPTION
* Partially implements issue #807 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/admin/log" | python -m json.tool
{
    "log4j": {
        "appenders": [
            {
                "layout": "time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | trans=%X{transactionId} | svc=%X{service} | subsvc=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n",
                "name": "console"
            }
        ],
        "level": "DEBUG"
    },
    "success": "true"
}
```
* Assignee @pcoello25 