### PR TITLE
hardening/920_remove_user_agent_and_ttl_headers_and_modify_content_type_header

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -27,3 +27,4 @@
 - [HARDENING] Expand topic name in OrionKafkaSink (#880)
 - [BUG] Remove 'Z' character (UTC mark) when encoding the reception time in OrionMySQLSink (#909)
 - [HARDENING] Invalidate configurations instead of exiting Cygnus upon wrong configuration (#917)
+- [HARDENING] Remove the user-agent header, and consider content-type as a Http-only header (#920)

--- a/doc/flume_extensions_catalogue/orion_rest_handler.md
+++ b/doc/flume_extensions_catalogue/orion_rest_handler.md
@@ -1,18 +1,52 @@
-#<a name="top"></a>OrionCKANSink
+#<a name="top"></a>OrionRestHandler
 Content:
 
 * [Functionality](#section1)
     * [Mapping NGSI events to flume events](#section1.1)
-    * [Example](#section1.2)
+    * [Additional headers added by Flume interceptors](#section1.2)
+    * [Example](#section1.3)
 * [Administration guide](#section2)
     * [Configuration](#section2.1)
 * [Programmers guide](#section3)
     * [`OrionRestHandler` class](#section3.1)
 
 ##<a name="section1"></a>Functionality
-###<a name"section1.1"></a>Mapping NGSI events to flume events
-This section explains how a notified NGSI event containing context data is converted into a Flume event, suitable for being consumed by any of the Cygnus sinks, thanks to OrionRESTHandler
+###<a name="section1.1"></a>Mapping NGSI events to flume events
+This section explains how a notified NGSI event (an http message) containing context data is converted into a Flume event (an object in memory or a file), suitable for being consumed by any of the Cygnus sinks, thanks to `OrionRestHandler`.
 
+It is necessary to remark again this handler is designed for being used by `HttpSource`, the native component of Apache Flume. An http message containing a NGSI-like notification will be received by `HttpSource` and passed to `OrionRestHandler` in order to create one, and only one, Flume event object to be put in a sink's channel (mainly, these channels are objects in memory, or files).
+
+On the one hand, the http message containing the NGSI-like notification will be composed of a set of http headers, and a payload. On the other hand, a Flume event object is composed of a set of headers, and a body. As can be seen, there is a quasi-direct translation among http message and Flume event object:
+
+| http message | Flume event object |
+|---|---|
+| `Content-Type` header | `content-type` header (discarded from 0.14.0) |
+| `Fiware-Service` header | `fiware-service` header |
+| `Fiware-ServicePath` header | `fiware-servicepath` header |
+| `Fiware-Correlator` header | `fiware-correlator` header |
+| any other header | discarded |
+| payload | body |
+
+All the FIWARE headers are added to the Flume event object if notified. If not, default values are used (it is the case of `fiware-service` and `fiware-servicepath`, which take the configured value of `default_service` and `default_service_path` respectively, see below the configuration section) or auto-generated (it is the case of `fiware-correlator`).
+
+In addition to the `fiware-correlator`, a `transaction-id` is created for internally identify a complete Cygnus transaction, i.e. starting at the source when the context data is notified, and finishing in the sink, where such data is finally persisted. If `Fiware-Correlator` header is not notified, then `fiware-correlator` and `transactionid` get the same auto-generated value.
+
+[Top](#top)
+
+###<a name="section1.2"></a>Additional headers added by Flume interceptors
+Despite all the details about interceptors used in Cygnus are widely documented [here](./grouping_interceptor.md), it is worth reminding that:
+
+* An interceptor is a piece of code in charge of "intercepting" events before they are put in the sink's channel and modifying them by adding/removing/modifying a header.
+* A `timestamp` header is added by the native `TimestampInterceptor`. It is expressed as a Unix time.
+* A `notified-entities` header is added by the custom `GroupingInterceptor`. This header contains one <i>default destination</i> per each notified context element. It is used by the sinks when the grouping rules are not enabled.
+* A `notified-servicepaths` header is added by the custom `GroupingInterceptor`. This header contains one <i>default service path</i> per each notified context element. It is used by the sinks when the grouping rules are not enabled.
+* A `grouped-entities` header is added by the custom `GroupingInterceptor`. This header contains one <i>grouped destination</i> per each notified context element. It is used by the sinks when the grouping rules are enabled.
+* A `grouped-servicepath` header is added by the custom `GroupingInterceptor`. This header contains one <i>grouped service path</i> per each notified context element. It is used by the sinks when the grouping rules are enabled.
+
+
+[Top](#top)
+
+###<a name="section1.3"></a>Example
 A NGSI-like event example could be (the code below is an <i>object representation</i>, not any real data format; look for it at [Orion documentation](https://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_User_and_Programmers_Guide#ONCHANGE)):
 
     ngsi-event={
@@ -23,6 +57,7 @@ A NGSI-like event example could be (the code below is an <i>object representatio
             Content-Type: application/json
             Fiware-Service: vehicles
             Fiware-ServicePath: 4wheels
+            Fiware-Correlator: ABCDEF1234567890
         },
         payload={
             {
@@ -58,15 +93,14 @@ A NGSI-like event example could be (the code below is an <i>object representatio
         }
     }
 
-Flume events are not much more different than the above representation: there is a set of headers and a body. This is an advantage, since allows for a quick translation between formats. The equivalent <i>object representation</i> (not any real data format) for such a notified NGSI event could be the following Flume event:
+As said, Flume events are not much more different than the above representation: there is a set of headers and a body. This is an advantage, since allows for a quick translation between formats. The equivalent <i>object representation</i> (not any real data format) for such a notified NGSI event could be the following Flume event:
 
     flume-event={
         headers={
-	         content-type=application/json,
 	         timestamp=1429535775,
-	         transactionId=1429535775-308-0000000000,
 	         fiware-service=vehicles,
 	         fiware-servicepath=/4wheels,
+	         fiware-correlator=ABCDEF1234567890
 	         notified-entities=car1_car
 	         notified-servicepaths=/4wheels
 	         grouped-entities=car1_car
@@ -89,22 +123,6 @@ Flume events are not much more different than the above representation: there is
 	         ]
 	     }
     }
-
-The headers are a subset of the notified HTTP headers and others added by Cygnus interceptors:
-
-* The <b>content-type</b> header is a replica of the HTTP header. It is needed for the different sinks to know how to parse the event body. In this case it is JSON.
-* The notification reception time is included in the list of headers (as <b>timestamp</b>) for timestamping purposes in the different sinks. It is added by a native interceptor.
-* The <b>transactionId</b> identifies a complete Cygnus transaction, starting at the source when the context data is notified, and finishing in the sink, where such data is finally persisted. It is generated by Cygnus unless notifed as a Http header; in that case it is reused instead.
-* Note that Orion can include a `Fiware-Service` HTTP header specifying the tenant/organization associated to the notification. Since version 0.3, Cygnus is able to support this header, although the actual processing of such tenant/organization depends on the particular sink. If the notification doesn't include this header, then Cygnus will use the default service specified in the `default_service` configuration property of `OrionRESTHandler`. This NGSI header is directly added to the Flume event as `fiware-service`.
-* Orion can notify another HTTP header, `Fiware-ServicePath` specifying a subservice within a tenant/organization. Since version 0.6, Cygnus is able to support this header, although the actual processing of such subservice depends on the particular sink. If the notification doesn't include this header, then Cygnus will use the default service path specified in the `default_service_path` configuration property of `OrionRESTHandler`. This NGSI header is used for building several Flume headers:
-    * It is directly added as the `fiware-servicepath`.
-    * It is replicated, per each notified context element, as the `notified-servicespaths` array. This is used when the grouping feature is not enabled in the processing sink.
-    * It may also appear in the `grouped-servicepaths` array when, being enabled the grouping feature, there is no rule changing the default servicePath.
-* By the default, the final persistece element (file, table, collection, etc), also named as the <i>destination</i>, is composed as the concatenation of the entity ID and type. This can be changed by the grouping feature, if enabled, deciding a new detination per each notified context element. Thus, the following headers may appear in a Flume event:
-    * `notified-entities`, an array that can be used by those sinks not enabling the grouping feature.
-    * `grouped-entities`, an array that can be used by those sinks enabling the grouping feature.
-
-The body simply contains a byte representation of the HTTP payload that will be parsed by the sinks.
 
 [Top](#top)
 

--- a/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
+++ b/src/main/java/com/telefonica/iot/cygnus/handlers/OrionRestHandler.java
@@ -234,14 +234,14 @@ public class OrionRestHandler implements HTTPSourceHandler {
             
             if (headerName.equals(Constants.HEADER_TRANSACTION_ID)) {
                 transId = headerValue;
-            } else if (headerName.equals(Constants.HEADER_CONTENT_TYPE)) {
+            } else if (headerName.equals(Constants.HTTP_HEADER_CONTENT_TYPE)) {
                 if (!headerValue.contains("application/json")) {
                     LOGGER.warn("Bad HTTP notification (" + headerValue + " content type not supported)");
                     throw new HTTPBadRequestException(headerValue + " content type not supported");
                 } else {
                     contentType = headerValue;
                 } // if else
-            } else if (headerName.equals(Constants.HTTP_HEADER_FIWARE_SERVICE)) {
+            } else if (headerName.equals(Constants.HEADER_FIWARE_SERVICE)) {
                 if (headerValue.length() > Constants.SERVICE_HEADER_MAX_LEN) {
                     LOGGER.warn("Bad HTTP notification ('fiware-service' header length greater than "
                             + Constants.SERVICE_HEADER_MAX_LEN + ")");
@@ -250,7 +250,7 @@ public class OrionRestHandler implements HTTPSourceHandler {
                 } else {
                     service = headerValue;
                 } // if else
-            } else if (headerName.equals(Constants.HTTP_HEADER_FIWARE_SERVICE_PATH)) {
+            } else if (headerName.equals(Constants.HEADER_FIWARE_SERVICE_PATH)) {
                 if (headerValue.length() > Constants.SERVICE_PATH_HEADER_MAX_LEN) {
                     LOGGER.warn("Bad HTTP notification ('fiware-servicePath' header length greater than "
                             + Constants.SERVICE_PATH_HEADER_MAX_LEN + ")");
@@ -300,15 +300,12 @@ public class OrionRestHandler implements HTTPSourceHandler {
         
         // create the appropiate headers
         Map<String, String> eventHeaders = new HashMap<String, String>();
-        eventHeaders.put(Constants.HEADER_CONTENT_TYPE, contentType);
-        LOGGER.debug("Adding flume event header (name=" + Constants.HEADER_CONTENT_TYPE + ", value=" + contentType
-                + ")");
-        eventHeaders.put(Constants.HTTP_HEADER_FIWARE_SERVICE, service == null ? defaultService : service);
-        LOGGER.debug("Adding flume event header (name=" + Constants.HTTP_HEADER_FIWARE_SERVICE
+        eventHeaders.put(Constants.HEADER_FIWARE_SERVICE, service == null ? defaultService : service);
+        LOGGER.debug("Adding flume event header (name=" + Constants.HEADER_FIWARE_SERVICE
                 + ", value=" + (service == null ? defaultService : service) + ")");
-        eventHeaders.put(Constants.HTTP_HEADER_FIWARE_SERVICE_PATH, servicePath == null
+        eventHeaders.put(Constants.HEADER_FIWARE_SERVICE_PATH, servicePath == null
                 ? defaultServicePath : servicePath);
-        LOGGER.debug("Adding flume event header (name=" + Constants.HTTP_HEADER_FIWARE_SERVICE_PATH
+        LOGGER.debug("Adding flume event header (name=" + Constants.HEADER_FIWARE_SERVICE_PATH
                 + ", value=" + (servicePath == null ? defaultServicePath : servicePath) + ")");
         eventHeaders.put(Constants.HEADER_TRANSACTION_ID, transId);
         LOGGER.debug("Adding flume event header (name=" + Constants.HEADER_TRANSACTION_ID

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptor.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingInterceptor.java
@@ -76,27 +76,19 @@ public class GroupingInterceptor implements Interceptor {
         String body = new String(event.getBody());
         
         // get some original header values
-        String fiwareServicePath = headers.get(Constants.HTTP_HEADER_FIWARE_SERVICE_PATH);
+        String fiwareServicePath = headers.get(Constants.HEADER_FIWARE_SERVICE_PATH);
         
         // parse the original body; this part may be unnecessary if notifications are parsed at the source only once
         // see --> https://github.com/telefonicaid/fiware-cygnus/issues/359
         NotifyContextRequest notification;
+        Gson gson = new Gson();
 
-        if (headers.get(Constants.HEADER_CONTENT_TYPE).contains("application/json")) {
-            Gson gson = new Gson();
-
-            try {
-                notification = gson.fromJson(body, NotifyContextRequest.class);
-            } catch (Exception e) {
-                LOGGER.error("Runtime error (" + e.getMessage() + ")");
-                return null;
-            } // try catch // try catch
-        } else {
-            // this point should never be reached since the content type has been checked when receiving the
-            // notification
-            LOGGER.error("Runtime error (Unrecognized content type (not Json)");
+        try {
+            notification = gson.fromJson(body, NotifyContextRequest.class);
+        } catch (Exception e) {
+            LOGGER.error("Runtime error (" + e.getMessage() + ")");
             return null;
-        } // if else if
+        } // try catch
         
         // iterate on the contextResponses
         ArrayList<String> defaultDestinations = new ArrayList<String>();

--- a/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
+++ b/src/main/java/com/telefonica/iot/cygnus/sinks/OrionSink.java
@@ -415,9 +415,9 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
                 MDC.put(Constants.LOG4J_TRANS,
                         event.getHeaders().get(Constants.HEADER_TRANSACTION_ID));
                 MDC.put(Constants.LOG4J_SVC,
-                        event.getHeaders().get(Constants.HTTP_HEADER_FIWARE_SERVICE));
+                        event.getHeaders().get(Constants.HEADER_FIWARE_SERVICE));
                 MDC.put(Constants.LOG4J_SUBSVC,
-                        event.getHeaders().get(Constants.HTTP_HEADER_FIWARE_SERVICE_PATH));
+                        event.getHeaders().get(Constants.HEADER_FIWARE_SERVICE_PATH));
             } catch (Exception e) {
                 LOGGER.error("Runtime error (" + e.getMessage() + ")");
             } // catch
@@ -502,24 +502,16 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
      */
     private NotifyContextRequest parseEventBody(Event event) throws Exception {
         String eventData = new String(event.getBody());
-        Map<String, String> eventHeaders = event.getHeaders();
 
-        // parse the eventData
+        // parse the event body as a Json document
         NotifyContextRequest notification = null;
+        Gson gson = new Gson();
 
-        if (eventHeaders.get(Constants.HEADER_CONTENT_TYPE).contains("application/json")) {
-            Gson gson = new Gson();
-
-            try {
-                notification = gson.fromJson(eventData, NotifyContextRequest.class);
-            } catch (Exception e) {
-                throw new CygnusBadContextData(e.getMessage());
-            } // try catch
-        } else {
-            // this point should never be reached since the content type has been checked when receiving the
-            // notification
-            throw new Exception("Unrecognized content type (not Json)");
-        } // if else if
+        try {
+            notification = gson.fromJson(eventData, NotifyContextRequest.class);
+        } catch (Exception e) {
+            throw new CygnusBadContextData(e.getMessage());
+        } // try catch
 
         return notification;
     } // parseEventBody
@@ -601,7 +593,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
 
         private void accumulateByService(Map<String, String> headers, NotifyContextRequest notification) {
             Long recvTimeTs = new Long(headers.get(Constants.FLUME_HEADER_TIMESTAMP));
-            String service = headers.get(Constants.HTTP_HEADER_FIWARE_SERVICE);
+            String service = headers.get(Constants.HEADER_FIWARE_SERVICE);
             String destination = service;
 
             if (!enableGrouping) {
@@ -627,7 +619,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
 
         private void accumulateByServicePath(Map<String, String> headers, NotifyContextRequest notification) {
             Long recvTimeTs = new Long(headers.get(Constants.FLUME_HEADER_TIMESTAMP));
-            String service = headers.get(Constants.HTTP_HEADER_FIWARE_SERVICE);
+            String service = headers.get(Constants.HEADER_FIWARE_SERVICE);
 
             if (!enableGrouping) {
                 String[] notifiedServicePaths = headers.get(Constants.FLUME_HEADER_NOTIFIED_SERVICE_PATHS).split(",");
@@ -654,7 +646,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
 
         private void accumulateByEntity(Map<String, String> headers, NotifyContextRequest notification) {
             Long recvTimeTs = new Long(headers.get(Constants.FLUME_HEADER_TIMESTAMP));
-            String service = headers.get(Constants.HTTP_HEADER_FIWARE_SERVICE);
+            String service = headers.get(Constants.HEADER_FIWARE_SERVICE);
 
             if (!enableGrouping) {
                 String[] notifiedServicePaths = headers.get(Constants.FLUME_HEADER_NOTIFIED_SERVICE_PATHS).split(",");
@@ -683,7 +675,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
 
         private void accumulateByAttribute(Map<String, String> headers, NotifyContextRequest notification) {
             Long recvTimeTs = new Long(headers.get(Constants.FLUME_HEADER_TIMESTAMP));
-            String service = headers.get(Constants.HTTP_HEADER_FIWARE_SERVICE);
+            String service = headers.get(Constants.HEADER_FIWARE_SERVICE);
             ArrayList<ContextElementResponse> contextElementResponses = notification.getContextResponses();
 
             if (!enableGrouping) {

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
@@ -29,23 +29,22 @@ public final class Constants {
      */
     private Constants() {
     } // Constants
-
-    // HTTP header names
-    public static final String HTTP_HEADER_FIWARE_SERVICE      = "fiware-service";
-    public static final String HTTP_HEADER_FIWARE_SERVICE_PATH = "fiware-servicepath";
+    
+    // Http header names
+    public static final String HTTP_HEADER_CONTENT_TYPE = "content-type";
     
     // Flume header names
     public static final String FLUME_HEADER_NOTIFIED_SERVICE_PATHS = "notified-servicepaths";
     public static final String FLUME_HEADER_GROUPED_SERVICE_PATHS  = "grouped-servicepaths";
     public static final String FLUME_HEADER_NOTIFIED_ENTITIES      = "notified-entities";
     public static final String FLUME_HEADER_GROUPED_ENTITIES       = "grouped-entities";
-    public static final String FLUME_HEADER_TTL                    = "ttl";
     public static final String FLUME_HEADER_TIMESTAMP              = "timestamp";
     
     // Both HTTP and Flume header names
-    public static final String HEADER_CONTENT_TYPE   = "content-type";
-    public static final String HEADER_USER_AGENT     = "user-agent";
-    public static final String HEADER_TRANSACTION_ID = "fiware-transaction";
+    
+    public static final String HEADER_FIWARE_SERVICE      = "fiware-service";
+    public static final String HEADER_FIWARE_SERVICE_PATH = "fiware-servicepath";
+    public static final String HEADER_TRANSACTION_ID      = "fiware-transaction";
 
     // Common fields for sinks/backends
     public static final String RECV_TIME_TS        = "recvTimeTs";
@@ -74,7 +73,6 @@ public final class Constants {
     public static final String PARAM_DEFAULT_SERVICE      = "default_service";
     public static final String PARAM_DEFAULT_SERVICE_PATH = "default_service_path";
     public static final String PARAM_NOTIFICATION_TARGET  = "notification_target";
-    public static final String PARAM_EVENTS_TTL           = "events_ttl";
     
     // OrionSTHSink specific headers
     public static final int STH_MAX_NAMESPACE_SIZE_IN_BYTES = 113;


### PR DESCRIPTION
* Implements issue #920 
* 100% unit tests passed:
```
Tests run: 89, Failures: 0, Errors: 0, Skipped: 0
```

`OrionRestHandler` specific tests detail:
```
Running com.telefonica.iot.cygnus.handlers.OrionRestHandlerTest
[OrionRestHandler.configure] -------- The configured default service path must start with '/'
[OrionRestHandler.configure] -  OK  - The configured default service path '/something' starts with '/'
[OrionRestHandler.getEvents] -------- When a the configuration is wrong, no evetns are obtained
16/04/05 16:14:03 ERROR handlers.OrionRestHandler: Bad configuration (notification_target=notify) -- Must start with '/'
16/04/05 16:14:03 ERROR handlers.OrionRestHandler: Bad configuration ('default_service_path' must start with '/')
[OrionRestHandler.getEvents] -  OK  - No events are processed since the configuration is wrong
[OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is reused
[OrionRestHandler.generateTransId] -  OK  - The notified transaction ID '1234567890-123-1234567890' is reused
[OrionRestHandler.configure] -------- The configured notification target must start with '/'
[OrionRestHandler.configure] -  OK  - The configured notification target '/notify' starts with '/'
[OrionRestHandler.configure] -------- When not configured, the default values are used for non mandatory parameters
[OrionRestHandler.configure] -  OK  - The default configuration value for 'notification_target' is '/notify'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service' is 'default'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service_path' is '/'
[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains fiware-service, fiware-servicepath and fiware-correlator headers
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'fiware-service'
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'fiware-service'
[OrionRestHandler.generateTransId] -------- When a transcation ID is not notified, it is generated
[OrionRestHandler.generateTransId] -  OK  - The transaction ID has been generated
[OrionRestHandler.getEvents] -------- When a notification is sent, the headers are valid
[OrionRestHandler.getEvents] -  OK  - The value for 'Content-Type' header is 'application/json'
[OrionRestHandler.getEvents] -  OK  - The value for 'fiware-servicePath' header starts with '/'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-service' header value is  less or equal than '50'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-servicePath' header value is less or equal than '50'
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.559 sec
```
* (unofficial) e2e tests passed:
```
time=2016-04-05T16:27:43.606CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header host received with value localhost:5050
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header content-type received with value application/json
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header accept received with value application/json
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header user-agent received with value orion/0.10.0
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header fiware-service received with value default
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header fiware-servicepath received with value /algo
time=2016-04-05T16:27:43.607CEST | lvl=DEBUG | trans= | svc= | subsvc= | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[233] : Header content-length received with value 460
time=2016-04-05T16:27:43.609CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[283] : Starting transaction (1459866457-443-0000000000)
time=2016-04-05T16:27:43.610CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[299] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-05T16:27:43.610CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[304] : Adding flume event header (name=fiware-service, value=default)
time=2016-04-05T16:27:43.610CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[308] : Adding flume event header (name=fiware-servicepath, value=/algo)
time=2016-04-05T16:27:43.610CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[311] : Adding flume event header (name=fiware-transaction, value=1459866457-443-0000000000)
time=2016-04-05T16:27:43.625CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[318] : Event put in the channel, id=1056470232
time=2016-04-05T16:27:43.692CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[427] : Event got from the channel (id=1056470232, headers={grouped-entities=Room1_Room, grouped-servicepaths=/algo, fiware-servicepath=/algo, notified-servicepaths=/algo, fiware-service=default, fiware-transaction=1459866457-443-0000000000, notified-entities=Room1_Room, timestamp=1459866463625}, bodyLength=460)
time=2016-04-05T16:28:09.707CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[391] : Batch accumulation time reached, the batch will be processed as it is
time=2016-04-05T16:28:09.707CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[443] : Batch completed, persisting it
time=2016-04-05T16:28:09.708CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=persistBatch | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[429] : [hdfs-sink] Processing sub-batch regarding the default_/algo_Room1_Room destination
time=2016-04-05T16:28:09.711CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=aggregate | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink$JSONColumnAggregator[651] : [hdfs-sink] Processing context element (id=Room1, type=Room)
time=2016-04-05T16:28:09.711CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=aggregate | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink$JSONColumnAggregator[673] : [hdfs-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-04-05T16:28:09.711CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[954] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (default/algo/Room1_Room/Room1_Room.txt), Data ({"recvTime":"2016-04-05T14:27:43.625Z","fiwareServicePath":"/algo","entityId":"Room1","entityType":"Room", "temperature":"26.5", "temperature_md":[]})
time=2016-04-05T16:28:09.716CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=doRequest | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[184] : Http request: GET http://cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/algo/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-04-05T16:28:10.346CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[264] : Http response status line: HTTP/1.1 200 OK
time=2016-04-05T16:28:10.348CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : Http response payload: {"FileStatus":{"pathSuffix":"","type":"FILE","length":1800,"owner":"frb","group":"frb","permission":"644","accessTime":1459780222569,"modificationTime":1459780290018,"blockSize":67108864,"replication":3}}
time=2016-04-05T16:28:10.349CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=doRequest | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[184] : Http request: POST http://cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/algo/Room1_Room/Room1_Room.txt?op=append&user.name=frb HTTP/1.1
time=2016-04-05T16:28:10.465CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[264] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-04-05T16:28:10.466CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : Http response payload: 
time=2016-04-05T16:28:10.467CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=doRequest | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[184] : Http request: POST http://cosmos.lab.fi-ware.org:14000/webhdfs/v1/user/frb/default/algo/Room1_Room/Room1_Room.txt?op=APPEND&user.name=frb&data=true HTTP/1.1
time=2016-04-05T16:28:10.848CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[264] : Http response status line: HTTP/1.1 200 OK
time=2016-04-05T16:28:10.848CEST | lvl=DEBUG | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=createJsonResponse | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[280] : Http response payload: 
time=2016-04-05T16:28:10.849CEST | lvl=INFO | trans=1459866457-443-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[447] : Finishing transaction (1459866457-443-0000000000)
```
* Assignee @pcoello25 