### PR TITLE
bug/873_906_wrong_timestamp_conversion_and_microseconds_support_0.13.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,5 @@
 - [BUG] Fix the way a set of notified attributes are processed in OrionMySQLSink, no order must be assumed (#855)
 - [FEATURE] When notified, use the TimeInstant metadata instead of the reception time (#859)
 - [HARDENING] Improve the different elements naming when notified/default service path is / (#877)
+- [BUG] Fix wrong data conversion from SQL timestamp to ISO 8601 UTC when a year must be decreased (#873)
+- [BUG] Add support for ISO 8601 timestamps containing 6 microsecond digits (#906)

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -54,13 +54,13 @@ public final class Utils {
     private static final Pattern ENCODEPATTERNSLASH = Pattern.compile("[^a-zA-Z0-9\\.\\-\\/]");
     private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final DateTimeFormatter FORMATTER1 = DateTimeFormat.forPattern(
-            "yyyy-MM-dd'T'hh:mm:ss'Z'").withOffsetParsed().withZoneUTC();
+            "yyyy-MM-dd'T'HH:mm:ss'Z'").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER2 = DateTimeFormat.forPattern(
-            "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'").withOffsetParsed().withZoneUTC();
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER3 = DateTimeFormat.forPattern(
-            "yyyy-MM-dd hh:mm:ss").withOffsetParsed();
+            "yyyy-MM-dd HH:mm:ss").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER4 = DateTimeFormat.forPattern(
-            "yyyy-MM-dd hh:mm:ss.SSS").withOffsetParsed();
+            "yyyy-MM-dd HH:mm:ss.SSS").withOffsetParsed().withZoneUTC();
     
     /**
      * Constructor. It is private since utility classes should not have a public or default constructor.
@@ -297,15 +297,23 @@ public final class Utils {
                             LOGGER.debug(e2.getMessage());
                             
                             try {
-                                dateTime = FORMATTER3.parseDateTime(mdValue);
-                            } catch (Exception e3) {
-                                LOGGER.debug(e3.getMessage());
+                                // ISO 8601 with microseconds
+                                String mdValueTruncated = mdValue.substring(0, mdValue.length() - 4) + "Z";
+                                dateTime = FORMATTER2.parseDateTime(mdValueTruncated);
+                            } catch (Exception e5) {
+                                LOGGER.debug(e5.getMessage());
                                 
                                 try {
-                                    dateTime = FORMATTER4.parseDateTime(mdValue);
-                                } catch (Exception e4) {
-                                    LOGGER.debug(e4.getMessage());
-                                    return null;
+                                    dateTime = FORMATTER3.parseDateTime(mdValue);
+                                } catch (Exception e3) {
+                                    LOGGER.debug(e3.getMessage());
+
+                                    try {
+                                        dateTime = FORMATTER4.parseDateTime(mdValue);
+                                    } catch (Exception e4) {
+                                        LOGGER.debug(e4.getMessage());
+                                        return null;
+                                    } // try catch
                                 } // try catch
                             } // try catch
                         } // try catch


### PR DESCRIPTION
* Fixes issues #873 and #906
* 100% unit tests passed:
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

Notification sent (TimeInstants are all above 12 hours):
```
{
	"subscriptionId": "56ebd67673a3713d25fcccb6",
	"originator": "localhost",
	"contextResponses": [{
		"contextElement": {
			"type": "thing",
			"isPattern": "false",
			"id": "thing:edisonFran",
			"attributes": [{
				"name": "TimeInstant",
				"type": "ISO8601",
				"value": "2016-03-29T10:15:04.131490Z"
			}, {
				"name": "h",
				"type": "string",
				"value": "48.6",
				"metadatas": [{
					"name": "TimeInstant",
					"type": "ISO8601",
					"value": "2016-03-22T14:24:04.131974Z"
				}]
			}, {
				"name": "humidity",
				"type": "string",
				"value": "68.6",
				"metadatas": [{
					"name": "TimeInstant",
					"type": "ISO8601",
					"value": "2016-03-18T16:21:48.722010Z"
				}]
			}, {
				"name": "r",
				"type": "string",
				"value": "false",
				"metadatas": [{
					"name": "TimeInstant",
					"type": "ISO8601",
					"value": "2016-03-22T14:24:04.132386Z"
				}]
			}, {
				"name": "t",
				"type": "string",
				"value": "24.2",
				"metadatas": [{
					"name": "TimeInstant",
					"type": "ISO8601",
					"value": "2016-03-22T14:24:04.131490Z"
				}]
			}, {
				"name": "temperature",
				"type": "string",
				"value": "62.4",
				"metadatas": [{
					"name": "TimeInstant",
					"type": "ISO8601",
					"value": "2016-03-18T16:21:48.720730Z"
				}]
			}]
		},
		"statusCode": {
			"code": "200",
			"reasonPhrase": "OK"
		}
	}]
}
```

It is uccessfully stored in STH with the right timestamp (the TimeInstant one):
```
> db['sth_/something_thing_edisonFran_thing'].find()
{ "_id" : ObjectId("56fd3c6054836c189a5db2b7"), "recvTime" : ISODate("2016-03-31T15:03:55.046Z"), "attrName" : "TimeInstant", "attrType" : "ISO8601", "attrValue" : "2016-03-29T10:15:04.131490Z" }
{ "_id" : ObjectId("56fd3c6054836c189a5db2b8"), "recvTime" : ISODate("2016-03-22T14:24:04.131Z"), "attrName" : "h", "attrType" : "string", "attrValue" : "48.6" }
{ "_id" : ObjectId("56fd3c6054836c189a5db2b9"), "recvTime" : ISODate("2016-03-18T16:21:48.722Z"), "attrName" : "humidity", "attrType" : "string", "attrValue" : "68.6" }
{ "_id" : ObjectId("56fd3c6054836c189a5db2ba"), "recvTime" : ISODate("2016-03-22T14:24:04.132Z"), "attrName" : "r", "attrType" : "string", "attrValue" : "false" }
{ "_id" : ObjectId("56fd3c6054836c189a5db2bb"), "recvTime" : ISODate("2016-03-22T14:24:04.131Z"), "attrName" : "t", "attrType" : "string", "attrValue" : "24.2" }
{ "_id" : ObjectId("56fd3c6054836c189a5db2bc"), "recvTime" : ISODate("2016-03-18T16:21:48.720Z"), "attrName" : "temperature", "attrType" : "string", "attrValue" : "62.4" }
```
* Assignee @frbattid