### PR TITLE
hardening/754_function_for_aligning_all_the_tests

### DIFF
--- a/src/test/java/com/telefonica/iot/cygnus/backends/kafka/KafkaBackendImplTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/backends/kafka/KafkaBackendImplTest.java
@@ -17,11 +17,11 @@
  */
 package com.telefonica.iot.cygnus.backends.kafka;
 
-import java.util.Properties;
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,39 +39,48 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaBackendImplTest {
     
-    // mocks 
-    @Mock 
+    // mocks
+    @Mock
     private KafkaProducer mockKafkaProducer;
     
     /**
-     * Sets up tests by creating a unique instance of the tested class, and by 
-     * defining the behaviour of the mocked
+     * Constructor.
+     */
+    public KafkaBackendImplTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // KafkaBackendImplTest
+    
+    /**
+     * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
      * classes.
      *  
      * @throws Exception
      */
-    
     @Before
-    public void setUp() throws Exception {  
+    public void setUp() throws Exception {
         when(mockKafkaProducer.send(Mockito.any(ProducerRecord.class))).thenReturn(null);
     } // setUp
     
+    /**
+     * [KafkaBackendImplTest.send] -------- The backend sends a message to Kafka.
+     * @throws Exception
+     */
     @Test
     public void recordIsAddedAndSent() throws Exception {
-        // null zookeeperEndpoint because is not necessary for pass the tests 
-        KafkaBackendImpl backendImpl = new KafkaBackendImpl("0.0.0.0:9092", null);    
+        // null zookeeperEndpoint because is not necessary for pass the tests
+        KafkaBackendImpl backendImpl = new KafkaBackendImpl("0.0.0.0:9092", null);
         backendImpl.setKafkaProducer(mockKafkaProducer);
-        System.out.println("[KafkaBackendImplTest ] -------- The backend sends a message to Kafka -------- ");
+        System.out.println(getTestTraceHead("[KafkaBackendImplTest.send]")
+                + "-------- The backend sends a message to Kafka");
         
         try {
-            backendImpl.send(Mockito.any(ProducerRecord.class));  
-            System.out.println("[KafkaBackendImpl.send] -  OK  - Added to be sent");
+            backendImpl.send(Mockito.any(ProducerRecord.class));
+            System.out.println(getTestTraceHead("[KafkaBackendImpl.send]") + "-  OK  - Added to be sent");
             assertTrue(true);
         } catch (AssertionError e) {
-            System.out.println("[KafkaBackendImpl.send] - FAIL - Addition failed");
+            System.out.println(getTestTraceHead("[KafkaBackendImpl.send]") + "- FAIL - Addition failed");
             throw e;
         } // try catch
-        
-    } // testTopicNameIsCreatedAndExists 
+    } // testTopicNameIsCreatedAndExists
     
 } // KafkaBackendImplTest

