### PR TITLE
bug/909_remove_z_character_when_encoding_recvtime_in_mysql

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -21,3 +21,4 @@
 - [HARDENING] Set external dependencies logging level to WARN in lo4j.properties.template (#881)
 - [HARDENING] Check the service-paths within grouping rules start with / (#901)
 - [HARDENING] Use MongoDB accepted character set in OrionMongoSink and OrionSTHSink (#898)
+- [BUG] Remove 'Z' character (UTC mark) when encoding the reception time in OrionMySQLSink (#909)

--- a/doc/flume_extensions_catalogue/orion_mysql_sink.md
+++ b/doc/flume_extensions_catalogue/orion_mysql_sink.md
@@ -56,7 +56,7 @@ The context attributes within each context response/entity are iterated, and a n
     * `attrValue`: In its simplest form, this value is just a string, but since Orion 0.11.0 it can be Json object or Json array.
     * `attrMd`: It contains a string serialization of the metadata array for the attribute in Json (if the attribute hasn't metadata, an empty array `[]` is inserted).
 * `column`: A single data row is added for all the notified context attributes. This kind of row will contain two fields per each entity's attribute (one for the value, named `<attrName>`, and other for the metadata, named `<attrName>_md`), plus four additional fields:
-    * `recvTime`: UTC timestamp in human-redable format ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601)).
+    * `recvTime`: Timestamp in human-readable format (Similar to [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601), nut avoiding the `Z` character denoting UTC, since all MySQL timestamps are suposed to be in UTC format).
     * `fiwareServicePath`: The notified one or the default one.
     * `entityId`: Notified entity identifier.
     * `entityType`: Notified entity type.

--- a/doc/flume_extensions_catalogue/orion_mysql_sink.md
+++ b/doc/flume_extensions_catalogue/orion_mysql_sink.md
@@ -56,7 +56,7 @@ The context attributes within each context response/entity are iterated, and a n
     * `attrValue`: In its simplest form, this value is just a string, but since Orion 0.11.0 it can be Json object or Json array.
     * `attrMd`: It contains a string serialization of the metadata array for the attribute in Json (if the attribute hasn't metadata, an empty array `[]` is inserted).
 * `column`: A single data row is added for all the notified context attributes. This kind of row will contain two fields per each entity's attribute (one for the value, named `<attrName>`, and other for the metadata, named `<attrName>_md`), plus four additional fields:
-    * `recvTime`: Timestamp in human-readable format (Similar to [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601), nut avoiding the `Z` character denoting UTC, since all MySQL timestamps are suposed to be in UTC format).
+    * `recvTime`: Timestamp in human-readable format (Similar to [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601), but avoiding the `Z` character denoting UTC, since all MySQL timestamps are supposed to be in UTC format).
     * `fiwareServicePath`: The notified one or the default one.
     * `entityId`: Notified entity identifier.
     * `entityType`: Notified entity type.

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -444,7 +444,7 @@ public class OrionMySQLSink extends OrionSink {
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
             long recvTimeTs = cygnusEvent.getRecvTimeTs();
-            String recvTime = Utils.getHumanReadable(recvTimeTs, true);
+            String recvTime = Utils.getHumanReadable(recvTimeTs, false);
 
             // get the event body
             ContextElement contextElement = cygnusEvent.getContextElement();

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionMySQLSink.java
@@ -370,7 +370,7 @@ public class OrionMySQLSink extends OrionSink {
         public void aggregate(CygnusEvent cygnusEvent) throws Exception {
             // get the event headers
             long recvTimeTs = cygnusEvent.getRecvTimeTs();
-            String recvTime = Utils.getHumanReadable(recvTimeTs, true);
+            String recvTime = Utils.getHumanReadable(recvTimeTs, false);
 
             // get the event body
             ContextElement contextElement = cygnusEvent.getContextElement();


### PR DESCRIPTION
* Fixes issue #909 
* 100% unit tests passed:
```
Tests run: 83, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

As can be seen, the recvTime value has not the final `Z` character:
```
Persisting data at OrionMySQLSink. Database (default), Table (something_Room1_Room), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1459442298809','2016-03-31T16:38:18.809','/something','Room1','Room','temperature','centigrade','26.5','[]'))
```
* Assignee @pcoello25 