### PR TITLE
hardening/877_fix_normal_service_path_in_names

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -148,7 +148,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
             notificationTarget = "/" + notificationTarget;
         } // if
         
-        defaultService = context.getString(Constants.PARAM_DEFAULT_SERVICE, "def_serv");
+        defaultService = context.getString(Constants.PARAM_DEFAULT_SERVICE, "default");
         
         if (defaultService.length() > Constants.SERVICE_HEADER_MAX_LEN) {
             LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE + "' parameter length greater than "
@@ -158,11 +158,17 @@ public class OrionRestHandler implements HTTPSourceHandler {
         } // if
         
         LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE + "=" + defaultService + ")");
-        defaultServicePath = context.getString(Constants.PARAM_DEFAULT_SERVICE_PATH, "def_serv_path");
+        defaultServicePath = context.getString(Constants.PARAM_DEFAULT_SERVICE_PATH, "/");
         
         if (defaultServicePath.length() > Constants.SERVICE_PATH_HEADER_MAX_LEN) {
             LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH + "' parameter length greater "
                     + "than " + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
+            LOGGER.info("Exiting Cygnus");
+            System.exit(-1);
+        } // if
+        
+        if (!defaultServicePath.startsWith("/")) {
+            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH + "' must start with '/')");
             LOGGER.info("Exiting Cygnus");
             System.exit(-1);
         } // if

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptor.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptor.java
@@ -26,19 +26,12 @@ import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.interceptor.Interceptor;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 /**
  * Custom interceptor in charge of extracting the destination where the data must be persisted. This destination is
@@ -124,14 +117,14 @@ public class GroupingInterceptor implements Interceptor {
             GroupingRule matchingRule = groupingRules.getMatchingRule(contextElement, fiwareServicePath);
             
             if (matchingRule == null) {
-                groupedDestinations.add(Utils.encode(contextElement.getId() + "_" + contextElement.getType()));
+                groupedDestinations.add(Utils.encode(contextElement.getId() + "_" + contextElement.getType(), false, true));
                 groupedServicePaths.add(fiwareServicePath);
             } else {
                 groupedDestinations.add((String) matchingRule.getDestination());
                 groupedServicePaths.add((String) matchingRule.getNewFiwareServicePath());
             } // if else
             
-            defaultDestinations.add(Utils.encode(contextElement.getId() + "_" + contextElement.getType()));
+            defaultDestinations.add(Utils.encode(contextElement.getId() + "_" + contextElement.getType(), false, true));
             defaultServicePaths.add(fiwareServicePath);
         } // for
         

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
@@ -88,7 +88,7 @@ public class GroupingRule {
      * @return The rule's destination.
      */
     public String getDestination() {
-        return Utils.encode((String) jsonRule.get("destination"));
+        return Utils.encode((String) jsonRule.get("destination"), false, true);
     } // destination
 
     /**
@@ -96,7 +96,7 @@ public class GroupingRule {
      * @return The rule's newFiwareServicePath.
      */
     public String getNewFiwareServicePath() {
-        return Utils.encode((String) jsonRule.get("fiware_service_path"));
+        return Utils.encode((String) jsonRule.get("fiware_service_path"), false, true);
     } // getNewFiwareServicePath
     
     /**

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -26,7 +26,6 @@ import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.Constants;
 import com.telefonica.iot.cygnus.utils.Utils;
 import java.util.ArrayList;
-import java.util.Locale;
 import org.apache.flume.Context;
 
 /**
@@ -455,9 +454,7 @@ public class OrionCKANSink extends OrionSink {
         if (fiwareServicePath.equals("/")) {
             pkgName = Utils.encode(fiwareService, false, true);
         } else {
-            // no concatenation character, i.e. '_', is needed since the service must start with '/',
-            // which will be encoded as '_'
-            pkgName = Utils.encode(fiwareService, false, true) + Utils.encode(fiwareServicePath, true, false);
+            pkgName = Utils.encode(fiwareService, false, true) + Utils.encode(fiwareServicePath, false, true);
         } // if else
 
         if (pkgName.length() > Constants.MAX_NAME_LEN) {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionCKANSink.java
@@ -431,7 +431,7 @@ public class OrionCKANSink extends OrionSink {
      * @throws Exception
      */
     private String buildOrgName(String fiwareService) throws Exception {
-        String orgName = Utils.encode(fiwareService);
+        String orgName = Utils.encode(fiwareService, false, true);
 
         if (orgName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building orgName=fiwareService (" + orgName + ") and its length is "
@@ -453,9 +453,11 @@ public class OrionCKANSink extends OrionSink {
         String pkgName;
 
         if (fiwareServicePath.equals("/")) {
-            pkgName = Utils.encode(fiwareService);
+            pkgName = Utils.encode(fiwareService, false, true);
         } else {
-            pkgName = Utils.encode(fiwareService) + "_" + Utils.encode(fiwareServicePath);
+            // no concatenation character, i.e. '_', is needed since the service must start with '/',
+            // which will be encoded as '_'
+            pkgName = Utils.encode(fiwareService, false, true) + Utils.encode(fiwareServicePath, true, false);
         } // if else
 
         if (pkgName.length() > Constants.MAX_NAME_LEN) {
@@ -473,7 +475,7 @@ public class OrionCKANSink extends OrionSink {
      * @throws Exception
      */
     private String buildResName(String destination) throws Exception {
-        String resName = Utils.encode(destination);
+        String resName = Utils.encode(destination, false, true);
 
         if (resName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building resName=destination (" + resName + ") and its length is greater "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -336,12 +336,16 @@ public class OrionDynamoDBSink extends OrionSink {
         String tableName;
 
         switch (dataModel) {
-            case DMBYENTITY:
-                tableName = Utils.encode(service) + (servicePath.equals("/") ? "" : "_" + Utils.encode(servicePath))
-                        + "_" + Utils.encode(destination);
-                break;
             case DMBYSERVICEPATH:
-                tableName = Utils.encode(service) + (servicePath.equals("/") ? "" : "_" + Utils.encode(servicePath));
+                String truncatedServicePath = Utils.encode(servicePath, true, false);
+                tableName = Utils.encode(service, false, true)
+                        + (truncatedServicePath.isEmpty() ? "" : "_" + truncatedServicePath);
+                break;
+            case DMBYENTITY:
+                truncatedServicePath = Utils.encode(servicePath, true, false);
+                tableName = Utils.encode(service, false, true)
+                        + (truncatedServicePath.isEmpty() ? "" : "_" + truncatedServicePath)
+                        + "_" + Utils.encode(destination, false, true);
                 break;
             default:
                 throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSink.java
@@ -349,7 +349,7 @@ public class OrionDynamoDBSink extends OrionSink {
                 break;
             default:
                 throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
-                            + "'. Please, use DMBYSERVICEPATH, DMBYENTITY or DMBYATTRIBUTE");
+                            + "'. Please, use DMBYSERVICEPATH or DMBYENTITY");
         } // switch
 
         if (tableName.length() > Constants.MAX_NAME_LEN) {

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -529,7 +529,7 @@ public class OrionHDFSSink extends OrionSink {
             firstLevel = buildFirstLevel(service);
             secondLevel = buildSecondLevel(servicePath);
             thirdLevel = buildThirdLevel(destination);
-            hdfsFolder = firstLevel + (servicePath.equals("/") ? "/" : "/" + secondLevel + "/") + thirdLevel;
+            hdfsFolder = firstLevel + secondLevel + "/" + thirdLevel; // secondLevel
             hdfsFile = hdfsFolder + "/" + thirdLevel + ".txt";
         } // initialize
 
@@ -1045,7 +1045,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildFirstLevel(String fiwareService) throws Exception {
-        String firstLevel = Utils.encode(fiwareService);
+        String firstLevel = Utils.encode(fiwareService, false, true);
 
         if (firstLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building firstLevel=fiwareService (fiwareService=" + fiwareService + ") "
@@ -1064,7 +1064,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildSecondLevel(String fiwareServicePath) throws Exception {
-        String secondLevel = Utils.encode(fiwareServicePath);
+        String secondLevel = Utils.encode(fiwareServicePath, false, false);
 
         if (secondLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building secondLevel=fiwareServicePath (" + fiwareServicePath + ") and "
@@ -1082,7 +1082,7 @@ public class OrionHDFSSink extends OrionSink {
      * @throws Exception
      */
     private String buildThirdLevel(String destination) throws Exception {
-        String thirdLevel = Utils.encode(destination);
+        String thirdLevel = Utils.encode(destination, false, true);
 
         if (thirdLevel.length() > Constants.MAX_NAME_LEN_HDFS) {
             throw new CygnusBadConfiguration("Building thirdLevel=destination (" + destination + ") and its length is "

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSink.java
@@ -529,7 +529,7 @@ public class OrionHDFSSink extends OrionSink {
             firstLevel = buildFirstLevel(service);
             secondLevel = buildSecondLevel(servicePath);
             thirdLevel = buildThirdLevel(destination);
-            hdfsFolder = firstLevel + secondLevel + "/" + thirdLevel; // secondLevel
+            hdfsFolder = firstLevel + (servicePath.equals("/") ? "" : secondLevel) + "/" + thirdLevel;
             hdfsFile = hdfsFolder + "/" + thirdLevel + ".txt";
         } // initialize
 

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSink.java
@@ -223,7 +223,7 @@ public class OrionKafkaSink extends OrionSink {
 
             switch (dataModel) {
                 case DMBYSERVICE:
-                    name = Utils.encode(service);
+                    name = Utils.encode(service, false, true);
                     break;
                 case DMBYSERVICEPATH:
                     if (servicePath.equals("/")) {
@@ -231,13 +231,13 @@ public class OrionKafkaSink extends OrionSink {
                                 + "dm-by-service-path data model");
                     } // if
                     
-                    name = Utils.encode(servicePath);
+                    name = Utils.encode(servicePath, true, false);
                     break;
                 case DMBYENTITY:
-                    name = Utils.encode(entity);
+                    name = Utils.encode(entity, false, true);
                     break;
                 case DMBYATTRIBUTE:
-                    name = Utils.encode(attribute);
+                    name = Utils.encode(attribute, false, true);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMongoBaseSink.java
@@ -109,9 +109,9 @@ public abstract class OrionMongoBaseSink extends OrionSink {
         // FIXME: mongoPassword should be read as a SHA1 and decoded here
         mongoPassword = context.getString("mongo_password", "");
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mongo_password=" + mongoPassword + ")");
-        dbPrefix = Utils.encode(context.getString("db_prefix", "sth_"));
+        dbPrefix = Utils.encode(context.getString("db_prefix", "sth_"), false, true);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (db_prefix=" + dbPrefix + ")");
-        collectionPrefix = Utils.encode(context.getString("collection_prefix", "sth_"));
+        collectionPrefix = Utils.encode(context.getString("collection_prefix", "sth_"), false, true);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (collection_prefix=" + collectionPrefix + ")");
         
         String shouldHashStr = context.getString("should_hash", "false");
@@ -191,7 +191,7 @@ public abstract class OrionMongoBaseSink extends OrionSink {
      * @throws Exception
      */
     protected String buildDbName(String fiwareService) throws Exception {
-        String dbName = dbPrefix + Utils.encode(fiwareService);
+        String dbName = dbPrefix + Utils.encode(fiwareService, false, true);
 
         if (dbName.length() > Constants.MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building dbName=fiwareService (" + dbName + ") and its length is greater "
@@ -227,14 +227,16 @@ public abstract class OrionMongoBaseSink extends OrionSink {
                             + "dm-by-service-path data model");
                 } // if
                 
-                collectionName = Utils.encodeSTH(fiwareServicePath);
+                collectionName = Utils.encode(fiwareServicePath, false, false);
                 break;
             case DMBYENTITY:
-                collectionName = Utils.encodeSTH(fiwareServicePath) + "_" + Utils.encode(entity);
+                collectionName = Utils.encode(fiwareServicePath, false, false) + "_"
+                        + Utils.encode(entity, false, true);
                 break;
             case DMBYATTRIBUTE:
-                collectionName = Utils.encodeSTH(fiwareServicePath) + "_" + Utils.encode(entity)
-                        + "_" + Utils.encode(attribute);
+                collectionName = Utils.encode(fiwareServicePath, false, false)
+                        + "_" + Utils.encode(entity, false, true)
+                        + "_" + Utils.encode(attribute, false, true);
                 break;
             default:
                 // this should never be reached

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -297,7 +297,7 @@ public class OrionMySQLSink extends OrionSink {
         } // initialize
         
         private String buildDbName() throws Exception {
-            String name = Utils.encode(service);
+            String name = Utils.encode(service, false, true);
 
             if (name.length() > Constants.MAX_NAME_LEN) {
                 throw new CygnusBadConfiguration("Building database name '" + name
@@ -317,14 +317,18 @@ public class OrionMySQLSink extends OrionSink {
                                 + "dm-by-service-path data model");
                     } // if
                     
-                    name = Utils.encode(servicePath);
+                    name = Utils.encode(servicePath, true, false);
                     break;
                 case DMBYENTITY:
-                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity);
+                    String truncatedServicePath = Utils.encode(servicePath, true, false);
+                    name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                            + Utils.encode(entity, false, true);
                     break;
                 case DMBYATTRIBUTE:
-                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity)
-                            + '_' + Utils.encode(attribute);
+                    truncatedServicePath = Utils.encode(servicePath, true, false);
+                    name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                            + Utils.encode(entity, false, true)
+                            + '_' + Utils.encode(attribute, false, true);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSink.java
@@ -261,7 +261,7 @@ public class OrionPostgreSQLSink extends OrionSink {
         } // initialize
 
         private String buildSchemaName() throws Exception {
-            String name = Utils.encode(service);
+            String name = Utils.encode(service, false, true);
 
             if (name.length() > Constants.MAX_NAME_LEN) {
                 throw new CygnusBadConfiguration("Building schema name '" + name
@@ -281,14 +281,18 @@ public class OrionPostgreSQLSink extends OrionSink {
                                 + "dm-by-service-path data model");
                     } // if
                     
-                    name = Utils.encode(servicePath);
+                    name = Utils.encode(servicePath, true, false);
                     break;
                 case DMBYENTITY:
-                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity);
+                    String truncatedServicePath = Utils.encode(servicePath, true, false);
+                    name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                            + Utils.encode(entity, false, true);
                     break;
                 case DMBYATTRIBUTE:
-                    name = (servicePath.equals("/") ? "" : Utils.encode(servicePath) + '_') + Utils.encode(entity)
-                            + '_' + Utils.encode(attribute);
+                    truncatedServicePath = Utils.encode(servicePath, true, false);
+                    name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                            + Utils.encode(entity, false, true)
+                            + '_' + Utils.encode(attribute, false, true);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -45,7 +45,7 @@ public final class Utils {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(Utils.class);
     private static final Pattern ENCODEPATTERN = Pattern.compile("[^a-zA-Z0-9\\.\\-]");
-    private static final Pattern ENCODESTHPATTERN = Pattern.compile("[^a-zA-Z0-9\\.\\-\\/]");
+    private static final Pattern ENCODEPATTERNSLASH = Pattern.compile("[^a-zA-Z0-9\\.\\-\\/]");
     private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final DateTimeFormatter FORMATTER1 = DateTimeFormat.forPattern(
             "yyyy-MM-dd'T'hh:mm:ss'Z'").withOffsetParsed().withZoneUTC();
@@ -67,21 +67,19 @@ public final class Utils {
      * This should be only called when building a persistence element name, such as table names, file paths, etc.
      * 
      * @param in
+     * @param deleteSlash
+     * @param encodeSlash
      * @return The encoded version of the input string.
      */
-    public static String encode(String in) {
-        return ENCODEPATTERN.matcher(in).replaceAll("_");
+    public static String encode(String in, boolean deleteSlash, boolean encodeSlash) {
+        if (deleteSlash) {
+            return ENCODEPATTERN.matcher(in.substring(1)).replaceAll("_");
+        } else if (encodeSlash) {
+            return ENCODEPATTERN.matcher(in).replaceAll("_");
+        } else {
+            return ENCODEPATTERNSLASH.matcher(in).replaceAll("_");
+        } // if else
     } // encode
-    
-    /**
-     * Encodes a string replacing all the non alphanumeric characters by '_' (except by '-', '.' and '/').
-     * This should be only called when building a STH persistence element names.
-     * @param in
-     * @return The encoded version of the input string.
-     */
-    public static String encodeSTH(String in) {
-        return ENCODESTHPATTERN.matcher(in).replaceAll("_");
-    } // encodeSTH
     
     /**
      * Encodes a string replacing all the non alphanumeric characters by '_'.

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionCKANSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.*; // this is required by "when" like function
 import static org.junit.Assert.*; // this is required by "fail" like assertions
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.utils.TestUtils;
-import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -65,13 +64,13 @@ public class OrionCKANSinkTest {
     private final String normalService = "vehicles";
     private final String abnormalService =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionDynamoDBSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -21,7 +21,6 @@ import com.telefonica.iot.cygnus.backends.dynamo.DynamoDBBackendImpl;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
 import com.telefonica.iot.cygnus.utils.TestUtils;
-import java.util.ArrayList;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
@@ -66,13 +65,13 @@ public class OrionDynamoDBSinkTest {
     private final String normalService = "vehicles";
     private final String abnormalService =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionHDFSSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -76,10 +76,10 @@ public class OrionHDFSSinkTest {
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "longservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
@@ -87,7 +87,7 @@ public class OrionHDFSSinkTest {
             + "longservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -21,7 +21,6 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.sinks.OrionKafkaSink.TopicAPI;
 import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
 import com.telefonica.iot.cygnus.utils.TestUtils;
-import java.util.ArrayList;
 import org.apache.curator.test.TestingServer;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
@@ -73,13 +72,13 @@ public class OrionKafkaSinkTest {
     private final String normalService = "vehicles";
     private final String abnormalService =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -24,7 +24,6 @@ import com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
 import com.telefonica.iot.cygnus.utils.TestUtils;
-import java.util.ArrayList;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
@@ -66,13 +65,13 @@ public class OrionMySQLSinkTest {
     private final String normalService = "vehicles";
     private final String abnormalService =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionPostgreSQLSinkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.*; // this is required by "when" like function
 import com.telefonica.iot.cygnus.backends.postgresql.PostgreSQLBackendImpl;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.utils.TestUtils;
-import java.util.ArrayList;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
@@ -64,13 +63,13 @@ public class OrionPostgreSQLSinkTest {
     private final String normalService = "vehicles";
     private final String abnormalService =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservname";
-    private final String normalDefaultServicePath = "4wheels";
-    private final String rootServicePath = "";
+    private final String normalDefaultServicePath = "/4wheels";
+    private final String rootServicePath = "/";
     private final String abnormalDefaultServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalGroupedServicePath = "cars";
     private final String abnormalGroupedServicePath =
-            "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
+            "/tooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongservpathname";
     private final String normalDefaultDestination = "car1_car";
     private final String abnormalDefaultDestination =
             "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongdestname";


### PR DESCRIPTION
* Partially implements issue #877 
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Notifications sent (serive-paths are `/` and `/something`, respectively):
```
time=2016-03-29T15:36:19.889CEST | lvl=INFO | trans=1459258551-23-0000000000 | svc=default | subsvc=/ | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[272] : Received data ({  "subscriptionId" : "56e2ad4e8001ff5e0a5260ec",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "type" : "cosa1",        "isPattern" : "false",        "id" : "z0011",        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "111",            "metadatas" : [              {                "name" : "TimeInstant",                "type" : "recvTime",                "value" : "2015-12-12T11:11:11.111Z"              }            ]          }        ]      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
..
time=2016-03-29T15:41:23.001CEST | lvl=INFO | trans=1459258551-23-0000000001 | svc=default | subsvc=/something | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[272] : Received data ({  "subscriptionId" : "56e2ad4e8001ff5e0a5260ec",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "type" : "cosa1",        "isPattern" : "false",        "id" : "z0011",        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "111",            "metadatas" : [              {                "name" : "TimeInstant",                "type" : "recvTime",                "value" : "2015-12-12T11:11:11.111Z"              }            ]          }        ]      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
```

`OrionHDFSSink` (data_model is dm-by-entity):
```
Persisting data at OrionHDFSSink. HDFS file (default/z0011_cosa1/z0011_cosa1.txt)
Persisting data at OrionHDFSSink. HDFS file (default/something/z0011_cosa1/z0011_cosa1.txt)
```

`OrionCKANSink` (data_model is dm-by-entity):
```
Persisting data at OrionCKANSink (orgName=default, pkgName=default, resName=z0011_cosa1)
Persisting data at OrionCKANSink (orgName=default, pkgName=default_something, resName=z0011_cosa1)
```

`OrionMySQLSink` (data_model is dm-by-service-path):
```
Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
Persisting data at OrionMySQLSink. Database (default), Table (something)
```

`OrionMySQLSink` (data_model is dm-by-entity):
```
Persisting data at OrionMySQLSink. Database (default), Table (z0011_cosa1)
Persisting data at OrionMySQLSink. Database (default), Table (something_z0011_cosa1)
```

`OrionMongoSink` (data_model is dm-by-service-path):
```
Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
Persisting data at OrionMongoSink. Database: sth_default, Collection: sth_/something
```

`OrionMongoSink` (data_model is dm-by-entity):
```
Persisting data at OrionMongoSink. Database: sth_default, Collection: sth_/_z0011_cosa1
Persisting data at OrionMongoSink. Database: sth_default, Collection: sth_/something_z0011_cosa1
```

`OrionSTHSink` (data_model is dm-by-service-path):
```
Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
Persisting data at OrionSTHSink. Database: sth_default, Collection: sth_/something.aggr
```

`OrionSTHSink` (data_model is dm-by-entity):
```
Persisting data at OrionSTHSink. Database: sth_default, Collection: sth_/_z0011_cosa1.aggr
Persisting data at OrionSTHSink. Database: sth_default, Collection: sth_/something_z0011_cosa1.aggr
```

`OrionDynamoDBSink` (data_model is dm-by-service-path):
```
Persisting data at OrionDynamoSink. Dynamo table (default)
Persisting data at OrionDynamoSink. Dynamo table (default_something)
```

`OrionDynamoDBSink` (data_model is dm-by-entity):
```
Persisting data at OrionDynamoSink. Dynamo table (default_z0011_cosa1)
Persisting data at OrionDynamoSink. Dynamo table (default_something_z0011_cosa1)
```

`OrionPostgreSQLSink` (data_model is dm-by-service-path):
```
Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
Persisting data at OrionPostgreSQLSink. Schema (default), Table (something)
```

`OrionPostgreSQLSink` (data_model is dm-by-entity):
```
Persisting data at OrionPostgreSQLSink. Schema (default), Table (z0011_cosa1)
Persisting data at OrionPostgreSQLSink. Schema (default), Table (something_z0011_cosa1)
```

`OrionKafkaSink` (data_model is dm-by-service):
```
Persisting data at OrionKafkaSink. Topic (default)
Persisting data at OrionKafkaSink. Topic (default)
```

`OrionKafkaSink` (data_model is dm-by-service-path):
```
Bad configuration (Default service path '/' cannot be used with dm-by-service-path data model)
Persisting data at OrionKafkaSink. Topic (something)
```

`OrionKafkaSink` (data_model is dm-by-entity):
```
Persisting data at OrionKafkaSink. Topic (z0011_cosa1)
Persisting data at OrionKafkaSink. Topic (z0011_cosa1)
```

`OrionKafkaSink` (data_model is dm-by-attribute):
```
Persisting data at OrionKafkaSink. Topic (temperature)
Persisting data at OrionKafkaSink. Topic (temperature)
```
* Assignee @pcoello25 