--- a/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/handlers/OrionRestHandlerTest.java
@@ -19,6 +19,7 @@
 package com.telefonica.iot.cygnus.handlers;
 
 import com.telefonica.iot.cygnus.utils.Constants;
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
@@ -54,13 +55,13 @@ public class OrionRestHandlerTest {
     private HttpServletRequest mockHttpServletRequest;
     
     // Other variables
-    JSONObject notification;
+    private JSONObject notification;
     
     /**
      * Constructor.
      */
     public OrionRestHandlerTest() {
-        LogManager.getRootLogger().setLevel(Level.ERROR);
+        LogManager.getRootLogger().setLevel(Level.FATAL);
     } // OrionRestHandlerTest
     
     /**
@@ -84,7 +85,7 @@ public class OrionRestHandlerTest {
         attributes.put("type", "centigrade");
         attributes.put("value", "26.5");
         JSONObject contextElement = new JSONObject();
-        contextElement.put("attributes",attributes);
+        contextElement.put("attributes", attributes);
         contextElement.put("type", "Room");
         contextElement.put("isPattern", "false");
         contextElement.put("id", "room1");
@@ -111,38 +112,41 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testConfigureNotMandatoryParameters() {
-        System.out.println("[OrionRestHandler.configure] -------- When not configured, the default values are used "
-                + "for non mandatory parameters");
+        System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                + "-------- When not configured, the default values are used for non mandatory parameters");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
         
         try {
             assertEquals("/notify", handler.getNotificationTarget());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
-                    + "'notification_target' is '/notify'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The default configuration value for 'notification_target' is '/notify'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
-                    + "'notification_target' is '" + handler.getNotificationTarget() + "'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The default configuration value for 'notification_target' is '"
+                    + handler.getNotificationTarget() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals("default", handler.getDefaultService());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
-                    + "'default_service' is 'default'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The default configuration value for 'default_service' is 'default'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
-                    + "'default_service' is '" + handler.getDefaultService() + "'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The default configuration value for 'default_service' is '"
+                    + handler.getDefaultService() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals("/", handler.getDefaultServicePath());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The default configuration value for "
-                    + "'default_service_path' is '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The default configuration value for 'default_service_path' is '/'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The default configuration value for "
-                    + "'default_service_path' is '" + handler.getDefaultServicePath() + "'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The default configuration value for 'default_service_path' is '"
+                    + handler.getDefaultServicePath() + "'");
             throw e;
         } // try catch
     } // testConfigureNotMandatoryParameters
@@ -152,8 +156,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testConfigureDefaultServicePathStartsWithSlash() {
-        System.out.println("[OrionRestHandler.configure] -------- The configured default service path must start "
-                + "with '/'");
+        System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                + "-------- The configured default service path must start with '/'");
         OrionRestHandler handler = new OrionRestHandler();
         String configuredDefaultServicePath = "/something";
         handler.configure(createContext(null, null, configuredDefaultServicePath));
@@ -161,11 +165,13 @@ public class OrionRestHandlerTest {
         try {
             assertEquals(configuredDefaultServicePath, handler.getDefaultServicePath());
             assertTrue(!handler.getInvalidConfiguration());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The configured default service path '"
-                    + configuredDefaultServicePath + "' starts with '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The configured default service path '" + configuredDefaultServicePath
+                    + "' starts with '/'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The configured default service path '"
-                    + configuredDefaultServicePath + "' does not start with '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The configured default service path '" + configuredDefaultServicePath
+                    + "' does not start with '/'");
             throw e;
         } // try catch
     } // testConfigureDefaultServicePathStartsWithSlash
@@ -175,8 +181,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testConfigureNotificationTargerStartsWithSlash() {
-        System.out.println("[OrionRestHandler.configure] -------- The configured notification target must start "
-                + "with '/'");
+        System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                + "-------- The configured notification target must start with '/'");
         OrionRestHandler handler = new OrionRestHandler();
         String configuredNotificationTarget = "/notify";
         handler.configure(createContext(configuredNotificationTarget, null, null));
@@ -184,11 +190,13 @@ public class OrionRestHandlerTest {
         try {
             assertEquals(configuredNotificationTarget, handler.getNotificationTarget());
             assertTrue(!handler.getInvalidConfiguration());
-            System.out.println("[OrionRestHandler.configure] -  OK  - The configured notification target '"
-                    + configuredNotificationTarget + "' starts with '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The configured notification target '" + configuredNotificationTarget
+                    + "' starts with '/'");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.configure] - FAIL - The configured notification target '"
-                    + configuredNotificationTarget + "' does not start with '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The configured notification target '" + configuredNotificationTarget
+                    + "' does not start with '/'");
             throw e;
         } // try catch // try catch
     } // testConfigureDefaultServicePathStartsWithSlash
@@ -198,33 +206,38 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGetEventsContentTypeHeader() {
-        System.out.println("[OrionRestHandler.getEvents] -------- When a notification is sent, the headers are valid");
+        System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                + "-------- When a notification is sent, the headers are valid");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
         
         try {
             handler.getEvents(mockHttpServletRequest);
             assertTrue(true);
-            System.out.println("[OrionRestHandler.getEvents] -  OK  - The value for 'Content-Type' header is "
-                    + "'application/json'");
-            System.out.println("[OrionRestHandler.getEvents] -  OK  - The value for 'fiware-servicePath' header "
-                    + "starts with '/'");
-            System.out.println("[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-service' header value is "
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "-  OK  - The value for 'Content-Type' header is 'application/json'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "-  OK  - The value for 'fiware-servicePath' header starts with '/'");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "-  OK  - The length of 'fiware-service' header value is "
                     + " less or equal than '" + Constants.SERVICE_HEADER_MAX_LEN + "'");
-            System.out.println("[OrionRestHandler.getEvents] -  OK  - The length of 'fiware-servicePath' header value "
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "-  OK  - The length of 'fiware-servicePath' header value "
                     + "is less or equal than '" + Constants.SERVICE_PATH_HEADER_MAX_LEN + "'");
         } catch (Exception e) {
             if (e.getMessage().contains("content type not supported")) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The value for 'Content-Type' is not "
-                        + "'application/json'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The value for 'Content-Type' is not 'application/json'");
             } else if (e.getMessage().contains("header value must start with '/'")) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The value for 'fiware-servicePath' does not "
-                        + "start with '/'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The value for 'fiware-servicePath' does not start with '/'");
             } else if (e.getMessage().contains("'fiware-service' header length greater than")) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The length of 'fiware-service' header value "
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The length of 'fiware-service' header value "
                         + "is greater than '" + Constants.SERVICE_HEADER_MAX_LEN + "'");
             } else if (e.getMessage().contains("'fiware-servicePath' header length greater than")) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The length of 'fiware-servicePath' header "
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The length of 'fiware-servicePath' header "
                         + "value is greater than '" + Constants.SERVICE_PATH_HEADER_MAX_LEN + "'");
             } // if else
             
@@ -237,8 +250,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGetEventsNullEventsUponInvalidConfiguration() {
-        System.out.println("[OrionRestHandler.getEvents] -------- When a the configuration is wrong, no evetns "
-                + "are obtained");
+        System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                + "-------- When a the configuration is wrong, no evetns are obtained");
         OrionRestHandler handler = new OrionRestHandler();
         String configuredNotificationTarget = "notify"; // wrong value
         String configuredDefaultService = "default";
@@ -252,16 +265,16 @@ public class OrionRestHandlerTest {
             
             try {
                 assertEquals(0, events.size());
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - No events are processed since the "
-                        + "configuration is wrong");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - No events are processed since the configuration is wrong");
             } catch (AssertionError e1) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The events are being processed "
-                        + "despite of the configuration is wrong");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The events are being processed despite of the configuration is wrong");
                 throw e1;
             } // try catch
         } catch (Exception ex) {
-            System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
-                    + "the events");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "- FAIL - There was some problem while processing the events");
             assertTrue(false);
         } // try catch
     } // testGetEventsNullEventsUponInvalidConfiguration
@@ -272,8 +285,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGetEventsSingleEvent() {
-        System.out.println("[OrionRestHandler.getEvents] -------- When a notification is sent as a Http message, "
-                + "a single Flume event is generated");
+        System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                + "-------- When a notification is sent as a Http message, a single Flume event is generated");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
         List<Event> events;
@@ -283,14 +296,16 @@ public class OrionRestHandlerTest {
             
             try {
                 assertEquals(1, events.size());
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - A single event has been generated");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - A single event has been generated");
             } catch (AssertionError e1) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - 0, 2 or more than an event were generated");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - 0, 2 or more than an event were generated");
                 throw e1;
             } // try catch
         } catch (Exception e) {
-            System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
-                    + "the events");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "- FAIL - There was some problem while processing the events");
             assertTrue(false);
         } // try catch
     } // testGetEventsSingleEvent
@@ -301,7 +316,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGetEventsHeadersInFlumeEvent() {
-        System.out.println("[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains "
+        System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                + "-------- When a Flume event is generated, it contains "
                 + "fiware-service, fiware-servicepath and fiware-correlator headers");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
@@ -312,36 +328,36 @@ public class OrionRestHandlerTest {
             
             try {
                 assertTrue(headers.containsKey("fiware-service"));
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains "
-                        + "'fiware-service'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - The generated Flume event contains 'fiware-service'");
             } catch (AssertionError e1) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
-                        + "contains 'fiware-servicepath'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The generated Flume event does not contain 'fiware-servicepath'");
                 throw e1;
             } // try catch
             
             try {
                 assertTrue(headers.containsKey("fiware-servicepath"));
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains "
-                        + "'fiware-service'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - The generated Flume event contains 'fiware-service'");
             } catch (AssertionError e2) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
-                        + "contains 'fiware-servicepath'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The generated Flume event does not contain 'fiware-servicepath'");
                 throw e2;
             } // try catch
 
             try {
                 assertTrue(headers.containsKey("fiware-correlator"));
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - The generated Flume event contains "
-                        + "'fiware-correlator'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - The generated Flume event contains 'fiware-correlator'");
             } catch (AssertionError e3) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The generated Flume event does not "
-                        + "contains 'fiware-correlator'");
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The generated Flume event does not contain 'fiware-correlator'");
                 throw e3;
             } // try catch
         } catch (Exception e) {
-            System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
-                    + "the events");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "- FAIL - There was some problem while processing the events");
             assertTrue(false);
         } // try catch
     } // testGetEventsHeadersInFlumeEvent
@@ -352,7 +368,8 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGetEventsBodyInFlumeEvent() {
-        System.out.println("[OrionRestHandler.getEvents] -------- When a Flume event is generated, it contains "
+        System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                + "-------- When a Flume event is generated, it contains "
                 + "the payload of the Http notification as body");
         OrionRestHandler handler = new OrionRestHandler();
         handler.configure(createContext(null, null, null)); // default configuration
@@ -376,16 +393,18 @@ public class OrionRestHandlerTest {
             
             try {
                 assertTrue(areEqual);
-                System.out.println("[OrionRestHandler.getEvents] -  OK  - The event body '" + new String(body)
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "-  OK  - The event body '" + new String(body)
                         + "' is equal to the notification Json '" + new String(notificationBytes) + "'");
             } catch (AssertionError e1) {
-                System.out.println("[OrionRestHandler.getEvents] - FAIL - The event body '" + new String(body)
+                System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                        + "- FAIL - The event body '" + new String(body)
                         + "' is nbot equal to the notification Json '" + new String(notificationBytes) + "'");
                 throw e1;
             } // try catch
         } catch (Exception e) {
-            System.out.println("[OrionRestHandler.getEvents] - FAIL - There was some problem while processing "
-                    + "the events");
+            System.out.println(getTestTraceHead("[OrionRestHandler.getEvents]")
+                    + "- FAIL - There was some problem while processing the events");
             assertTrue(false);
         } // try catch
     } // testGetEventsBodyInFlumeEvent
@@ -395,18 +414,18 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGenerateTransIdReused() {
-        System.out.println("[OrionRestHandler.generateTransId] -------- When a transcation ID is notified, it is "
-                + "reused");
+        System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                + "-------- When a transcation ID is notified, it is reused");
         OrionRestHandler handler = new OrionRestHandler();
         String notifiedTransId = "1234567890-123-1234567890";
         
         try {
             assertEquals(notifiedTransId, handler.generateTransId(notifiedTransId));
-            System.out.println("[OrionRestHandler.generateTransId] -  OK  - The notified transaction ID '"
-                    + notifiedTransId + "' is reused");
+            System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                    + "-  OK  - The notified transaction ID '" + notifiedTransId + "' is reused");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.generateTransId] - FAIL - The notified transaction ID '"
-                    + notifiedTransId + "' is not reused");
+            System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                    + "- FAIL - The notified transaction ID '" + notifiedTransId + "' is not reused");
             throw e;
         } // try catch
     } // testGenerateTransIdReused
@@ -416,17 +435,18 @@ public class OrionRestHandlerTest {
      */
     @Test
     public void testGenerateTransIdGenerated() {
-        System.out.println("[OrionRestHandler.generateTransId] -------- When a transcation ID is not notified, "
-                + "it is generated");
+        System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                + "-------- When a transcation ID is not notified, it is generated");
         OrionRestHandler handler = new OrionRestHandler();
         String notifiedTransId = null;
         
         try {
             assertTrue(handler.generateTransId(notifiedTransId) != null);
-            System.out.println("[OrionRestHandler.generateTransId] -  OK  - The transaction ID has been generated");
+            System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                    + "-  OK  - The transaction ID has been generated");
         } catch (AssertionError e) {
-            System.out.println("[OrionRestHandler.generateTransId] - FAIL - The transaction ID has not been "
-                    + "generated");
+            System.out.println(getTestTraceHead("[OrionRestHandler.generateTransId]")
+                    + "- FAIL - The transaction ID has not been generated");
             throw e;
         } // try catch
     } // testGenerateTransIdGenerated

