### PR TITLE
hardening/917_invalid_configurations_rest_handler

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -26,3 +26,4 @@
 - [HARDENING] Use MongoDB accepted character set in OrionMongoSink and OrionSTHSink (#898)
 - [HARDENING] Expand topic name in OrionKafkaSink (#880)
 - [BUG] Remove 'Z' character (UTC mark) when encoding the reception time in OrionMySQLSink (#909)
+- [HARDENING] Invalidate configurations instead of exiting Cygnus upon wrong configuration (#917)

--- a/conf/agent.conf.template
+++ b/conf/agent.conf.template
@@ -46,8 +46,6 @@ cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.Ori
 # cygnusagent.sources.http-source.handler.default_service = default
 # Default service path (service path semantic depends on the persistence sink)
 # cygnusagent.sources.http-source.handler.default_service_path = /
-# Number of channel re-injection retries before a Flume event is definitely discarded (-1 means infinite retries)
-cygnusagent.sources.http-source.handler.events_ttl = 10
 # Source interceptors, do not change
 cygnusagent.sources.http-source.interceptors = ts gi
 # TimestampInterceptor, do not change

--- a/doc/flume_extensions_catalogue/orion_rest_handler.md
+++ b/doc/flume_extensions_catalogue/orion_rest_handler.md
@@ -1,5 +1,17 @@
-#OrionRESTHandler
-This document explains how a notified NGSI event containing context data is converted into a Flume event, suitable for being consumed by any of the Cygnus sinks, thanks to OrionRESTHandler
+#<a name="top"></a>OrionCKANSink
+Content:
+
+* [Functionality](#section1)
+    * [Mapping NGSI events to flume events](#section1.1)
+    * [Example](#section1.2)
+* [Administration guide](#section2)
+    * [Configuration](#section2.1)
+* [Programmers guide](#section3)
+    * [`OrionRestHandler` class](#section3.1)
+
+##<a name="section1"></a>Functionality
+###<a name"section1.1"></a>Mapping NGSI events to flume events
+This section explains how a notified NGSI event containing context data is converted into a Flume event, suitable for being consumed by any of the Cygnus sinks, thanks to OrionRESTHandler
 
 A NGSI-like event example could be (the code below is an <i>object representation</i>, not any real data format; look for it at [Orion documentation](https://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_User_and_Programmers_Guide#ONCHANGE)):
 
@@ -54,11 +66,11 @@ Flume events are not much more different than the above representation: there is
 	         timestamp=1429535775,
 	         transactionId=1429535775-308-0000000000,
 	         fiware-service=vehicles,
-	         fiware-servicepath=4wheels,
+	         fiware-servicepath=/4wheels,
 	         notified-entities=car1_car
-	         notified-servicepaths=4wheels
+	         notified-servicepaths=/4wheels
 	         grouped-entities=car1_car
-	         grouped-servicepath=4wheels
+	         grouped-servicepath=/4wheels
         },
         body={
 	         entityId=car1,
@@ -93,3 +105,32 @@ The headers are a subset of the notified HTTP headers and others added by Cygnus
     * `grouped-entities`, an array that can be used by those sinks enabling the grouping feature.
 
 The body simply contains a byte representation of the HTTP payload that will be parsed by the sinks.
+
+[Top](#top)
+
+##<a name="section2"></a>Administration guide
+###<a name="section2.1"></a>Configuration
+`OrionRestHandler` is configured through the following parameters:
+
+| Parameter | Mandatory | Default value | Comments |
+|---|---|---|---|
+| notification\_target | no | `notify/` | Any other configured value must start with `/`. |
+| default\_service | no | `default` || 
+| default\_service\_path | no | `/` | `/` is the root service path (also know as root subservice). Any other configured value must start with `/`. |
+
+A configuration example could be:
+
+    cygnusagent.sources = http-source
+    ...
+    cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.OrionRestHandler
+    cygnusagent.sources.http-source.notification_target = /notify
+    cygnusagent.sources.http-source.default_service = default
+    cygnusagent.sources.http-source.default_service_path = /
+
+[Top](#top)
+
+##<a name="section3"></a>Programmers guide
+###<a name="section3.1"></a>`OrionRestHandler` class
+TBD
+
+[Top](#top)

--- a/doc/installation_and_administration_guide/cygnus_agent_conf.md
+++ b/doc/installation_and_administration_guide/cygnus_agent_conf.md
@@ -81,11 +81,9 @@ cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.Ori
 # URL target
 cygnusagent.sources.http-source.handler.notification_target = /notify
 # Default service (service semantic depends on the persistence sink)
-cygnusagent.sources.http-source.handler.default_service = def_serv
+cygnusagent.sources.http-source.handler.default_service = default
 # Default service path (service path semantic depends on the persistence sink)
-cygnusagent.sources.http-source.handler.default_service_path = def_servpath
-# Number of channel re-injection retries before a Flume event is definitely discarded (-1 means infinite retries)
-cygnusagent.sources.http-source.handler.events_ttl = 10
+cygnusagent.sources.http-source.handler.default_service_path = /
 # Source interceptors, do not change
 cygnusagent.sources.http-source.interceptors = ts gi
 # TimestampInterceptor, do not change

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -198,7 +198,8 @@ public class OrionRestHandler implements HTTPSourceHandler {
     public List<Event> getEvents(javax.servlet.http.HttpServletRequest request) throws Exception {
         // if the configuration is invalid, nothing has to be done but to return null
         if (invalidConfiguration) {
-            return null;
+            LOGGER.debug("Invalid configuration, thus returning an empty list of Flume events");
+            return new ArrayList<Event>();
         } // if
         
         numReceivedEvents++;

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -52,6 +52,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
     private static final CygnusLogger LOGGER = new CygnusLogger(OrionRestHandler.class);
     
     // configuration parameters
+    private boolean invalidConfiguration;
     private String notificationTarget;
     private String defaultService;
     private String defaultServicePath;
@@ -71,6 +72,9 @@ public class OrionRestHandler implements HTTPSourceHandler {
      * time, it is the closest code to such real initialization.
      */
     public OrionRestHandler() {
+        // initially, the configuration is meant to be valid
+        invalidConfiguration = false;
+        
         // print Cygnus version
         LOGGER.info("Cygnus version (" + Utils.getCygnusVersion() + "." + Utils.getLastCommit() + ")");
     } // OrionRestHandler
@@ -138,47 +142,65 @@ public class OrionRestHandler implements HTTPSourceHandler {
     protected String getDefaultServicePath() {
         return defaultServicePath;
     } // getDefaultServicePath
+    
+    /**
+     * Gets true if the configuration is invalid, false otherwise. It is protected due to it is only
+     * required for testing purposes.
+     * @return
+     */
+    protected boolean getInvalidConfiguration() {
+        return invalidConfiguration;
+    } // getInvalidConfiguration
 
     @Override
     public void configure(Context context) {
-        notificationTarget = context.getString(Constants.PARAM_NOTIFICATION_TARGET, "notify");
-        LOGGER.debug("Reading configuration (" + Constants.PARAM_NOTIFICATION_TARGET + "=" + notificationTarget + ")");
-
-        if (notificationTarget.charAt(0) != '/') {
-            notificationTarget = "/" + notificationTarget;
-        } // if
+        notificationTarget = context.getString(Constants.PARAM_NOTIFICATION_TARGET, "/notify");
+        
+        if (notificationTarget.startsWith("/")) {
+            LOGGER.debug("Reading configuration (" + Constants.PARAM_NOTIFICATION_TARGET + "="
+                    + notificationTarget + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration (" + Constants.PARAM_NOTIFICATION_TARGET + "="
+                    + notificationTarget + ") -- Must start with '/'");
+        } // if else
         
         defaultService = context.getString(Constants.PARAM_DEFAULT_SERVICE, "default");
         
         if (defaultService.length() > Constants.SERVICE_HEADER_MAX_LEN) {
-            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE + "' parameter length greater than "
-                    + Constants.SERVICE_HEADER_MAX_LEN + ")");
-            LOGGER.info("Exiting Cygnus");
-            System.exit(-1);
-        } // if
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE
+                    + "' parameter length greater than " + Constants.SERVICE_HEADER_MAX_LEN + ")");
+        } else {
+            LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE + "="
+                    + defaultService + ")");
+        } // if else
         
-        LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE + "=" + defaultService + ")");
         defaultServicePath = context.getString(Constants.PARAM_DEFAULT_SERVICE_PATH, "/");
         
         if (defaultServicePath.length() > Constants.SERVICE_PATH_HEADER_MAX_LEN) {
-            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH + "' parameter length greater "
-                    + "than " + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
-            LOGGER.info("Exiting Cygnus");
-            System.exit(-1);
-        } // if
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH
+                    + "' parameter length greater " + "than " + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
+        } else if (!defaultServicePath.startsWith("/")) {
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH
+                    + "' must start with '/')");
+        } else {
+            LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE_PATH + "="
+                    + defaultServicePath + ")");
+        } // if else
         
-        if (!defaultServicePath.startsWith("/")) {
-            LOGGER.error("Bad configuration ('" + Constants.PARAM_DEFAULT_SERVICE_PATH + "' must start with '/')");
-            LOGGER.info("Exiting Cygnus");
-            System.exit(-1);
-        } // if
-        
-        LOGGER.debug("Reading configuration (" + Constants.PARAM_DEFAULT_SERVICE_PATH + "=" + defaultServicePath + ")");
         LOGGER.info("Startup completed");
     } // configure
             
     @Override
     public List<Event> getEvents(javax.servlet.http.HttpServletRequest request) throws Exception {
+        // if the configuration is invalid, nothing has to be done but to return null
+        if (invalidConfiguration) {
+            return null;
+        } // if
+        
         numReceivedEvents++;
         
         // check the method
@@ -302,7 +324,8 @@ public class OrionRestHandler implements HTTPSourceHandler {
     
     /**
      * Generates a new unique transaction identifier. The format for this id is:
-     * <bootTimeSeconds>-<bootTimeMilliseconds>-<transactionCount%10000000000>
+     * bootTimeSecond-bootTimeMilliseconds-transactionCount%10000000000
+     * @param transId An alrady existent transaction ID, most probably a notified one
      * @return A new unique transaction identifier
      */
     protected String generateTransId(String transId) {

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -218,7 +218,7 @@ public class OrionRestHandlerTest {
                 configuredDefaultServicePath));
         
         try {
-            assertEquals(null, handler.getEvents(mockHttpServletRequest1));
+            assertEquals(0, handler.getEvents(mockHttpServletRequest1).size());
             System.out.println("[OrionRestHandler.getEvents] -  OK  - No events are processed since the "
                     + "configuration is wrong");
         } catch (AssertionError e1) {

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -119,6 +119,52 @@ public class OrionRestHandlerTest {
     } // testConfigureNotMandatoryParameters
     
     /**
+     * [OrionRestHandler.configure] -------- The configured default service path must start with '/'.
+     */
+    @Test
+    public void testConfigureDefaultServicePathStartsWithSlash() {
+        System.out.println("[OrionRestHandler.configure] -------- The configured default service path must start "
+                + "with '/'");
+        OrionRestHandler handler = new OrionRestHandler();
+        String configuredDefaultServicePath = "/something";
+        handler.configure(createContext(null, null, configuredDefaultServicePath));
+        
+        try {
+            assertEquals(configuredDefaultServicePath, handler.getDefaultServicePath());
+            assertTrue(!handler.getInvalidConfiguration());
+            System.out.println("[OrionRestHandler.configure] -  OK  - The configured default service path '"
+                    + configuredDefaultServicePath + "' starts with '/'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.configure] - FAIL - The configured default service path '"
+                    + configuredDefaultServicePath + "' does not start with '/'");
+            throw e;
+        } // try catch
+    } // testConfigureDefaultServicePathStartsWithSlash
+    
+    /**
+     * [OrionRestHandler.configure] -------- The configured notification target must start with '/'.
+     */
+    @Test
+    public void testConfigureNotificationTargerStartsWithSlash() {
+        System.out.println("[OrionRestHandler.configure] -------- The configured notification target must start "
+                + "with '/'");
+        OrionRestHandler handler = new OrionRestHandler();
+        String configuredNotificationTarget = "/notify";
+        handler.configure(createContext(configuredNotificationTarget, null, null));
+        
+        try {
+            assertEquals(configuredNotificationTarget, handler.getNotificationTarget());
+            assertTrue(!handler.getInvalidConfiguration());
+            System.out.println("[OrionRestHandler.configure] -  OK  - The configured notification target '"
+                    + configuredNotificationTarget + "' starts with '/'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.configure] - FAIL - The configured notification target '"
+                    + configuredNotificationTarget + "' does not start with '/'");
+            throw e;
+        } // try catch // try catch
+    } // testConfigureDefaultServicePathStartsWithSlash
+    
+    /**
      * [OrionRestHandler.getEvents] -------- When a notification is sent, the headers are valid.
      */
     @Test
@@ -156,6 +202,35 @@ public class OrionRestHandlerTest {
             assertTrue(false);
         } // try catch
     } // testGetEventsContentTypeHeader
+    
+    /**
+     * [OrionRestHandler.getEvents] -------- When a the configuration is wrong, no events are obtained.
+     */
+    @Test
+    public void testGetEventsNullEventsUponInvalidConfiguration() {
+        System.out.println("[OrionRestHandler.getEvents] -------- When a the configuration is wrong, no evetns "
+                + "are obtained");
+        OrionRestHandler handler = new OrionRestHandler();
+        String configuredNotificationTarget = "notify"; // wrong value
+        String configuredDefaultService = "default";
+        String configuredDefaultServicePath = "something"; // wrong value
+        handler.configure(createContext(configuredNotificationTarget, configuredDefaultService,
+                configuredDefaultServicePath));
+        
+        try {
+            assertEquals(null, handler.getEvents(mockHttpServletRequest1));
+            System.out.println("[OrionRestHandler.getEvents] -  OK  - No events are processed since the "
+                    + "configuration is wrong");
+        } catch (AssertionError e1) {
+            System.out.println("[OrionRestHandler.getEvents] - FAIL - The events are being processed "
+                    + "despite of the configuration is wrong");
+            throw e1;
+        } catch (Exception e2) {
+            System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
+                    + "the events");
+            assertTrue(false);
+        } // try catch
+    } // testGetEventsNullEventsUponInvalidConfiguration
     
     /**
      * [OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is reused.


### PR DESCRIPTION
* Implements issue #917 
* 100% unit tests passed:
```
Running com.telefonica.iot.cygnus.handlers.OrionRestHandlerTest
[OrionRestHandler.configure] -------- The configured default service path must start with '/'
[OrionRestHandler.configure] -  OK  - The configured default service path '/something' starts with '/'
[OrionRestHandler.getEvents] -------- When a the configuration is wrong, no evetns are obtained
16/04/04 16:19:08 ERROR handlers.OrionRestHandler: Bad configuration (notification_target=notify) -- Must start with '/'
16/04/04 16:19:08 ERROR handlers.OrionRestHandler: Bad configuration ('default_service_path' must start with '/')
[OrionRestHandler.getEvents] -  OK  - No events are processed since the configuration is wrong
[OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is reused
[OrionRestHandler.generateTransId] -  OK  - The notified transaction ID '1234567890-123-1234567890' is reused
[OrionRestHandler.configure] -------- The configured notification target must start with '/'
[OrionRestHandler.configure] -  OK  - The configured notification target '/notify' starts with '/'
[OrionRestHandler.configure] -------- When not configured, the default values are used for non mandatory parameters
[OrionRestHandler.configure] -  OK  - The default configuration value for 'notification_target' is '/notify'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service' is 'default'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service_path' is '/'
[OrionRestHandler.generateTransId] -------- When a transcation ID is not notified, it is generated
[OrionRestHandler.generateTransId] -  OK  - The transaction ID has been generated
[OrionRestHandler.getEvents] -------- When a notification is sent, the headers are valid
[OrionRestHandler.getEvents] -  OK  - The value for 'Content-Type' header is 'application/json'
[OrionRestHandler.getEvents] -  OK  - The value for 'fiware-servicePath' header starts with '/'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-service' header value is  less or equal than '50'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-servicePath' header value is less or equal than '50'
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.583 sec
```
* (unofficial) e2e tests passed:

Configuration (relevant parts):
```
# should be '/notify' instead of 'notify'
cygnusagent.sources.http-source.handler.notification_target = notify
cygnusagent.sources.http-source.handler.default_service = default
cygnusagent.sources.http-source.handler.default_service_path = /
```

Log traces (relevant ones):
```
time=2016-04-04T16:23:44.460CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[201] : Invalid configuration, thus returning an empty list of Flume events
```

If the above configuration is fixed (i.e. `notification_target = /notify`) everything goes well:
```
time=2016-04-04T16:31:02.190CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[283] : Starting transaction (1459780258-489-0000000000)
time=2016-04-04T16:31:02.191CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[299] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-04T16:31:02.193CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[321] : Event put in the channel, id=1202194081
time=2016-04-04T16:31:28.969CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[350] : Batch accumulation time reached, the batch will be processed as it is
time=2016-04-04T16:31:28.970CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[402] : Batch completed, persisting it
time=2016-04-04T16:31:28.971CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[954] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (default/algo/Room1_Room/Room1_Room.txt), Data ({"recvTime":"2016-04-04T14:31:02.193Z","fiwareServicePath":"/algo","entityId":"Room1","entityType":"Room", "temperature":"26.5", "temperature_md":[]})
time=2016-04-04T16:31:29.787CEST | lvl=INFO | trans=1459780258-489-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[406] : Finishing transaction (1459780258-489-0000000000)
```
* Assignee @pcoello25 