### PR TITLE
hardening/754_add_test_orion_sink_tests

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -106,22 +106,54 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
         numProcessedEvents = 0;
         numPersistedEvents = 0;
     } // OrionSink
+    
+    /**
+     * Gets the batch size.
+     * @return The batch size.
+     */
+    protected int getBatchSize() {
+        return batchSize;
+    } // getBatchSize
+    
+    /**
+     * Gets the batch timeout.
+     * @return The batch timeout.
+     */
+    protected int getBatchTimeout() {
+        return batchTimeout;
+    } // getBatchTimeout
+    
+    /**
+     * Gets the batch TTL.
+     * @return The batch TTL.
+     */
+    protected int getBatchTTL() {
+        return batchTTL;
+    } // getBatchTTL
+    
+    /**
+     * Gets the data model.
+     * @return The data model
+     */
+    protected DataModel getDataModel() {
+        return dataModel;
+    } // getDataModel
 
     /**
      * Gets if the grouping feature is enabled.
      * @return True if the grouping feature is enabled, false otherwise.
      */
-    public boolean getEnableGrouping() {
+    protected boolean getEnableGrouping() {
         return enableGrouping;
     } // getEnableGrouping
 
     /**
-     * Gets the data model.
-     * @return The data model
+     * Gets if lower case is enabled.
+     * @return True is lower case is enabled, false otherwise.
      */
-    public DataModel getDataModel() {
-        return dataModel;
-    } // getDataModel
+    protected boolean getEnableLowerCase() {
+        return enableLowercase;
+    } // getEnableLowerCase
 
     /**
      * Gets the setup time.

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -194,6 +194,15 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
     public void setNumPersistedEvents(long n) {
         numPersistedEvents = n;
     } // setNumPersistedEvents
+    
+    /**
+     * Gets true if the configuration is invalid, false otherwise. It is protected due to it is only
+     * required for testing purposes.
+     * @return
+     */
+    protected boolean getInvalidConfiguration() {
+        return invalidConfiguration;
+    } // getInvalidConfiguration
 
     @Override
     public void configure(Context context) {

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
@@ -19,9 +19,6 @@ package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.utils.Utils;
 import org.apache.flume.Context;
-import org.apache.flume.channel.MemoryChannel;
-import org.apache.flume.lifecycle.LifecycleState;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,30 +30,6 @@ import org.mockito.runners.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OrionMongoSinkTest {
-    
-    /**
-     * [OrionMongoSink] -------- The sink starts properly.
-     */
-    @Test
-    public void testStart() {
-        System.out.println("[OrionMongoSink] -------- The sink starts properly");
-        String collectionPrefix = "sth_";
-        String dbPrefix = "sth_";
-        OrionMongoSink sink = new OrionMongoSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
-        sink.setChannel(new MemoryChannel());
-        sink.start();
-        LifecycleState state = sink.getLifecycleState();
-        
-        try {
-            assertEquals(LifecycleState.START, state);
-            System.out.println("[OrionMongoSink] -  OK  - The sink started properly, the lifecycle state is '"
-                    + state.toString() + "'");
-        } catch (AssertionError e) {
-            System.out.println("[OrionMongoSink] - FAIL - The sink did not start properly, the lifecycle state "
-                    + "is '" + state.toString() + "'");
-        } // try catch
-    } // testStart
     
     /**
      * [OrionMongoSink] -------- Configured 'collection_prefix' cannot be 'system.'.

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
@@ -19,9 +19,6 @@ package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.utils.Utils;
 import org.apache.flume.Context;
-import org.apache.flume.channel.MemoryChannel;
-import org.apache.flume.lifecycle.LifecycleState;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,30 +30,6 @@ import org.mockito.runners.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OrionSTHSinkTest {
-    
-    /**
-     * [OrionSTHSink] -------- The sink starts properly.
-     */
-    @Test
-    public void testStart() {
-        System.out.println("[OrionSTHSink] -------- The sink starts properly");
-        String collectionPrefix = "sth_";
-        String dbPrefix = "sth_";
-        OrionSTHSink sink = new OrionSTHSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
-        sink.setChannel(new MemoryChannel());
-        sink.start();
-        LifecycleState state = sink.getLifecycleState();
-        
-        try {
-            assertEquals(LifecycleState.START, state);
-            System.out.println("[OrionSTHSink] -  OK  - The sink started properly, the lifecycle state is '"
-                    + state.toString() + "'");
-        } catch (AssertionError e) {
-            System.out.println("[OrionSTHSink] - FAIL - The sink did not start properly, the lifecycle state "
-                    + "is '" + state.toString() + "'");
-        } // try catch
-    } // testStart
     
     /**
      * [OrionSTHSink] -------- Configured 'collection_prefix' cannot be 'system.'.

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
@@ -22,6 +22,7 @@ import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -49,7 +50,7 @@ public class OrionSinkTest {
     public void testStart() {
         System.out.println("[OrionSink] -------- The sink starts properly");
         OrionSinkImpl sink = new OrionSinkImpl();
-        sink.configure(createContext());
+        sink.configure(createContext(null, null, null, null, null, null)); // default configuration
         sink.setChannel(new MemoryChannel());
         sink.start();
         LifecycleState state = sink.getLifecycleState();
@@ -73,7 +74,7 @@ public class OrionSinkTest {
         System.out.println("[OrionSink.configure] -------- When not configured, the default values are used "
                 + "for non mandatory parameters");
         OrionSinkImpl sink = new OrionSinkImpl();
-        sink.configure(createContext());
+        sink.configure(createContext(null, null, null, null, null, null)); // default configuration
         
         try {
             assertEquals(1, sink.getBatchSize());
@@ -136,14 +137,109 @@ public class OrionSinkTest {
         } // try catch
     } // testConfigureNotMandatoryParameters
     
-    private Context createContext() {
+    /**
+     * [OrionSink.configure] -------- The configuration becomes invalid upon out-of-the-limits configured values
+     * for parameters having a discrete set of accepted values, or numerical values having upper or lower limits.
+     */
+    @Test
+    public void testConfigureInvalidConfiguration() {
+        System.out.println("[OrionSink.configure] -------- The configuration becomes invalid upon out-of-the-limits "
+                + "configured values for parameters having a discrete set of accepted values, or numerical values "
+                + "having upper or lower limits");
+        OrionSinkImpl sink = new OrionSinkImpl();
+        String configuredBatchSize = "0";
+        sink.configure(createContext(configuredBatchSize, null, null, null, null, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_size='"
+                    + configuredBatchSize + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_size='"
+                    + configuredBatchSize + "' has not been detected");
+            throw e;
+        } // try catch
+        
+        sink = new OrionSinkImpl();
+        String configuredBatchTimeout = "0";
+        sink.configure(createContext(null, configuredBatchTimeout, null, null, null, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_timeout='"
+                    + configuredBatchTimeout + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_timeout='"
+                    + configuredBatchTimeout + "' has not been detected");
+            throw e;
+        } // try catch
+        
+        sink = new OrionSinkImpl();
+        String configuredBatchTTL = "-2";
+        sink.configure(createContext(null, null, configuredBatchTTL, null, null, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_ttl='"
+                    + configuredBatchTTL + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_ttl='"
+                    + configuredBatchTTL + "' has not been detected");
+            throw e;
+        } // try catch
+        
+        sink = new OrionSinkImpl();
+        String dataModel = "dm-by-other";
+        sink.configure(createContext(null, null, null, dataModel, null, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'data_model='"
+                    + dataModel + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'data_model='"
+                    + dataModel + "' has not been detected");
+            throw e;
+        } // try catch
+        
+        sink = new OrionSinkImpl();
+        String configuredEnableGrouping = "falso";
+        sink.configure(createContext(null, null, null, null, configuredEnableGrouping, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'enable_grouping='"
+                    + configuredEnableGrouping + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'enable_grouping='"
+                    + configuredEnableGrouping + "' has not been detected");
+            throw e;
+        } // try catch
+        
+        sink = new OrionSinkImpl();
+        String configuredEnableLowercase = "verdadero";
+        sink.configure(createContext(null, null, null, null, null, configuredEnableLowercase));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'enable_lowercase='"
+                    + configuredEnableLowercase + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'enable_lowercase='"
+                    + configuredEnableLowercase + "' has not been detected");
+            throw e;
+        } // try catch
+    } // testConfigureInvalidConfiguration
+    
+    private Context createContext(String batchSize, String batchTimeout, String batchTTL, String dataModel,
+            String enableGrouping, String enableLowercase) {
         Context context = new Context();
-        context.put("batch_size", "1");
-        context.put("batch_timeout", "30");
-        context.put("batch_ttl", "10");
-        context.put("data_model", "dm-by-entity");
-        context.put("enable_grouping", "false");
-        context.put("enable_lowercase", "false");
+        context.put("batch_size", batchSize);
+        context.put("batch_timeout", batchTimeout);
+        context.put("batch_ttl", batchTTL);
+        context.put("data_model", dataModel);
+        context.put("enable_grouping", enableGrouping);
+        context.put("enable_lowercase", enableLowercase);
         return context;
     } // createContext
     

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
+import org.apache.flume.Context;
+import org.apache.flume.channel.MemoryChannel;
+import org.apache.flume.lifecycle.LifecycleState;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class OrionSinkTest {
+    
+    /**
+     * This class is used to test once and only once the common functionality shared by all the real extending sinks.
+     */
+    private class OrionSinkImpl extends OrionSink {
+
+        @Override
+        void persistBatch(Batch batch) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet.");
+        } // persistBatch
+        
+    } // OrionSinkImpl
+    
+    /**
+     * [OrionSink] -------- The sink starts properly.
+     */
+    @Test
+    public void testStart() {
+        System.out.println("[OrionSink] -------- The sink starts properly");
+        OrionSinkImpl sink = new OrionSinkImpl();
+        sink.configure(createContext());
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        LifecycleState state = sink.getLifecycleState();
+        
+        try {
+            assertEquals(LifecycleState.START, state);
+            System.out.println("[OrionSink] -  OK  - The sink started properly, the lifecycle state is '"
+                    + state.toString() + "'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink] - FAIL - The sink did not start properly, the lifecycle state "
+                    + "is '" + state.toString() + "'");
+        } // try catch
+    } // testStart
+    
+    /**
+     * [OrionSink.configure] -------- When not configured, the default values are used for non mandatory
+     * parameters.
+     */
+    @Test
+    public void testConfigureNotMandatoryParameters() {
+        System.out.println("[OrionSink.configure] -------- When not configured, the default values are used "
+                + "for non mandatory parameters");
+        OrionSinkImpl sink = new OrionSinkImpl();
+        sink.configure(createContext());
+        
+        try {
+            assertEquals(1, sink.getBatchSize());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'batch_size' is '1'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'batch_size' is '" + sink.getBatchSize() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(30, sink.getBatchTimeout());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'batch_timeout' is '30'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'batch_timeout' is '" + sink.getBatchTimeout() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(10, sink.getBatchTTL());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'batch_ttl' is '10'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'batch_ttl' is '" + sink.getBatchTTL() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(DataModel.DMBYENTITY, sink.getDataModel());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'data_model' is 'dm-by-entity'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'data_model' is '" + sink.getDataModel() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(false, sink.getEnableGrouping());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'enable_grouping' is 'false'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'enable_grouping' is '" + sink.getEnableGrouping() + "'");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(false, sink.getEnableLowerCase());
+            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
+                    + "'enable_lowercase' is 'false'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+                    + "'enable_lowercase' is '" + sink.getEnableLowerCase() + "'");
+            throw e;
+        } // try catch
+    } // testConfigureNotMandatoryParameters
+    
+    private Context createContext() {
+        Context context = new Context();
+        context.put("batch_size", "1");
+        context.put("batch_timeout", "30");
+        context.put("batch_ttl", "10");
+        context.put("data_model", "dm-by-entity");
+        context.put("enable_grouping", "false");
+        context.put("enable_lowercase", "false");
+        return context;
+    } // createContext
+    
+} // OrionSinkTest

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
@@ -21,6 +21,8 @@ import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -42,6 +44,13 @@ public class OrionSinkTest {
         } // persistBatch
         
     } // OrionSinkImpl
