### PR TITLE
hardening/928_precompile_regexes_once_read

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,3 +30,4 @@
 - [HARDENING] Invalidate configurations instead of exiting Cygnus upon wrong configuration (#917)
 - [HARDENING] Add support for SQL timestamps with microseconds in Utils.getTimeInstant (#922)
 - [HARDENING] Remove the user-agent header, and consider content-type as a Http-only header (#920)
+- [HARDENING] Precompile the regexes once read in GroupingRules.java (#928)

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
@@ -33,6 +33,7 @@ import org.json.simple.JSONObject;
 public class GroupingRule {
 
     private final JSONObject jsonRule;
+    private Pattern pattern;
 
     /**
      * Constructor.
@@ -40,6 +41,7 @@ public class GroupingRule {
      */
     public GroupingRule(JSONObject jsonRule) {
         this.jsonRule = jsonRule;
+        this.pattern = Pattern.compile((String) jsonRule.get("regex"));
     } // GroupingRule
 
     /**
@@ -79,7 +81,7 @@ public class GroupingRule {
      * @return The compiled pattern
      */
     public Pattern getPattern() {
-        return Pattern.compile((String) jsonRule.get("regex"));
+        return pattern;
     } // getPattern
 
     /**

--- a/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
+++ b/src/main/java/com/telefonica/iot/cygnus/interceptors/GroupingRule.java
@@ -33,7 +33,7 @@ import org.json.simple.JSONObject;
 public class GroupingRule {
 
     private final JSONObject jsonRule;
-    private Pattern pattern;
+    private final Pattern pattern;
 
     /**
      * Constructor.

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
@@ -71,7 +71,7 @@ public class GroupingRuleTest {
                 + "-------- Rule's attributes are not null");
         
         JSONObject jsonObject = createJsonObject();
-        jsonObject.put("id",1L);
+        jsonObject.put("id", 1L);
         
         // Create the rule for doing the tests
         GroupingRule rule = new GroupingRule(jsonObject);

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
@@ -71,6 +71,7 @@ public class GroupingRuleTest {
                 + "-------- Rule's attributes are not null");
         
         JSONObject jsonObject = createJsonObject();
+        jsonObject.put("id",1L);
         
         // Create the rule for doing the tests
         GroupingRule rule = new GroupingRule(jsonObject);
@@ -145,7 +146,6 @@ public class GroupingRuleTest {
         jsonRule.put("regex", "room1");
         jsonRule.put("fiware_service_path", "/rooms");
         jsonRule.put("destination", "all_rooms");
-        jsonRule.put("id",1L);
         return jsonRule;
     } // createJsonObject
     

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
@@ -22,7 +22,9 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -65,5 +67,83 @@ public class GroupingRuleTest {
             throw e;
         } // try catch
     } // testFiwareServicePathStartsWithSlash
+    
+    @Test
+    public void testIfGetsAreNotNull() {
+        System.out.println(getTestTraceHead("[GroupingRule.groupingRule]")
+                + "-------- Rule's attributes are not null");
+        JSONObject jsonRule = new JSONObject();
+        JSONArray fields = new JSONArray();
+        fields.add("entityId");
+        jsonRule.put("fields", fields);
+        jsonRule.put("regex", "room1");
+        jsonRule.put("fiware_service_path", "/rooms");
+        jsonRule.put("destination", "all_rooms");
+        jsonRule.put("id",1L);
+        
+        // Create the rule for do the tests
+        GroupingRule rule = new GroupingRule(jsonRule);
+        
+        try { 
+            assertTrue(rule.getPattern() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
+                    + "-  OK  - Rule’s pattern is not null. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
+                    + "- FAIL - Rule’s pattern is null. '");
+            throw e;
+        }// try catch
+        
+        try { 
+            assertTrue(rule.getId() > 0L);
+            System.out.println(getTestTraceHead("[GroupingRule.getId]")
+                    + "-  OK  - Rule’s id is upper than 0. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getId]")
+                    + "- FAIL - Rule’s id is invalid. '");
+            throw e;
+        }// try catch
+        
+        try { 
+            assertTrue(rule.getFields() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
+                    + "-  OK  - Rule’s fields are not null. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
+                    + "- FAIL - Rule’s fields are null. '");
+            throw e;
+        }// try catch
+        
+        try { 
+            assertTrue(rule.getRegex() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
+                    + "-  OK  - Rule’s regex is not null. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
+                    + "- FAIL - Rule’s regex is null. '");
+            throw e;
+        }// try catch
+        
+        try { 
+            assertTrue(rule.getDestination() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
+                    + "-  OK  - Rule’s destination is not null. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
+                    + "- FAIL - Rule’s destination is null. '");
+            throw e;
+        }// try catch
+        
+        try { 
+            assertTrue(rule.getNewFiwareServicePath() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
+                    + "-  OK  - Rule’s newFiwareServicePath is not null. '");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
+                    + "- FAIL - Rule’s newFiwareServicePath is null. '");
+            throw e;
+        }// try catch
+           
+    } // testIfGetsAreNotNull
     
 } // GroupingRuleTest

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
@@ -47,13 +47,7 @@ public class GroupingRuleTest {
     public void testFiwareServicePathStartsWithSlash() {
         System.out.println(getTestTraceHead("[GroupingRule.isValid]")
                 + "-------- fiware-servicePath field in a grouping rule must start with '/'");
-        JSONObject jsonRule = new JSONObject();
-        JSONArray fields = new JSONArray();
-        fields.add("entityId");
-        jsonRule.put("fields", fields);
-        jsonRule.put("regex", "room1");
-        jsonRule.put("fiware_service_path", "/rooms");
-        jsonRule.put("destination", "all_rooms");
+        JSONObject jsonRule = createJsonObject();
         
         try {
             assertEquals(0, GroupingRule.isValid(jsonRule, true));
@@ -68,10 +62,82 @@ public class GroupingRuleTest {
         } // try catch
     } // testFiwareServicePathStartsWithSlash
     
+    /**
+     * [Groupingrule.getXXXX] -------- Rule's attributes are not null.
+     */
     @Test
     public void testIfGetsAreNotNull() {
-        System.out.println(getTestTraceHead("[GroupingRule.groupingRule]")
+        System.out.println(getTestTraceHead("[GroupingRule.getXXXX]")
                 + "-------- Rule's attributes are not null");
+        
+        JSONObject jsonObject = createJsonObject();
+        
+        // Create the rule for doing the tests
+        GroupingRule rule = new GroupingRule(jsonObject);
+        
+        try { 
+            assertTrue(rule.getPattern() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
+                    + "-  OK  - Rule’s pattern is not null");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
+                    + "- FAIL - Rule’s pattern is null");
+            throw e;
+        } // try catch
+        
+        try { 
+            assertTrue(rule.getId() > 0L);
+            System.out.println(getTestTraceHead("[GroupingRule.getId]")
+                    + "-  OK  - Rule’s id is upper than 0");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getId]")
+                    + "- FAIL - Rule’s id is invalid");
+            throw e;
+        } // try catch
+        
+        try { 
+            assertTrue(rule.getFields() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
+                    + "-  OK  - Rule’s fields are not null");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
+                    + "- FAIL - Rule’s fields are null");
+            throw e;
+        } // try catch
+        
+        try { 
+            assertTrue(rule.getRegex() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
+                    + "-  OK  - Rule’s regex is not null");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
+                    + "- FAIL - Rule’s regex is null");
+            throw e;
+        } // try catch
+        
+        try { 
+            assertTrue(rule.getDestination() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
+                    + "-  OK  - Rule’s destination is not null");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
+                    + "- FAIL - Rule’s destination is null");
+            throw e;
+        } // try catch
+        
+        try { 
+            assertTrue(rule.getNewFiwareServicePath() != null);
+            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
+                    + "-  OK  - Rule’s newFiwareServicePath is not null");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
+                    + "- FAIL - Rule’s newFiwareServicePath is null");
+            throw e;
+        } // try catch
+           
+    } // testIfGetsAreNotNull
+    
+    public JSONObject createJsonObject() {
         JSONObject jsonRule = new JSONObject();
         JSONArray fields = new JSONArray();
         fields.add("entityId");
@@ -80,70 +146,7 @@ public class GroupingRuleTest {
         jsonRule.put("fiware_service_path", "/rooms");
         jsonRule.put("destination", "all_rooms");
         jsonRule.put("id",1L);
-        
-        // Create the rule for do the tests
-        GroupingRule rule = new GroupingRule(jsonRule);
-        
-        try { 
-            assertTrue(rule.getPattern() != null);
-            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
-                    + "-  OK  - Rule’s pattern is not null. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getPattern]")
-                    + "- FAIL - Rule’s pattern is null. '");
-            throw e;
-        }// try catch
-        
-        try { 
-            assertTrue(rule.getId() > 0L);
-            System.out.println(getTestTraceHead("[GroupingRule.getId]")
-                    + "-  OK  - Rule’s id is upper than 0. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getId]")
-                    + "- FAIL - Rule’s id is invalid. '");
-            throw e;
-        }// try catch
-        
-        try { 
-            assertTrue(rule.getFields() != null);
-            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
-                    + "-  OK  - Rule’s fields are not null. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getFields]")
-                    + "- FAIL - Rule’s fields are null. '");
-            throw e;
-        }// try catch
-        
-        try { 
-            assertTrue(rule.getRegex() != null);
-            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
-                    + "-  OK  - Rule’s regex is not null. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getRegex]")
-                    + "- FAIL - Rule’s regex is null. '");
-            throw e;
-        }// try catch
-        
-        try { 
-            assertTrue(rule.getDestination() != null);
-            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
-                    + "-  OK  - Rule’s destination is not null. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getDestination]")
-                    + "- FAIL - Rule’s destination is null. '");
-            throw e;
-        }// try catch
-        
-        try { 
-            assertTrue(rule.getNewFiwareServicePath() != null);
-            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
-                    + "-  OK  - Rule’s newFiwareServicePath is not null. '");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[GroupingRule.getNewFiwareServicePath]")
-                    + "- FAIL - Rule’s newFiwareServicePath is null. '");
-            throw e;
-        }// try catch
-           
-    } // testIfGetsAreNotNull
+        return jsonRule;
+    } // createJsonObject
     
 } // GroupingRuleTest


### PR DESCRIPTION
* Implements issue #928 
* 100% unit test passed:
```
Results : Tests run: 104, Failures: 0, Errors: 0, Skipped: 0
```
Specific tests added in this PR:
```
Running com.telefonica.iot.cygnus.interceptors.GroupingRuleTest
[GroupingRule.getXXXX] -------------------------- Rule's attributes are not null
[GroupingRule.getPattern] ----------------  OK  - Rule’s pattern is not null
[GroupingRule.getId] ---------------------  OK  - Rule’s id is upper than 0
[GroupingRule.getFields] -----------------  OK  - Rule’s fields are not null
[GroupingRule.getRegex] ------------------  OK  - Rule’s regex is not null
[GroupingRule.getDestination] ------------  OK  - Rule’s destination is not null
[GroupingRule.getNewFiwareServicePath] ---  OK  - Rule’s newFiwareServicePath is not null
```
* Assignee: @frbattid 