--- a/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/interceptors/GroupingRuleTest.java
@@ -17,6 +17,9 @@
  */
 package com.telefonica.iot.cygnus.interceptors;
 
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import static org.junit.Assert.assertEquals;
@@ -29,11 +32,19 @@ import org.junit.Test;
 public class GroupingRuleTest {
     
     /**
-     * [Groupingrule] -------- fiware-servicePath field in a grouping rule must start with '/'.
+     * Constructor.
+     */
+    public GroupingRuleTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // GroupingRuleTest
+    
+    /**
+     * [Groupingrule.isValid] -------- fiware-servicePath field in a grouping rule must start with '/'.
      */
     @Test
     public void testFiwareServicePathStartsWithSlash() {
-        System.out.println("[GroupingRule] -------- fiware-servicePath field in a grouping rule must start with '/'");
+        System.out.println(getTestTraceHead("[GroupingRule.isValid]")
+                + "-------- fiware-servicePath field in a grouping rule must start with '/'");
         JSONObject jsonRule = new JSONObject();
         JSONArray fields = new JSONArray();
         fields.add("entityId");
@@ -44,10 +55,12 @@ public class GroupingRuleTest {
         
         try {
             assertEquals(0, GroupingRule.isValid(jsonRule, true));
-            System.out.println("[GroupingRule] -  OK  - The fiware-servicePath field in the rule '"
+            System.out.println(getTestTraceHead("[GroupingRule.isValid]")
+                    + "-  OK  - The fiware-servicePath field in the rule '"
                     + jsonRule.toJSONString() + "' starts with '/'");
         } catch (AssertionError e) {
-            System.out.println("[GroupingRule] - FAIL - The fiware-servicePath field in the rule '"
+            System.out.println(getTestTraceHead("[GroupingRule.isValid]")
+                    + "- FAIL - The fiware-servicePath field in the rule '"
                     + jsonRule.toJSONString() + "' does not start with '/'");
             throw e;
         } // try catch

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionKafkaSinkTest.java
@@ -17,208 +17,238 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import org.apache.flume.Context;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 /**
  *
- * @author frb
+ * @author pcoello25
  */
-public class OrionKafkaSinkTest {   
+public class OrionKafkaSinkTest {
     
-    String service = "service";
-    String serviceUpper = "SERVICE";
-    String servicePath = "/servicePath";
-    String servicePathUpper = "/SERVICEPATH";
-    String servicePathSlash = "/";
-    String entity = "entityId_entityType";
-    String attribute = "attributeName";
-    String expectedTopic;
+    private final String service = "service";
+    private final String servicePath = "/servicePath";
+    private final String servicePathSlash = "/";
+    private final String entity = "entityId_entityType";
+    private final String attribute = "attributeName";
+    private String expectedTopic;
     
+    /**
+     * Constructor.
+     */
+    public OrionKafkaSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // OrionKafkaSinkTest
+    
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByService() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
-                + "root service-path is notified/defaulted and data_model="
-                + "dm-by-service, the Kafka topic name "
-                + "is <service>");
+    public void testbuildTopicNameDmByService() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-service, the Kafka topic "
+                + "name is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-service"));
-        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equal to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByService
+    } // testBuildTopicNameDmByService
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByServiceWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
-                + "root service-path is notified/defaulted and "
-                + "data_model=dm-by-service, the Kafka "
+    public void testBuildTopicNameDmByServiceWithSlashServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When the "
+                + "root service-path is notified/defaulted and data_model=dm-by-service, the Kafka "
                 + "topic name is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-service-path"));
-        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByServiceWithSlashServicePath
+    } // testBuildTopicNameDmByServiceWithSlashServicePath
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
-                + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-service-path, "
+    public void testBuildTopicNameDmByServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-service-path, "
                 + "the Kafka topic name is <service>_<service-path>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-service-path"));
