### PR TITLE
hardening/880_add_tests_for_expanded_topic_names

### DIFF
--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -49,11 +49,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service] Created topic is equals to <service>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation - "
+                    + "Created topic is equal to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-service] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -72,11 +72,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service] Created topic is equals to <service>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-service] Bad build topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -95,11 +95,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service-path] Created topic is equals to <service>_<servicePath>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-service-path] Bad build topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -118,11 +118,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service-path] Created topic is equals to <service>_<servicePath>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-service-path] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -141,11 +141,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-entity] Created topic is equals to <service>_<servicePath>_<entityId>_<entityType>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-entity] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -164,11 +164,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-entity] Created topic is equals to <service>_<entityId>_<entityType>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-entity] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -187,11 +187,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-attribute] Created topic is equals to <service>_<servicePath>_<entityId>_<entityType>_<attributeName>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-attribute] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         
@@ -210,11 +210,11 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-attribute] Created topic is equals to <service>_<entityId>_<entityType>_<attributeName>");
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+                    + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
-                    + "[dm-by-attribute] Bad built topic: " + topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
         

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -40,56 +40,56 @@ public class OrionKafkaSinkTest {
     public void testTopicNameDmByService() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
                 + "root service-path is notified/defaulted and data_model="
-                + "dm-by-service and enable_grouping=false, the Kafka topic name "
+                + "dm-by-service, the Kafka topic name "
                 + "is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-service"));
+        sink.configure(createContext("false", "dm-by-service"));
         String topic = sink.buildTopicName(service,servicePath,entity,attribute);
         
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
             System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service] Create topic is equals to <service>");
+                    + "[dm-by-service] Created topic is equals to <service>");
         } catch (AssertionError e) {
             System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
                     + "[dm-by-service] Bad built topic: " + topic);
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByService
+    } // testTopicNameDmByService
     
     @Test
     public void testTopicNameDmByServiceWithSlashServicePath() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
                 + "root service-path is notified/defaulted and "
-                + "data_model=dm-by-service and enable_grouping=false, the Kafka "
+                + "data_model=dm-by-service, the Kafka "
                 + "topic name is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        sink.configure(createContext("false", "dm-by-service-path"));
         String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
         
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
             System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-service] Topic created is equals to <service>");
+                    + "[dm-by-service] Created topic is equals to <service>");
         } catch (AssertionError e) {
             System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
                     + "[dm-by-service] Bad build topic: " + topic);
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByService
+    } // testTopicNameDmByServiceWithSlashServicePath
     
     @Test
     public void testTopicNameDmByServicePath() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
                 + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-service-path and enable_grouping=false, "
+                + "and data_model=dm-by-service-path, "
                 + "the Kafka topic name is <service>_<service-path>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        sink.configure(createContext("false", "dm-by-service-path"));
         String topic = sink.buildTopicName(service,servicePath,entity,attribute);
         
         try {
@@ -103,16 +103,16 @@ public class OrionKafkaSinkTest {
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByServicePath 
+    } // testTopicNameDmByServicePath 
     
     @Test
     public void testTopicNameDmByServicePathWithSlashServicePath() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
                 + "root service-path is notified/defaulted and "
-                + "data_model=dm-by-service-path and enable_grouping=false, "
+                + "data_model=dm-by-service-path, "
                 + "the Kafka topic name is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        sink.configure(createContext("false", "dm-by-service-path"));
         String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
         
         try {
@@ -126,62 +126,62 @@ public class OrionKafkaSinkTest {
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByServicePath    
+    } // testTopicNameDmByServicePathWithSlashServicePath    
     
     @Test
     public void testTopicNameDmByEntity() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
                 + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-entity and enable_grouping=false, the "
+                + "and data_model=dm-by-entity, the "
                 + "Kafka topic name is <service>_<service-path>_<entityId>_<entityType>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-entity"));
+        sink.configure(createContext("false", "dm-by-entity"));
         String topic = sink.buildTopicName(service,servicePath,entity,attribute);
         
         try {
             expectedTopic = "service_servicePath_entityId_entityType";
             assertEquals(expectedTopic, topic);
             System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-entity] Create topic is equals to <service>_<servicePath>_<entityId>_<entityType>");
+                    + "[dm-by-entity] Created topic is equals to <service>_<servicePath>_<entityId>_<entityType>");
         } catch (AssertionError e) {
             System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
                     + "[dm-by-entity] Bad built topic: " + topic);
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByEntity
+    } // testTopicNameDmByEntity
     
     @Test
     public void testTopicNameDmByEntityWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
                 + "root service-path is notified/defaulted and data_model=dm-by-"
-                + "entity and enable_grouping=false, the Kafka topic name is "
+                + "entity, the Kafka topic name is "
                 + "<service>_<entityId>_<entityType>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-entity"));
