### PR TITLE
hardening/922_add_support_for_sql_timestamps_with_microseconds

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -27,3 +27,4 @@
 - [HARDENING] Expand topic name in OrionKafkaSink (#880)
 - [BUG] Remove 'Z' character (UTC mark) when encoding the reception time in OrionMySQLSink (#909)
 - [HARDENING] Invalidate configurations instead of exiting Cygnus upon wrong configuration (#917)
+- [HARDENING] Add support for SQL timestamps with microseconds in Utils.getTimeInstant (#922)

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Utils.java
@@ -300,7 +300,15 @@ public final class Utils {
                                         dateTime = FORMATTER4.parseDateTime(mdValue);
                                     } catch (Exception e5) {
                                         LOGGER.debug(e5.getMessage());
-                                        return null;
+                                        
+                                        try {
+                                            // SQL timestamp with microseconds
+                                            String mdValueTruncated = mdValue.substring(0, mdValue.length() - 3);
+                                            dateTime = FORMATTER4.parseDateTime(mdValueTruncated);
+                                        } catch (Exception e6) {
+                                            LOGGER.debug(e6.getMessage());
+                                            return null;
+                                        } // try catch
                                     } // try catch
                                 } // try catch
                             } // try catch

--- a/src/test/java/com/telefonica/iot/cygnus/utils/UtilsTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/utils/UtilsTest.java
@@ -165,4 +165,30 @@ public class UtilsTest {
         } // try catch
     } // testGetTimeInstantSQLTimestampWithMiliseconds
     
+    /**
+     * [Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp with microseconds.
+     */
+    @Test
+    public void testGetTimeInstantSQLTimestampWithMicroseconds() {
+        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL "
+                + "timestamp with microseconds");
+        JSONObject metadataJson = new JSONObject();
+        metadataJson.put("name", "TimeInstant");
+        metadataJson.put("type", "SQL timestamp");
+        metadataJson.put("value", "2017-01-01 00:00:01.123456");
+        JSONArray metadatasJson = new JSONArray();
+        metadatasJson.add(metadataJson);
+        String metadatasStr = metadatasJson.toJSONString();
+        Long timeInstant = Utils.getTimeInstant(metadatasStr);
+
+        try {
+            assertTrue(timeInstant != null);
+            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
+                    + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
+        } catch (AssertionError e) {
+            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            throw e;
+        } // try catch
+    } // testGetTimeInstantSQLTimestampWithMicroseconds
+    
 } // UtilsTest


### PR DESCRIPTION
* Implements issue #922 
* 100% unit tests passed:
```
Running com.telefonica.iot.cygnus.utils.UtilsTest
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp with microseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01.123456Z"}]' is '1483228801123'
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp with miliseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01.123"}]' is '1483228801123'
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp without miliseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01Z"}]' is '1483228801000'
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp with miliseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01.123Z"}]' is '1483228801123'
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp without miliseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01"}]' is '1483228801000'
[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp with microseconds
[Utils.getTimeInstant] -  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01.123456"}]' is '1483228801123'
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.588 sec
```
* (unofficial) e2e tests passed:
```
Received data ({	"subscriptionId": "56e2ad4e8001ff5e0a5260ec",	"originator": "localhost",	"contextResponses": [{		"contextElement": {	"type": "cosa1",			"isPattern": "false",			"id": "z0011",			"attributes": [{				"name": "temperature",		"type": "centigrade",				"value": "111",				"metadatas": [{					"name": "TimeInstant",				"type": "recvTime",					"value": "2015-12-12 11:11:11.123456"				}]			}]		},		"statusCode": {			"code": "200",			"reasonPhrase": "OK"		}	}]})
..
persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionMongoSink[344] : [mongo-sink] Persisting data at OrionMongoSink. Database: sth_default, Collection: sth_/algo_z0011_cosa1, Data: [Document{{recvTime=Sat Dec 12 12:11:11 CET 2015, attrName=temperature, attrType=centigrade, attrValue=111}}]
..
> db['sth_/algo_z0011_cosa1'].find()
{ "_id" : ObjectId("5704a754e8fae1076d868492"), "recvTime" : ISODate("2015-12-12T11:11:11.123Z"), "attrName" : "temperature", "attrType" : "centigrade", "attrValue" : "111" }
```
* Assignee @pcoello25 