-        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
             expectedTopic = "service_servicePath";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByServicePath 
+    } // testBuildTopicNameDmByServicePath
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByServicePathWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
-                + "root service-path is notified/defaulted and "
-                + "data_model=dm-by-service-path, "
+    public void testBuildTopicNameDmByServicePathWithSlashServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When the "
+                + "root service-path is notified/defaulted and data_model=dm-by-service-path, "
                 + "the Kafka topic name is <service>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-service-path"));
-        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
             expectedTopic = "service";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByServicePathWithSlashServicePath    
+    } // testBuildTopicNameDmByServicePathWithSlashServicePath
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByEntity() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
-                + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-entity, the "
+    public void testBuildTopicNameDmByEntity() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-entity, the "
                 + "Kafka topic name is <service>_<service-path>_<entityId>_<entityType>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-entity"));
-        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
             expectedTopic = "service_servicePath_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]")  + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByEntity
+    } // testBuildTopicNameDmByEntity
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByEntityWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
-                + "root service-path is notified/defaulted and data_model=dm-by-"
-                + "entity, the Kafka topic name is "
-                + "<service>_<entityId>_<entityType>");
+    public void testBuildTopicNameDmByEntityWithSlashServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When the "
+                + "root service-path is notified/defaulted and data_model=dm-by-entity, the Kafka topic "
+                + "name is <service>_<entityId>_<entityType>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-entity"));
-        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
             expectedTopic = "service_entityId_entityType";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
-                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
+                    + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic
+                    + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByEntityWithSlashServicePath
+    } // testBuildTopicNameDmByEntityWithSlashServicePath
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByAttribute() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When a non "
-                + "root service-path is notified/defaulted and data_model=dm-by-"
-                + "attribute, the Kafka topic name is "
-                + "<service>_<service-path>_<entityId>_<entityType>_<attrName>");
+    public void testBuildTopicNameDmByAttribute() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When a non "
+                + "root service-path is notified/defaulted and data_model=dm-by-attribute, the Kafka "
+                + "topic name is <service>_<service-path>_<entityId>_<entityType>_<attrName>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-attribute"));
-        String topic = sink.buildTopicName(service,servicePath,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
             expectedTopic = "service_servicePath_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByAttribute
+    } // testBuildTopicNameDmByAttribute
     
+    /**
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testTopicNameDmByAttributeWithSlashServicePath() throws Exception {
-        System.out.println("[OrionKafkaSink.buildTopicName ] -------- When the "
-                + "root service-path is notified/defaulted "
-                + "and data_model=dm-by-attribute, the "
+    public void testBuildTopicNameDmByAttributeWithSlashServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-------- When the "
+                + "root service-path is notified/defaulted and data_model=dm-by-attribute, the "
                 + "Kafka topic name is <service>_<entityId>_<entityType>_<attrName>");
         OrionKafkaSink sink = new OrionKafkaSink();
         sink.configure(createContext("false", "dm-by-attribute"));
-        String topic = sink.buildTopicName(service,servicePathSlash,entity,attribute);
+        String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
             expectedTopic = "service_entityId_entityType_attributeName";
             assertEquals(expectedTopic, topic);
-            System.out.println("[OrionKafkaSink.buildTopicName ] -  OK  - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
         } catch (AssertionError e) {
-            System.out.println("[OrionKafkaSink.buildTopicName ] - FAIL - "
+            System.out.println(getTestTraceHead("[OrionKafkaSink.buildTopicName]") + "- FAIL - "
                     + "Wrong topic built, expected: '" + expectedTopic + "' but '" + topic + "' was created instead.");
             throw e;
         } // try catch
-        
-    } // testTopicNameDmByAttributeWithSlashServicePath
+    } // testBuildTopicNameDmByAttributeWithSlashServicePath
     
     private Context createContext(String lowerCase, String dataModel) {
         Context context = new Context();

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionMongoSinkTest.java
@@ -17,8 +17,11 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.Utils;
 import org.apache.flume.Context;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,11 +35,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class OrionMongoSinkTest {
     
     /**
-     * [OrionMongoSink] -------- Configured 'collection_prefix' cannot be 'system.'.
+     * Constructor.
+     */
+    public OrionMongoSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // OrionMongoSinkTest
+    
+    /**
+     * [OrionMongoSink.configure] -------- Configured 'collection_prefix' cannot be 'system.'.
      */
     @Test
