### PR TITLE
hardening/add_test_not_mandatory_params_def_value_rest_handler

### DIFF
--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -44,11 +44,31 @@ public class OrionRestHandlerTest {
         
         try {
             assertEquals("/notify", handler.getNotificationTarget());
-            assertEquals("default", handler.getDefaultService());
-            assertEquals("/", handler.getDefaultServicePath());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration values are used");
+            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
+                    + "'notification_target' is '/notify'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration values are not used");
+            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
+                    + "'notification_target' is '" + handler.getNotificationTarget() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("default", handler.getDefaultService());
+            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
+                    + "'default_service' is 'default'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
+                    + "'default_service' is '" + handler.getDefaultService() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("/", handler.getDefaultServicePath());
+            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
+                    + "'default_service_path' is '/'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
+                    + "'default_service_path' is '" + handler.getDefaultServicePath() + "'");
             throw e;
         } // try catch
     } // testConfigureNotMandatoryParameters


### PR DESCRIPTION
* Implement a test regarding #754 
* New test passed:
```
Running com.telefonica.iot.cygnus.handlers.OrionRestHandlerTest
[OrionRestHandler.configure] -------- When not configured, the default values are used for non mandatory parameters
16/04/01 09:06:45 INFO handlers.OrionRestHandler: Cygnus version (0.13.0.11c22308a620f922f62652e8e1cc3f0bd44ab8dc)
16/04/01 09:06:45 INFO handlers.OrionRestHandler: Startup completed
[OrionRestHandler.configure] -  OK  - The default configuration value for 'notification_target' is '/notify'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service' is 'default'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service_path' is '/'
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.454 sec
```
* Assignee @pcoello25 