+        sink.configure(createContext("false", "dm-by-entity"));
         String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
         
         try {
             expectedTopic = "service_entityId_entityType";
             assertEquals(expectedTopic, topic);
             System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
-                    + "[dm-by-entity] Created topid is equals to <service>_<entityId>_<entityType>");
+                    + "[dm-by-entity] Created topic is equals to <service>_<entityId>_<entityType>");
         } catch (AssertionError e) {
             System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
                     + "[dm-by-entity] Bad built topic: " + topic);
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByEntity
+    } // testTopicNameDmByEntityWithSlashServicePath
     
     @Test
     public void testTopicNameDmByAttribute() throws Exception {
         System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
                 + "root service-path is notified/defaulted and data_model=dm-by-"
-                + "attribute and enable_grouping=false, the Kafka topic name is "
+                + "attribute, the Kafka topic name is "
                 + "<service>_<service-path>_<entityId>_<entityType>_<attrName>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-attribute"));
+        sink.configure(createContext("false", "dm-by-attribute"));
         String topic = sink.buildTopicName(service,servicePath,entity,attribute);
         
         try {
@@ -195,16 +195,16 @@ public class OrionKafkaSinkTest {
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByAttribute
+    } // testTopicNameDmByAttribute
     
     @Test
     public void testTopicNameDmByAttributeWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
                 + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-attribute and enable_grouping=false, the "
+                + "and data_model=dm-by-attribute, the "
                 + "Kafka topic name is <service>_<entityId>_<entityType>_<attrName>");
         OrionKafkaSink sink = new OrionKafkaSink();
-        sink.configure(createContext("false", "false", "dm-by-attribute"));
+        sink.configure(createContext("false", "dm-by-attribute"));
         String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
         
         try {
@@ -218,12 +218,11 @@ public class OrionKafkaSinkTest {
             throw e;
         } // try catch
         
-    } // testTopicNamesDmByAttribute
+    } // testTopicNameDmByAttributeWithSlashServicePath
     
-    private Context createContext(String lowerCase, String grouping, String dataModel) {
+    private Context createContext(String lowerCase, String dataModel) {
         Context context = new Context();
         context.put("enable_lowercase", lowerCase);
-        context.put("enable_grouping", grouping);
         context.put("data_model", dataModel);
         return context;
     } // createContext

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -49,10 +49,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equal to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -72,10 +72,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -95,10 +95,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -118,10 +118,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -141,10 +141,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -164,10 +164,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -187,10 +187,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_servicePath_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
@@ -210,10 +210,10 @@ public class OrionKafkaSinkTest {
         try {
             expectedTopic = "service_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation - "
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -17,9 +17,215 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import org.apache.flume.Context;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
 /**
  *
  * @author frb
  */
 public class OrionKafkaSinkTest {   
+    
+    String service = "service";
+    String serviceUpper = "SERVICE";
+    String servicePath = "/servicePath";
+    String servicePathUpper = "/SERVICEPATH";
+    String servicePathSlash = "/";
+    String entity = "entityId_entityType";
+    String attribute = "attributeName";
+    String expectedTopic;
+    
+    @Test
+    public void testTopicNameDmByService() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted and data_model="
+                + "dm-by-service and enable_grouping=false, the Kafka topic name "
+                + "is <service>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-service"));
+        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        
+        try {
+            expectedTopic = "service";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-service] Create topic is equals to <service>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-service] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByService
+    
+    @Test
+    public void testTopicNameDmByServiceWithSlashServicePath() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
+                + "root service-path is notified/defaulted and "
+                + "data_model=dm-by-service and enable_grouping=false, the Kafka "
+                + "topic name is <service>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        
+        try {
+            expectedTopic = "service";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-service] Topic created is equals to <service>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-service] Bad build topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByService
+    
+    @Test
+    public void testTopicNameDmByServicePath() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted "
+                + "and data_model=dm-by-service-path and enable_grouping=false, "
+                + "the Kafka topic name is <service>_<service-path>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        
+        try {
+            expectedTopic = "service_servicePath";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-service-path] Created topic is equals to <service>_<servicePath>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-service-path] Bad build topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByServicePath 
+    
+    @Test
+    public void testTopicNameDmByServicePathWithSlashServicePath() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
+                + "root service-path is notified/defaulted and "
+                + "data_model=dm-by-service-path and enable_grouping=false, "
+                + "the Kafka topic name is <service>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-service-path"));
+        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        
+        try {
+            expectedTopic = "service";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-service-path] Created topic is equals to <service>_<servicePath>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-service-path] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByServicePath    
+    
+    @Test
+    public void testTopicNameDmByEntity() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted "
+                + "and data_model=dm-by-entity and enable_grouping=false, the "
+                + "Kafka topic name is <service>_<service-path>_<entityId>_<entityType>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-entity"));
+        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        
+        try {
+            expectedTopic = "service_servicePath_entityId_entityType";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-entity] Create topic is equals to <service>_<servicePath>_<entityId>_<entityType>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-entity] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByEntity
+    
+    @Test
+    public void testTopicNameDmByEntityWithSlashServicePath() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-"
+                + "entity and enable_grouping=false, the Kafka topic name is "
+                + "<service>_<entityId>_<entityType>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-entity"));
+        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        
+        try {
+            expectedTopic = "service_entityId_entityType";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-entity] Created topid is equals to <service>_<entityId>_<entityType>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-entity] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByEntity
+    
+    @Test
+    public void testTopicNameDmByAttribute() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-"
+                + "attribute and enable_grouping=false, the Kafka topic name is "
+                + "<service>_<service-path>_<entityId>_<entityType>_<attrName>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-attribute"));
+        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        
+        try {
+            expectedTopic = "service_servicePath_entityId_entityType_attributeName";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-attribute] Created topic is equals to <service>_<servicePath>_<entityId>_<entityType>_<attributeName>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-attribute] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByAttribute
+    
+    @Test
+    public void testTopicNameDmByAttributeWithSlashServicePath() throws Exception {
+        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
+                + "root service-path is notified/defaulted "
+                + "and data_model=dm-by-attribute and enable_grouping=false, the "
+                + "Kafka topic name is <service>_<entityId>_<entityType>_<attrName>");
+        OrionKafkaSink sink = new OrionKafkaSink();
+        sink.configure(createContext("false", "false", "dm-by-attribute"));
+        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        
+        try {
+            expectedTopic = "service_entityId_entityType_attributeName";
+            assertEquals(expectedTopic, topic);
+            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation "
+                    + "[dm-by-attribute] Created topic is equals to <service>_<entityId>_<entityType>_<attributeName>");
+        } catch (AssertionError e) {
+            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - Failed creation '"
+                    + "[dm-by-attribute] Bad built topic: " + topic);
+            throw e;
+        } // try catch
+        
+    } // testTopicNamesDmByAttribute
+    
+    private Context createContext(String lowerCase, String grouping, String dataModel) {
+        Context context = new Context();
+        context.put("enable_lowercase", lowerCase);
+        context.put("enable_grouping", grouping);
+        context.put("data_model", dataModel);
+        return context;
+    } // createContext
+    
 } // OrionKafkaSinkTest