-    public void testConfiguredCollectionPrefixIsNotSystem() {
-        System.out.println("[OrionMongoSink] -------- Configured 'collection_prefix' cannot be 'system.'");
+    public void testConfigureCollectionPrefixIsNotSystem() {
+        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                + "-------- Configured 'collection_prefix' cannot be 'system.'");
         String collectionPrefix = "system.";
         String dbPrefix = "sth_";
         OrionMongoSink sink = new OrionMongoSink();
@@ -44,19 +55,21 @@ public class OrionMongoSinkTest {
         
         try {
             assertTrue(sink.invalidConfiguration);
-            System.out.println("[OrionMongoSink] -  OK  - 'system.' value detected for 'collection_prefix'");
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "-  OK  - 'system.' value detected for 'collection_prefix'");
         } catch (AssertionError e) {
-            System.out.println("[OrionMongoSink] - FAIL - 'system.' value not detected for 'collection_prefix'");
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "- FAIL - 'system.' value not detected for 'collection_prefix'");
         } // try catch
-    } // testConfiguredCollectionPrefixIsNotSystem
+    } // testConfigureCollectionPrefixIsNotSystem
     
     /**
-     * [OrionMongoSink] -------- Configured 'collection_prefix' is encoded when having forbiden characters.
+     * [OrionMongoSink.configure] -------- Configured 'collection_prefix' is encoded when having forbiden characters.
      */
     @Test
-    public void testConfiguredCollectionPrefixIsEncoded() {
-        System.out.println("[OrionMongoSink] -------- Configured 'collection_prefix' "
-                + "is encoded when having forbiden characters");
+    public void testConfigureCollectionPrefixIsEncoded() {
+        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                + "-------- Configured 'collection_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "this\\is/a$prefix.with-forbiden,chars:-.";
         String dbPrefix = "sth_";
         OrionMongoSink sink = new OrionMongoSink();
@@ -65,21 +78,23 @@ public class OrionMongoSinkTest {
         
         try {
             assertTrue(sink.collectionPrefix.equals(encodedCollectionPrefix));
-            System.out.println("[OrionMongoSink] -  OK  - 'collection_prefix=" + collectionPrefix
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "-  OK  - 'collection_prefix=" + collectionPrefix
                     + "' correctly encoded as '" + encodedCollectionPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println("[OrionMongoSink] - FAIL - 'collection_prefix=" + collectionPrefix
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "- FAIL - 'collection_prefix=" + collectionPrefix
                     + "' wrongly encoded as '" + encodedCollectionPrefix + "'");
         } // try catch
-    } // testConfiguredCollectionPrefixIsEncoded
+    } // testConfigureCollectionPrefixIsEncoded
     
     /**
-     * [OrionMongoSink] -------- Configured 'db_prefix' is encoded when having forbiden characters.
+     * [OrionMongoSink.configure] -------- Configured 'db_prefix' is encoded when having forbiden characters.
      */
     @Test
-    public void testConfiguredDBPrefixIsEncoded() {
-        System.out.println("[OrionMongoSink] -------- Configured 'db_prefix' "
-                + "is encoded when having forbiden characters");
+    public void testConfigureDBPrefixIsEncoded() {
+        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                + "-------- Configured 'db_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "sth_";
         String dbPrefix = "this\\is/a$prefix.with forbiden\"chars:-,";
         OrionMongoSink sink = new OrionMongoSink();
@@ -88,13 +103,13 @@ public class OrionMongoSinkTest {
         
         try {
             assertTrue(sink.dbPrefix.equals(encodedDbPrefix));
-            System.out.println("[OrionMongoSink] -  OK  - 'db_prefix=" + dbPrefix
-                    + "' correctly encoded as '" + encodedDbPrefix + "'");
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "-  OK  - 'db_prefix=" + dbPrefix + "' correctly encoded as '" + encodedDbPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println("[OrionMongoSink] - FAIL - 'db_prefix=" + dbPrefix
-                    + "' wrongly encoded as '" + encodedDbPrefix + "'");
+            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+                    + "- FAIL - 'db_prefix=" + dbPrefix + "' wrongly encoded as '" + encodedDbPrefix + "'");
         } // try catch
-    } // testConfiguredDBPrefixIsEncoded
+    } // testConfigureDBPrefixIsEncoded
     
     private Context createContext(String collectionPrefix, String dbPrefix) {
         Context context = new Context();

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSTHSinkTest.java
@@ -17,8 +17,11 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.Utils;
 import org.apache.flume.Context;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,11 +35,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class OrionSTHSinkTest {
     
     /**
-     * [OrionSTHSink] -------- Configured 'collection_prefix' cannot be 'system.'.
+     * Constructor.
+     */
+    public OrionSTHSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // OrionSTHSinkTest
+    
+    /**
+     * [OrionSTHSink.configure] -------- Configured 'collection_prefix' cannot be 'system.'.
      */
     @Test
-    public void testConfiguredCollectionPrefixIsNotSystem() {
-        System.out.println("[OrionSTHSink] -------- Configured 'collection_prefix' cannot be 'system.'");
+    public void testConfigureCollectionPrefixIsNotSystem() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure)")
+                + "-------- Configured 'collection_prefix' cannot be 'system.'");
         String collectionPrefix = "system.";
         String dbPrefix = "sth_";
         OrionSTHSink sink = new OrionSTHSink();
@@ -44,19 +55,21 @@ public class OrionSTHSinkTest {
         
         try {
             assertTrue(sink.invalidConfiguration);
-            System.out.println("[OrionSTHSink] -  OK  - 'system.' value detected for 'collection_prefix'");
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - 'system.' value detected for 'collection_prefix'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSTHSink] - FAIL - 'system.' value not detected for 'collection_prefix'");
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - 'system.' value not detected for 'collection_prefix'");
         } // try catch
-    } // testConfiguredCollectionPrefixIsNotSystem
+    } // testConfigureCollectionPrefixIsNotSystem
     
     /**
-     * [OrionSTHSink] -------- Configured 'collection_prefix' is encoded when having forbiden characters.
+     * [OrionSTHSink.configure] -------- Configured 'collection_prefix' is encoded when having forbiden characters.
      */
     @Test
-    public void testConfiguredCollectionPrefixIsEncoded() {
-        System.out.println("[OrionSTHSink] -------- Configured 'collection_prefix' "
-                + "is encoded when having forbiden characters");
+    public void testConfigureCollectionPrefixIsEncoded() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                + "-------- Configured 'collection_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "this\\is/a$prefix.with-forbiden,chars:-.";
         String dbPrefix = "sth_";
         OrionSTHSink sink = new OrionSTHSink();
@@ -65,21 +78,23 @@ public class OrionSTHSinkTest {
         
         try {
             assertTrue(sink.collectionPrefix.equals(encodedCollectionPrefix));
-            System.out.println("[OrionSTHSink] -  OK  - 'collection_prefix=" + collectionPrefix
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - 'collection_prefix=" + collectionPrefix
                     + "' correctly encoded as '" + encodedCollectionPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSTHSink] - FAIL - 'collection_prefix=" + collectionPrefix
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - 'collection_prefix=" + collectionPrefix
                     + "' wrongly encoded as '" + encodedCollectionPrefix + "'");
         } // try catch
-    } // testConfiguredCollectionPrefixIsEncoded
+    } // testConfigureCollectionPrefixIsEncoded
     
     /**
-     * [OrionSTHSink] -------- Configured 'db_prefix' is encoded when having forbiden characters.
+     * [OrionSTHSink.configure] -------- Configured 'db_prefix' is encoded when having forbiden characters.
      */
     @Test
