### PR TITLE
hardening/930_add_internal_transaction

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,7 +10,7 @@
 - [FEATURE] When notified, use the TimeInstant metadata instead of the reception time (#859)
 - [HARDENING] Add docker and support badges to the README (#858)
 - [HARDENING] Add a management API method for reseting the statistics (#851)
-- [FEATURE] Reuse a notified transaction ID (#843)
+- [FEATURE] Reuse a notified Correlator ID when notified, otherwise generate it (#843)
 - [HARDENING] Remove deprecated configuration parameters in OrionHDFSSink (#868)
 - [FEATURE] When configured, ignore white space-based string attributes (#678)
 - [BUG] Fix processing of splited Http responses in HttpBackend (#875)
@@ -30,3 +30,4 @@
 - [HARDENING] Invalidate configurations instead of exiting Cygnus upon wrong configuration (#917)
 - [HARDENING] Add support for SQL timestamps with microseconds in Utils.getTimeInstant (#922)
 - [HARDENING] Remove the user-agent header, and consider content-type as a Http-only header (#920)
+- [HARDENING] Add an internal Transaction ID (#930)

--- a/conf/log4j.properties.template
+++ b/conf/log4j.properties.template
@@ -47,7 +47,7 @@ log4j.appender.LOGFILE.MaxFileSize=100MB
 log4j.appender.LOGFILE.MaxBackupIndex=10
 log4j.appender.LOGFILE.File=${flume.log.dir}/${flume.log.file}
 log4j.appender.LOGFILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.LOGFILE.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n
+log4j.appender.LOGFILE.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n
 
 # Warning: If you enable the following appender it will fill up your disk if you don't have a cleanup job!
 # cleanup job example: find /var/log/cygnus -type f -mtime +30 -exec rm -f {} \;
@@ -59,11 +59,11 @@ log4j.appender.DAILY.rollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPoli
 log4j.appender.DAILY.rollingPolicy.ActiveFileName=${flume.log.dir}/${flume.log.file}
 log4j.appender.DAILY.rollingPolicy.FileNamePattern=${flume.log.dir}/${flume.log.file}.%d{yyyy-MM-dd}
 log4j.appender.DAILY.layout=org.apache.log4j.PatternLayout
-log4j.appender.DAILY.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n
+log4j.appender.DAILY.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n
 
 # Console appender, i.e. printing logs in the standar output.
 # Add "console" to flume.root.logger above if you want to use this.
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n
+log4j.appender.console.layout.ConversionPattern=time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n

--- a/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
+++ b/src/main/java/com/telefonica/iot/cygnus/utils/Constants.java
@@ -34,6 +34,7 @@ public final class Constants {
     public static final String HTTP_HEADER_CONTENT_TYPE = "content-type";
     
     // Flume header names
+    public static final String FLUME_HEADER_TRANSACTION_ID         = "transaction-id";
     public static final String FLUME_HEADER_NOTIFIED_SERVICE_PATHS = "notified-servicepaths";
     public static final String FLUME_HEADER_GROUPED_SERVICE_PATHS  = "grouped-servicepaths";
     public static final String FLUME_HEADER_NOTIFIED_ENTITIES      = "notified-entities";
@@ -41,7 +42,6 @@ public final class Constants {
     public static final String FLUME_HEADER_TIMESTAMP              = "timestamp";
     
     // Both HTTP and Flume header names
-    
     public static final String HEADER_FIWARE_SERVICE      = "fiware-service";
     public static final String HEADER_FIWARE_SERVICE_PATH = "fiware-servicepath";
     public static final String HEADER_CORRELATOR_ID       = "fiware-correlator";
@@ -83,6 +83,7 @@ public final class Constants {
     
     // log4j specific constants
     public static final String LOG4J_CORR = "correlatorId";
+    public static final String LOG4J_TRANS = "transactionId";
     public static final String LOG4J_SVC = "service";
     public static final String LOG4J_SUBSVC = "subservice";
     

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -297,12 +297,12 @@ public class OrionRestHandlerTest {
     
     /**
      * [OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains fiware-service,
-     * fiware-servicepath and fiware-correlator headers.
+     * fiware-servicepath, fiware-correlator and transaction-id headers.
      */
     @Test
     public void testGetEventsHeadersInFlumeEvent() {
         System.out.println("[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains "
-                + "fiware-service, fiware-servicepath and fiware-correlator headers");
+                + "fiware-service, fiware-servicepath, fiware-correlator and transaction-id headers");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
         Map<String, String> headers;
@@ -316,14 +316,14 @@ public class OrionRestHandlerTest {
                         + "'fiware-service'");
             } catch (AssertionError e1) {
                 System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
-                        + "contains 'fiware-servicepath'");
+                        + "contains 'fiware-service'");
                 throw e1;
             } // try catch
             
             try {
                 assertTrue(headers.containsKey("fiware-servicepath"));
                 System.out.println("[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains "
-                        + "'fiware-service'");
+                        + "'fiware-servicepath'");
             } catch (AssertionError e2) {
                 System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
                         + "contains 'fiware-servicepath'");
@@ -338,6 +338,16 @@ public class OrionRestHandlerTest {
                 System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
                         + "contains 'fiware-correlator'");
                 throw e3;
+            } // try catch
+            
+            try {
+                assertTrue(headers.containsKey("transaction-id"));
+                System.out.println("[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains "
+                        + "'transaction-id'");
+            } catch (AssertionError e4) {
+                System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
+                        + "contains 'transaction-id'");
+                throw e4;
             } // try catch
         } catch (Exception e) {
             System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
@@ -391,45 +401,92 @@ public class OrionRestHandlerTest {
     } // testGetEventsBodyInFlumeEvent
     
     /**
-     * [OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is reused.
+     * [OrionRestHandler.generateUniqueId] -------- An internal transaction ID is generated.
      */
     @Test
-    public void testGenerateTransIdReused() {
-        System.out.println("[OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is "
-                + "reused");
+    public void testGenerateUniqueIdTransIdGenerated() {
+        System.out.println("[OrionRestHandler.generateUniqueId] -------- An internal transaction ID is generated");
         OrionRestHandler handler = new OrionRestHandler();
-        String notifiedTransId = "1234567890-123-1234567890";
+        String generatedTransId = handler.generateUniqueId(null, null);
         
         try {
-            assertEquals(notifiedTransId, handler.generateTransId(notifiedTransId));
-            System.out.println("[OrionRestHandler.generateTransId] -  OK  - The notified transaction ID '"
-                    + notifiedTransId + "' is reused");
+            assertTrue(generatedTransId != null);
+            System.out.println("[OrionRestHandler.generateUniqueId] -  OK  - An internal transaction ID '"
+                    + generatedTransId + "' has been generated");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.generateTransId] - FAIL - The notified transaction ID '"
-                    + notifiedTransId + "' is not reused");
+            System.out.println("[OrionRestHandler.generateUniqueId] - FAIL - An intertnal transaction ID was not "
+                    + "generated");
             throw e;
-        } // try catch
-    } // testGenerateTransIdReused
+        } // try catch // try catch
+    } // testGenerateUniqueIdTransIdGenerated
     
     /**
-     * [OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is reused.
+     * [OrionRestHandler.generateUniqueId] -------- When a correlator ID is notified, it is reused.
      */
     @Test
-    public void testGenerateTransIdGenerated() {
-        System.out.println("[OrionRestHandler.generateTransId] -------- When a transcation ID is not notified, "
-                + "it is generated");
+    public void testGenerateUniqueIdCorrIdReused() {
+        System.out.println("[OrionRestHandler.generateUniqueId] -------- When a correlator ID is notified, it is "
+                + "reused");
         OrionRestHandler handler = new OrionRestHandler();
-        String notifiedTransId = null;
+        String generatedTransId = "1111111111-111-1111111111";
+        String notifiedCorrId = "1234567890-123-1234567890";
+        String generatedCorrId = handler.generateUniqueId(notifiedCorrId, generatedTransId);
         
         try {
-            assertTrue(handler.generateTransId(notifiedTransId) != null);
-            System.out.println("[OrionRestHandler.generateTransId] -  OK  - The transaction ID has been generated");
+            assertEquals(notifiedCorrId, generatedCorrId);
+            System.out.println("[OrionRestHandler.generateUniqueId] -  OK  - The notified transaction ID '"
+                    + notifiedCorrId + "' has been reused");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.generateTransId] - FAIL - The transaction ID has not been "
+            System.out.println("[OrionRestHandler.generateUniqueId] - FAIL - The notified transaction ID '"
+                    + notifiedCorrId + "' has not not reused, '" + generatedCorrId + "' has been generated instead");
+            throw e;
+        } // try catch // try catch
+    } // testGenerateUniqueIdCorrIdReused
+    
+    /**
+     * [OrionRestHandler.generateUniqueId] -------- When a correlation ID is not notified, it is generated.
+     */
+    @Test
+    public void testGenerateUniqueIdCorrIdGenerated() {
+        System.out.println("[OrionRestHandler.generateUniqueId] -------- When a correlation ID is not notified, "
+                + "it is generated");
+        OrionRestHandler handler = new OrionRestHandler();
+        String generatedTransId = "1234567890-123-1234567890";
+        String notifiedCorrId = null;
+        
+        try {
+            assertTrue(handler.generateUniqueId(notifiedCorrId, generatedTransId) != null);
+            System.out.println("[OrionRestHandler.generateUniqueId] -  OK  - The transaction ID has been generated");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.generateUniqueId] - FAIL - The transaction ID has not been "
                     + "generated");
             throw e;
         } // try catch
-    } // testGenerateTransIdGenerated
+    } // testGenerateUniqueIdCorrIdGenerated
+    
+    /**
+     * [OrionRestHandler.generateUniqueId] -------- When a correlation ID is generated, both generated correlation ID
+     * and generated transaction ID have the same value.
+     */
+    @Test
+    public void testGenerateUniqueIdSameCorrAndTransIds() {
+        System.out.println("[OrionRestHandler.generateUniqueId] -------- When a correlation ID is genereated, both "
+                + "generated correlation ID and generated transaction ID have the same value");
+        OrionRestHandler handler = new OrionRestHandler();
+        String generatedTransId = "1234567890-123-1234567890";
+        String notifiedCorrId = null;
+        String generatedCorrId = handler.generateUniqueId(notifiedCorrId, generatedTransId);
+        
+        try {
+            assertEquals(generatedTransId, generatedCorrId);
+            System.out.println("[OrionRestHandler.generateUniqueId] -  OK  - The generated transaction ID '"
+                    + generatedTransId + "' is equals to the generated correlator ID '" + generatedCorrId + "'");
+        } catch (AssertionError e) {
+            System.out.println("[OrionRestHandler.generateUniqueId] - FAIL - The generated transaction ID '"
+                    + generatedTransId + "' is not equals to the generated correlator ID '" + generatedCorrId + "'");
+            throw e;
+        } // try catch
+    } // testGenerateUniqueIdSameCorrAndTransIds
     
     private Context createContext(String notificationTarget, String defaultService, String defaultServicePath) {
         Context context = new Context();


### PR DESCRIPTION
* Implements issue #930 
* 100% unit tests passed:
```
Tests run: 103, Failures: 0, Errors: 0, Skipped: 0
```

Specific unit tests related to the PR:
```
Running com.telefonica.iot.cygnus.handlers.OrionRestHandlerTest
[OrionRestHandler.generateUniqueId] -------- When a correlation ID is genereated, both generated correlation ID and generated transaction ID have the same value
[OrionRestHandler.generateUniqueId] -  OK  - The generated transaction ID '1234567890-123-1234567890' is equals to the generated correlator ID '1234567890-123-1234567890'
[OrionRestHandler.configure] -------- The configured default service path must start with '/'
[OrionRestHandler.configure] -  OK  - The configured default service path '/something' starts with '/'
[OrionRestHandler.getEvents] -------- When a notification is sent as a Http message, a single Flume event is generated
[OrionRestHandler.getEvents] -  OK  - A single event has been generated
[OrionRestHandler.getEvents] -------- When a the configuration is wrong, no evetns are obtained
16/04/07 15:13:39 ERROR handlers.OrionRestHandler: Bad configuration (notification_target=notify) -- Must start with '/'
16/04/07 15:13:39 ERROR handlers.OrionRestHandler: Bad configuration ('default_service_path' must start with '/')
[OrionRestHandler.getEvents] -  OK  - No events are processed since the configuration is wrong
[OrionRestHandler.generateUniqueId] -------- An internal transaction ID is generated
[OrionRestHandler.generateUniqueId] -  OK  - An internal transaction ID '1460034818-969-0000000001' has been generated
[OrionRestHandler.configure] -------- The configured notification target must start with '/'
[OrionRestHandler.configure] -  OK  - The configured notification target '/notify' starts with '/'
[OrionRestHandler.configure] -------- When not configured, the default values are used for non mandatory parameters
[OrionRestHandler.configure] -  OK  - The default configuration value for 'notification_target' is '/notify'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service' is 'default'
[OrionRestHandler.configure] -  OK  - The default configuration value for 'default_service_path' is '/'
[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains fiware-service, fiware-servicepath, fiware-correlator and transaction-id headers
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'fiware-service'
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'fiware-servicepath'
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'fiware-correlator'
[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains 'transaction-id'
[OrionRestHandler.generateUniqueId] -------- When a correlation ID is not notified, it is generated
[OrionRestHandler.generateUniqueId] -  OK  - The transaction ID has been generated
[OrionRestHandler.getEvents] -------- When a notification is sent, the headers are valid
[OrionRestHandler.getEvents] -  OK  - The value for 'Content-Type' header is 'application/json'
[OrionRestHandler.getEvents] -  OK  - The value for 'fiware-servicePath' header starts with '/'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-service' header value is  less or equal than '50'
[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-servicePath' header value is less or equal than '50'
[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains the payload of the Http notification as body
[OrionRestHandler.getEvents] -  OK  - The event body '{"contextResponses":[{"contextElement":{"attributes":{"name":"temperature","type":"centigrade","value":"26.5"},"id":"room1","type":"Room","isPattern":"false"},"statusCode":{"code":"200","reasonPhrase":"OK"}}],"originator":"localhost","subscriptionId":"51c0ac9ed714fb3b37d7d5a8"}' is equal to the notification Json '{"contextResponses":[{"contextElement":{"attributes":{"name":"temperature","type":"centigrade","value":"26.5"},"id":"room1","type":"Room","isPattern":"false"},"statusCode":{"code":"200","reasonPhrase":"OK"}}],"originator":"localhost","subscriptionId":"51c0ac9ed714fb3b37d7d5a8"}'
[OrionRestHandler.generateUniqueId] -------- When a correlator ID is notified, it is reused
[OrionRestHandler.generateUniqueId] -  OK  - The notified transaction ID '1234567890-123-1234567890' has been reused
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.54 sec
```
* (unofficial) e2e tests passed:

Some correlator ID is notified:
```
time=2016-04-07T14:39:33.829CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[289] : Starting internal transaction (1460032768-866-0000000000)
time=2016-04-07T14:39:33.830CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[305] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-07T14:39:33.832CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[327] : Event put in the channel, id=145425347
time=2016-04-07T14:39:59.898CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[391] : Batch accumulation time reached, the batch will be processed as it is
time=2016-04-07T14:39:59.898CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[445] : Batch completed, persisting it
time=2016-04-07T14:39:59.900CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[954] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (default/algo/Room1_Room/Room1_Room.txt), Data ({"recvTime":"2016-04-07T12:39:33.833Z","fiwareServicePath":"/algo","entityId":"Room1","entityType":"Room", "temperature":"26.5", "temperature_md":[]})
time=2016-04-07T14:40:00.655CEST | lvl=INFO | corr=SOMETHING | trans=1460032768-866-0000000000 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[449] : Finishing internal transaction (SOMETHING)
```

No correlator ID is notified:
```
time=2016-04-07T14:40:28.111CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[289] : Starting internal transaction (1460032768-866-0000000001)
time=2016-04-07T14:40:28.111CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[305] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-07T14:40:28.112CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.OrionRestHandler[327] : Event put in the channel, id=1008237142
time=2016-04-07T14:41:00.695CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[391] : Batch accumulation time reached, the batch will be processed as it is
time=2016-04-07T14:41:00.695CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[445] : Batch completed, persisting it
time=2016-04-07T14:41:00.695CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionHDFSSink[954] : [hdfs-sink] Persisting data at OrionHDFSSink. HDFS file (default/algo/Room1_Room/Room1_Room.txt), Data ({"recvTime":"2016-04-07T12:40:28.112Z","fiwareServicePath":"/algo","entityId":"Room1","entityType":"Room", "temperature":"26.5", "temperature_md":[]})
time=2016-04-07T14:41:01.872CEST | lvl=INFO | corr=1460032768-866-0000000001 | trans=1460032768-866-0000000001 | svc=default | subsvc=/algo | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.OrionSink[449] : Finishing internal transaction (1460032768-866-0000000001)
```
* Assingnee @pcoello25 