+    
+    /**
+     * Constructor.
+     */
+    public OrionSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.ERROR);
+    } // OrionSinkTest
     
     /**
      * [OrionSink] -------- The sink starts properly.


### PR DESCRIPTION
* Partially implements issue #754 (hardening, adding more unit tests)
* 100% unit tests passed:
```
Running com.telefonica.iot.cygnus.sinks.OrionSinkTest
[OrionSink] -------- The sink starts properly
[OrionSink] -  OK  - The sink started properly, the lifecycle state is 'START'
[OrionSink.configure] -------- The configuration becomes invalid upon out-of-the-limits configured values for parameters having a discrete set of accepted values, or numerical values having upper or lower limits
[OrionSink.configure] -  OK  - A wrong configuration 'batch_size='0' has been detected
[OrionSink.configure] -  OK  - A wrong configuration 'batch_timeout='0' has been detected
[OrionSink.configure] -  OK  - A wrong configuration 'batch_ttl='-2' has been detected
[OrionSink.configure] -  OK  - A wrong configuration 'data_model='dm-by-other' has been detected
[OrionSink.configure] -  OK  - A wrong configuration 'enable_grouping='falso' has been detected
[OrionSink.configure] -  OK  - A wrong configuration 'enable_lowercase='verdadero' has been detected
[OrionSink.configure] -------- When not configured, the default values are used for non mandatory parameters
[OrionSink.configure] -  OK  - The default configuration value for 'batch_size' is '1'
[OrionSink.configure] -  OK  - The default configuration value for 'batch_timeout' is '30'
[OrionSink.configure] -  OK  - The default configuration value for 'batch_ttl' is '10'
[OrionSink.configure] -  OK  - The default configuration value for 'data_model' is 'dm-by-entity'
[OrionSink.configure] -  OK  - The default configuration value for 'enable_grouping' is 'false'
[OrionSink.configure] -  OK  - The default configuration value for 'enable_lowercase' is 'false'
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.321 sec
```
* Assignee @pcoello25 