-    public void testConfiguredDBPrefixIsEncoded() {
-        System.out.println("[OrionSTHSink] -------- Configured 'db_prefix' "
-                + "is encoded when having forbiden characters");
+    public void testConfigureDBPrefixIsEncoded() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                + "-------- Configured 'db_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "sth_";
         String dbPrefix = "this\\is/a$prefix.with forbiden\"chars:-.";
         OrionSTHSink sink = new OrionSTHSink();
@@ -88,13 +103,13 @@ public class OrionSTHSinkTest {
         
         try {
             assertTrue(sink.dbPrefix.equals(encodedDbPrefix));
-            System.out.println("[OrionSTHSink] -  OK  - 'db_prefix=" + dbPrefix
-                    + "' correctly encoded as '" + encodedDbPrefix + "'");
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - 'db_prefix=" + dbPrefix + "' correctly encoded as '" + encodedDbPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSTHSink] - FAIL - 'db_prefix=" + dbPrefix
-                    + "' wrongly encoded as '" + encodedDbPrefix + "'");
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - 'db_prefix=" + dbPrefix + "' wrongly encoded as '" + encodedDbPrefix + "'");
         } // try catch
-    } // testConfiguredDBPrefixIsEncoded
+    } // testConfigureDBPrefixIsEncoded
     
     private Context createContext(String collectionPrefix, String dbPrefix) {
         Context context = new Context();

--- a/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/sinks/OrionSinkTest.java
@@ -18,6 +18,7 @@
 package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.sinks.OrionSink.DataModel;
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
@@ -49,15 +50,15 @@ public class OrionSinkTest {
      * Constructor.
      */
     public OrionSinkTest() {
-        LogManager.getRootLogger().setLevel(Level.ERROR);
+        LogManager.getRootLogger().setLevel(Level.FATAL);
     } // OrionSinkTest
     
     /**
-     * [OrionSink] -------- The sink starts properly.
+     * [OrionSink.start] -------- The sink starts properly.
      */
     @Test
     public void testStart() {
-        System.out.println("[OrionSink] -------- The sink starts properly");
+        System.out.println(getTestTraceHead("[OrionSink.start]") + "-------- The sink starts properly");
         OrionSinkImpl sink = new OrionSinkImpl();
         sink.configure(createContext(null, null, null, null, null, null)); // default configuration
         sink.setChannel(new MemoryChannel());
@@ -66,11 +67,11 @@ public class OrionSinkTest {
         
         try {
             assertEquals(LifecycleState.START, state);
-            System.out.println("[OrionSink] -  OK  - The sink started properly, the lifecycle state is '"
-                    + state.toString() + "'");
+            System.out.println(getTestTraceHead("[OrionSink.start]")
+                    + "-  OK  - The sink started properly, the lifecycle state is '" + state.toString() + "'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink] - FAIL - The sink did not start properly, the lifecycle state "
-                    + "is '" + state.toString() + "'");
+            System.out.println(getTestTraceHead("[OrionSink.start]")
+                    + "- FAIL - The sink did not start properly, the lifecycle state is '" + state.toString() + "'");
         } // try catch
     } // testStart
     
@@ -80,67 +81,71 @@ public class OrionSinkTest {
      */
     @Test
     public void testConfigureNotMandatoryParameters() {
-        System.out.println("[OrionSink.configure] -------- When not configured, the default values are used "
-                + "for non mandatory parameters");
+        System.out.println(getTestTraceHead("[OrionSink.configure]")
+                + "-------- When not configured, the default values are used for non mandatory parameters");
         OrionSinkImpl sink = new OrionSinkImpl();
         sink.configure(createContext(null, null, null, null, null, null)); // default configuration
         
         try {
             assertEquals(1, sink.getBatchSize());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'batch_size' is '1'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'batch_size' is '1'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
-                    + "'batch_size' is '" + sink.getBatchSize() + "'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for 'batch_size' is '" + sink.getBatchSize() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals(30, sink.getBatchTimeout());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'batch_timeout' is '30'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'batch_timeout' is '30'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
-                    + "'batch_timeout' is '" + sink.getBatchTimeout() + "'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for 'batch_timeout' is '"
+                    + sink.getBatchTimeout() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals(10, sink.getBatchTTL());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'batch_ttl' is '10'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'batch_ttl' is '10'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
-                    + "'batch_ttl' is '" + sink.getBatchTTL() + "'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for 'batch_ttl' is '" + sink.getBatchTTL() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals(DataModel.DMBYENTITY, sink.getDataModel());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'data_model' is 'dm-by-entity'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'data_model' is 'dm-by-entity'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for "
                     + "'data_model' is '" + sink.getDataModel() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals(false, sink.getEnableGrouping());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'enable_grouping' is 'false'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'enable_grouping' is 'false'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for "
                     + "'enable_grouping' is '" + sink.getEnableGrouping() + "'");
             throw e;
         } // try catch
         
         try {
             assertEquals(false, sink.getEnableLowerCase());
-            System.out.println("[OrionSink.configure] -  OK  - The default configuration value for "
-                    + "'enable_lowercase' is 'false'");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - The default configuration value for 'enable_lowercase' is 'false'");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - The default configuration value for "
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - The default configuration value for "
                     + "'enable_lowercase' is '" + sink.getEnableLowerCase() + "'");
             throw e;
         } // try catch
@@ -152,19 +157,21 @@ public class OrionSinkTest {
      */
     @Test
     public void testConfigureInvalidConfiguration() {
-        System.out.println("[OrionSink.configure] -------- The configuration becomes invalid upon out-of-the-limits "
-                + "configured values for parameters having a discrete set of accepted values, or numerical values "
-                + "having upper or lower limits");
+        System.out.println(getTestTraceHead("[OrionSink.configure]")
+                + "-------- The configuration becomes invalid upon out-of-the-limits configured values for parameters "
+                + "having a discrete set of accepted values, or numerical values having upper or lower limits");
         OrionSinkImpl sink = new OrionSinkImpl();
         String configuredBatchSize = "0";
         sink.configure(createContext(configuredBatchSize, null, null, null, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_size='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'batch_size='"
                     + configuredBatchSize + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_size='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'batch_size='"
                     + configuredBatchSize + "' has not been detected");
             throw e;
         } // try catch
@@ -175,10 +182,12 @@ public class OrionSinkTest {
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_timeout='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'batch_timeout='"
                     + configuredBatchTimeout + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_timeout='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'batch_timeout='"
                     + configuredBatchTimeout + "' has not been detected");
             throw e;
         } // try catch
@@ -189,11 +198,11 @@ public class OrionSinkTest {
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'batch_ttl='"
-                    + configuredBatchTTL + "' has been detected");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'batch_ttl='" + configuredBatchTTL + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'batch_ttl='"
-                    + configuredBatchTTL + "' has not been detected");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'batch_ttl='" + configuredBatchTTL + "' has not been detected");
             throw e;
         } // try catch
         
@@ -203,11 +212,11 @@ public class OrionSinkTest {
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'data_model='"
-                    + dataModel + "' has been detected");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'data_model='" + dataModel + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'data_model='"
-                    + dataModel + "' has not been detected");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'data_model='" + dataModel + "' has not been detected");
             throw e;
         } // try catch
         