### PR DESCRIPTION
* Fix issue #880 
  * Update CHANGES_NEXT_RELEASE is not required.
* 100% unit test passed:
```
Results : Tests run: 101, Failures: 0, Errors: 0, Skipped: 0
```
Specific tests added in this PR:
```
Running com.telefonica.iot.cygnus.sinks.OrionKafkaSinkTest
[OrionKafkaSink.buildTopicName ] -------- When a non root service-path is notified/defaulted and data_model=dm-by-service-path, the Kafka topic name is <service>_<service-path>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service_servicePath
[OrionKafkaSink.buildTopicName ] -------- When the root service-path is notified/defaulted and data_model=dm-by-entity, the Kafka topic name is <service>_<entityId>_<entityType>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service_entityId_entityType
[OrionKafkaSink.buildTopicName ] -------- When the root service-path is notified/defaulted and data_model=dm-by-service, the Kafka topic name is <service>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service
[OrionKafkaSink.buildTopicName ] -------- When the root service-path is notified/defaulted and data_model=dm-by-attribute, the Kafka topic name is <service>_<entityId>_<entityType>_<attrName>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service_entityId_entityType_attributeName
[OrionKafkaSink.buildTopicName ] -------- When the root service-path is notified/defaulted and data_model=dm-by-service-path, the Kafka topic name is <service>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service
[OrionKafkaSink.buildTopicName ] -------- When a non root service-path is notified/defaulted and data_model=dm-by-entity, the Kafka topic name is <service>_<service-path>_<entityId>_<entityType>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service_servicePath_entityId_entityType
[OrionKafkaSink.buildTopicName ] -------- When a non root service-path is notified/defaulted and data_model=dm-by-service, the Kafka topic name is <service>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation - Created topic is equal to service
[OrionKafkaSink.buildTopicName ] -------- When a non root service-path is notified/defaulted and data_model=dm-by-attribute, the Kafka topic name is <service>_<service-path>_<entityId>_<entityType>_<attrName>
[OrionKafkaSink.buildTopicName ] -  OK  - Succesful creation  - Created topic is equals to service_servicePath_entityId_entityType_attributeName
```
* Assignee @frbattid