@@ -217,10 +226,12 @@ public class OrionSinkTest {
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'enable_grouping='"
-                    + configuredEnableGrouping + "' has been detected");
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'enable_grouping='"
++ configuredEnableGrouping + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'enable_grouping='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'enable_grouping='"
                     + configuredEnableGrouping + "' has not been detected");
             throw e;
         } // try catch
@@ -231,10 +242,12 @@ public class OrionSinkTest {
         
         try {
             assertTrue(sink.getInvalidConfiguration());
-            System.out.println("[OrionSink.configure] -  OK  - A wrong configuration 'enable_lowercase='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "-  OK  - A wrong configuration 'enable_lowercase='"
                     + configuredEnableLowercase + "' has been detected");
         } catch (AssertionError e) {
-            System.out.println("[OrionSink.configure] - FAIL - A wrong configuration 'enable_lowercase='"
+            System.out.println(getTestTraceHead("[OrionSink.configure]")
+                    + "- FAIL - A wrong configuration 'enable_lowercase='"
                     + configuredEnableLowercase + "' has not been detected");
             throw e;
         } // try catch

--- a/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
+++ b/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
@@ -20,17 +20,16 @@ package com.telefonica.iot.cygnus.utils;
 
 import com.google.gson.Gson;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
-import java.io.StringReader;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.xml.sax.InputSource;
 
 /**
  *
  * @author frb
  */
 public final class TestUtils {
+    
+    private static final int MAX_LEN_TEST_TRACE_HEAD = 40;
     
     /**
      * Constructor. It is private since utility clasess should not have a public or default constructor.
@@ -58,14 +57,13 @@ public final class TestUtils {
     } // createJsonNotifyContextRequest
     
     /**
-     * Encodes a string replacing all the non alphanumeric characters by '_'.
-     * 
-     * @param in
-     * @return The encoded version of the input string.
+     * Gets a trace head.
+     * @param originalHead
+     * @return A trace head
      */
-    public static String encode(String in) {
-        String res = in.replaceAll("[^a-zA-Z0-9\\.\\-]", "_");
-        return (res.startsWith("_") ? res.substring(1, res.length()) : res);
-    } // encode
-    
+    public static String getTestTraceHead(String originalHead) {
+        String traceHead = originalHead;
+        traceHead += " " + StringUtils.repeat("-", MAX_LEN_TEST_TRACE_HEAD - originalHead.length());
+        return traceHead;
+    } // getTestTraceHead
 } // TestUtils

--- a/src/test/java/com/telefonica/iot/cygnus/utils/UtilsTest.java
+++ b/src/test/java/com/telefonica/iot/cygnus/utils/UtilsTest.java
@@ -17,6 +17,9 @@
  */
 package com.telefonica.iot.cygnus.utils;
 
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import static org.junit.Assert.assertTrue;
@@ -30,6 +33,13 @@ import org.mockito.runners.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class UtilsTest {
+    
+    /**
+     * Constructor.
+     */
+    public UtilsTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // UtilsTest
 
     /**
      * [Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp without
@@ -37,7 +47,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithoutMiliseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 "
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid ISO 8601 "
                 + "timestamp without miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
@@ -50,10 +61,11 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]") + "-  OK  - Time instant obtained for '"
                     + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantISO8601TimestampWithoutMiliseconds
@@ -64,8 +76,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithMiliseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 "
-                + "timestamp with miliseconds");
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid ISO 8601 timestamp with miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -77,10 +89,11 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]") + "-  OK  - Time instant obtained for '"
                     + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantISO8601TimestampWithMiliseconds
@@ -91,8 +104,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithMicroseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 "
-                + "timestamp with microseconds");
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid ISO 8601 timestamp with microseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -104,10 +117,11 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]") + "-  OK  - Time instant obtained for '"
                     + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantISO8601TimestampWithMicroseconds
@@ -118,8 +132,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithoutMiliseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL "
-                + "timestamp without miliseconds");
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid SQL timestamp without miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -131,10 +145,11 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]") + "-  OK  - Time instant obtained for '"
                     + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantSQLTimestampWithoutMiliseconds
@@ -144,8 +159,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithMiliseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL "
-                + "timestamp with miliseconds");
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid SQL timestamp with miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -157,10 +172,12 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
-                    + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "-  OK  - Time instant obtained for '" + metadatasJson.toJSONString() + "' is '"
+                    + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantSQLTimestampWithMiliseconds
@@ -170,8 +187,8 @@ public class UtilsTest {
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithMicroseconds() {
-        System.out.println("[Utils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL "
-                + "timestamp with microseconds");
+        System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                + "-------- A time instant is obtained when passing a valid SQL timestamp with microseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -183,10 +200,12 @@ public class UtilsTest {
 
         try {
             assertTrue(timeInstant != null);
-            System.out.println("[Utils.getTimeInstant] -  OK  - Time instant obtained for '"
-                    + metadatasJson.toJSONString() + "' is '" + timeInstant + "'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "-  OK  - Time instant obtained for '" + metadatasJson.toJSONString() + "' is '"
+                    + timeInstant + "'");
         } catch (AssertionError e) {
-            System.out.println("[Utils.getTimeInstant] - FAIL - Time instant obtained is 'null'");
+            System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
+                    + "- FAIL - Time instant obtained is 'null'");
             throw e;
         } // try catch
     } // testGetTimeInstantSQLTimestampWithMicroseconds


### PR DESCRIPTION
* Partially implements issue #754 
* 100% unit tests passed:
```
Tests run: 101, Failures: 0, Errors: 0, Skipped: 0
```

A detail of the test fully aligned:
```
Running com.telefonica.iot.cygnus.sinks.OrionSinkTest
[OrionSink.start] ------------------------------- The sink starts properly
[OrionSink.start] ------------------------  OK  - The sink started properly, the lifecycle state is 'START'
[OrionSink.configure] --------------------------- The configuration becomes invalid upon out-of-the-limits configured values for parameters having a discrete set of accepted values, or numerical values having upper or lower limits
[OrionSink.configure] --------------------  OK  - A wrong configuration 'batch_size='0' has been detected
[OrionSink.configure] --------------------  OK  - A wrong configuration 'batch_timeout='0' has been detected
[OrionSink.configure] --------------------  OK  - A wrong configuration 'batch_ttl='-2' has been detected
[OrionSink.configure] --------------------  OK  - A wrong configuration 'data_model='dm-by-other' has been detected
[OrionSink.configure] --------------------  OK  - A wrong configuration 'enable_grouping='falso' has been detected
[OrionSink.configure] --------------------  OK  - A wrong configuration 'enable_lowercase='verdadero' has been detected
[OrionSink.configure] --------------------------- When not configured, the default values are used for non mandatory parameters
[OrionSink.configure] --------------------  OK  - The default configuration value for 'batch_size' is '1'
[OrionSink.configure] --------------------  OK  - The default configuration value for 'batch_timeout' is '30'
[OrionSink.configure] --------------------  OK  - The default configuration value for 'batch_ttl' is '10'
[OrionSink.configure] --------------------  OK  - The default configuration value for 'data_model' is 'dm-by-entity'
[OrionSink.configure] --------------------  OK  - The default configuration value for 'enable_grouping' is 'false'
[OrionSink.configure] --------------------  OK  - The default configuration value for 'enable_lowercase' is 'false'
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec
Running com.telefonica.iot.cygnus.sinks.OrionSTHSinkTest
[OrionSTHSink.configure] ------------------------ Configured 'db_prefix' is encoded when having forbiden characters
[OrionSTHSink.configure] -----------------  OK  - 'db_prefix=this\is/a$prefix.with forbiden"chars:-.' correctly encoded as 'this_is_a_prefix_with_forbiden_chars:-_'
[OrionSTHSink.configure) ------------------------ Configured 'collection_prefix' cannot be 'system.'
[OrionSTHSink.configure] -----------------  OK  - 'system.' value detected for 'collection_prefix'
[OrionSTHSink.configure] ------------------------ Configured 'collection_prefix' is encoded when having forbiden characters
[OrionSTHSink.configure] -----------------  OK  - 'collection_prefix=this\is/a$prefix.with-forbiden,chars:-.' correctly encoded as 'this\is/a_prefix.with-forbiden,chars:-.'
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec
Running com.telefonica.iot.cygnus.utils.UtilsTest
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid ISO 8601 timestamp with microseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01.123456Z"}]' is '1483228801123'
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid SQL timestamp with miliseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01.123"}]' is '1483228801123'
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid ISO 8601 timestamp without miliseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01Z"}]' is '1483228801000'
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid ISO 8601 timestamp with miliseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01T00:00:01.123Z"}]' is '1483228801123'
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid SQL timestamp without miliseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01"}]' is '1483228801000'
[Utils.getTimeInstant] -------------------------- A time instant is obtained when passing a valid SQL timestamp with microseconds
[Utils.getTimeInstant] -------------------  OK  - Time instant obtained for '[{"name":"TimeInstant","type":"SQL timestamp","value":"2017-01-01 00:00:01.123456"}]' is '1483228801123'
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec
```
* Assignee @pcoello25 