### PR TITLE
feature/927_add_ngsi_cartodb_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -37,3 +37,4 @@
 - [cygnus-ngsi] [hardening] Use UUIDv4 in the generation of correlator and transaction IDs in OrionRestHandler (#931)
 - [cygnus-ngsi] [task] Refactor de Github repository in a per agent fashion (#864)
 - [cygnus-ngsi] [hardening] Add documentation for API about /v1/subscriptions in ManagementInterface (#808)
+- [cygnus-ngsi] [feature] Add NGSICartoDBSink (#927)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.backends.cartodb;
+
+/**
+ *
+ * @author frb
+ */
+public interface CartoDBBackend {
+    
+    /**
+     * Inserts the given aggregated data in the give table within the give database.
+     * @param tableName
+     * @param fields
+     * @param rows
+     * @throws java.lang.Exception
+     */
+    void insert(String tableName, String fields, String rows) throws Exception;
+    
+} // CartoDBBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.backends.cartodb;
+
+import com.telefonica.iot.cygnus.backends.http.HttpBackend;
+import com.telefonica.iot.cygnus.backends.http.JsonResponse;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import java.net.URLEncoder;
+
+/**
+ *
+ * @author frb
+ */
+public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
+    
+    private final String apiKey;
+    private static final String BASE_URL = "/api/v2/sql?q=";
+    
+    /**
+     * Constructor.
+     * @param host
+     * @param port
+     * @param apiKey
+     * @param ssl
+     */
+    public CartoDBBackendImpl(String host, String port, boolean ssl, String apiKey) {
+        super(new String[]{host}, port, ssl, false, null, null, null, null);
+        this.apiKey = apiKey;
+    } // CartoDBBackendImpl
+
+    @Override
+    public void insert(String tableName, String fields, String rows) throws Exception {
+        String query = "INSERT INTO " + tableName + " " + fields + " VALUES " + rows;
+        String encodedQuery = URLEncoder.encode(query, "UTF-8");
+        String relativeURL = BASE_URL + encodedQuery + "&api_key=" + apiKey;
+        JsonResponse response = doRequest("GET", relativeURL, true, null, null);
+
+        // check the status
+        if (response.getStatusCode() != 200) {
+            throw new CygnusPersistenceError("The query '" + query + "' could not be executed. CartoDB response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
+        } // if
+    } // insert
+    
+} // CartoDBBackendImpl

--- a/cygnus-ngsi/pom.xml
+++ b/cygnus-ngsi/pom.xml
@@ -134,9 +134,9 @@
 	<version>0.9.1</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.telefonica.iot</groupId>
       <artifactId>cygnus-common</artifactId>
-      <version>${project.version}</version>
+      <version>0.13.0_SNAPSHOT</version>
     </dependency>
   </dependencies>
 
@@ -164,6 +164,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.6</version>
           <configuration>
             <descriptorRefs>
               <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -119,7 +119,7 @@ public class NGSICartoDBSink extends NGSISink {
         
         String flipCoordinatesStr = context.getString("flip_coordinates", "false");
         
-        if(flipCoordinatesStr.equals("true") || flipCoordinatesStr.equals("false")) {
+        if (flipCoordinatesStr.equals("true") || flipCoordinatesStr.equals("false")) {
             flipCoordinates = flipCoordinatesStr.equals("true");
             LOGGER.debug("[" + this.getName() + "] Reading configuration (flip_coordinates="
                     + flipCoordinatesStr + ")");
@@ -272,10 +272,11 @@ public class NGSICartoDBSink extends NGSISink {
             
             for (ContextAttribute contextAttribute : contextAttributes) {
                 String attrName = contextAttribute.getName();
+                String attrType = contextAttribute.getType();
                 String attrValue = contextAttribute.getContextValue(false);
                 String attrMetadata = contextAttribute.getContextMetadata();
                 
-                if (!NGSIUtils.getLocation(attrValue, attrMetadata, flipCoordinates).startsWith(
+                if (!NGSIUtils.getLocation(attrValue, attrType, attrMetadata, flipCoordinates).startsWith(
                         "ST_SetSRID(ST_MakePoint(")) {
                     aggregation.put(attrName, new ArrayList<String>());
                     aggregation.put(attrName + "_md", new ArrayList<String>());
@@ -316,7 +317,7 @@ public class NGSICartoDBSink extends NGSISink {
                 String attrMetadata = contextAttribute.getContextMetadata();
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
-                String location = NGSIUtils.getLocation(attrValue, attrMetadata, flipCoordinates);
+                String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadata, flipCoordinates);
                 
                 if (location.startsWith("ST_SetSRID(ST_MakePoint(")) {
                     aggregation.get(NGSIConstants.THE_GEOM).add(location);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.telefonica.iot.cygnus.backends.cartodb.CartoDBBackendImpl;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
+import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import com.telefonica.iot.cygnus.utils.NGSIUtils;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import org.apache.flume.Context;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSICartoDBSink extends NGSISink {
+    
+    private static final CygnusLogger LOGGER = new CygnusLogger(NGSICartoDBSink.class);
+    private String host;
+    private String port;
+    private boolean ssl;
+    private String apiKey;
+    private CartoDBBackendImpl backend;
+    
+    /**
+     * Constructor.
+     */
+    public NGSICartoDBSink() {
+        super();
+    } // NGSICartoDBSink
+    
+    @Override
+    public void configure(Context context) {
+        // Read NGSISink general configuration
+        super.configure(context);
+        
+        // Read NGSICartoDB specific configuration
+        String endpoint = context.getString("endpoint");
+        
+        if (endpoint == null) {
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (endpoint=null) -- Must not be empty)");
+            return;
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (endpoint=" + endpoint + ")");
+        } // else
+        
+        int index = 0;
+        
+        if (endpoint.startsWith("http://")) {
+            port = "80";
+            ssl = false;
+            index = 7;
+        } else if (endpoint.startsWith("https://")) {
+            port = "443";
+            ssl = true;
+            index = 8;
+        } else {
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (endpoint=" + endpoint + ") "
+                    + "-- The URI must use the http or https schemes)");
+            return;
+        } // if else
+        
+        String hostPort = endpoint.substring(index);
+        String[] split = hostPort.split(":");
+        
+        if (split.length == 2) {
+            host = split[0];
+            port = split[1];
+        } else {
+            host = split[0];
+        } // if else
+        
+        apiKey = context.getString("api_key");
+        
+        if (apiKey == null) {
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (apiKey=null) -- Must not be empty)");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (apiKey=" + apiKey + ")");
+        } // if else
+    } // configure
+    
+    @Override
+    public void start() {
+        try {
+            // create the persistence backend
+            backend = new CartoDBBackendImpl(host, port, ssl, apiKey);
+            LOGGER.debug("[" + this.getName() + "] CartoDB persistence backend created");
+        } catch (Exception e) {
+            LOGGER.error("Error while creating the CartoDB persistence backend. Details: " + e.getMessage());
+        } // try catch
+
+        super.start();
+    } // start
+
+    @Override
+    void persistBatch(NGSIBatch batch) throws Exception {
+        if (batch == null) {
+            LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
+            return;
+        } // if
+
+        // iterate on the destinations, for each one a single create / append will be performed
+        for (String destination : batch.getDestinations()) {
+            LOGGER.debug("[" + this.getName() + "] Processing sub-batch regarding the " + destination
+                    + " destination");
+
+            // get the sub-batch for this destination
+            ArrayList<NGSIEvent> subBatch = batch.getEvents(destination);
+
+            // get an aggregator for this destination and initialize it
+            CartoDBAggregator aggregator = new CartoDBAggregator();
+            aggregator.initialize(subBatch.get(0));
+
+            for (NGSIEvent cygnusEvent : subBatch) {
+                aggregator.aggregate(cygnusEvent);
+            } // for
+
+            // persist the aggregation
+            persistAggregation(aggregator);
+            batch.setPersisted(destination);
+        } // for
+    } // persistBatch
+    
+    /**
+     * Convenience class for aggregating data.
+     */
+    private class CartoDBAggregator {
+        
+        private LinkedHashMap<String, ArrayList<String>> aggregation;
+        private String service;
+        private String servicePath;
+        private String entity;
+        private String attribute;
+        private String dbName;
+        private String tableName;
+        
+        public String getDbName() {
+            return dbName;
+        } // getDbName
+        
+        public String getTableName() {
+            return tableName;
+        } // getTableName
+        
+        public String getRows() {
+            String rows = "";
+            int numEvents = aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).size();
+            
+            for (int i = 0; i < numEvents; i++) {
+                if (i == 0) {
+                    rows += "(";
+                } else {
+                    rows += ",(";
+                } // if else
+                
+                boolean first = true;
+                Iterator it = aggregation.keySet().iterator();
+            
+                while (it.hasNext()) {
+                    ArrayList<String> values = (ArrayList<String>) aggregation.get((String) it.next());
+                    String value = values.get(i);
+                    
+                    if (!value.startsWith("ST_SetSRID(ST_MakePoint(")) {
+                        value = "'" + value + "'";
+                    } // if
+                    
+                    if (first) {
+                        rows += value;
+                        first = false;
+                    } else {
+                        rows += "," + value;
+                    } // if else
+                } // while
+                
+                rows += ")";
+            } // for
+            
+            return rows;
+        } // getRows
+        
+        public String getFields() {
+            String fields = "(";
+            boolean first = true;
+            Iterator it = aggregation.keySet().iterator();
+            
+            while (it.hasNext()) {
+                if (first) {
+                    fields += (String) it.next();
+                    first = false;
+                } else {
+                    fields += "," + (String) it.next();
+                } // if else
+            } // while
+            
+            return fields + ")";
+        } // getFields
+        
+        public void initialize(NGSIEvent cygnusEvent) throws Exception {
+            service = cygnusEvent.getService();
+            servicePath = cygnusEvent.getServicePath();
+            entity = cygnusEvent.getEntity();
+            attribute = cygnusEvent.getAttribute();
+            dbName = buildDbName(service);
+            tableName = buildTableName(servicePath, entity, attribute);
+            
+            // aggregation initialization
+            aggregation = new LinkedHashMap<String, ArrayList<String>>();
+            aggregation.put(NGSIConstants.RECV_TIME, new ArrayList<String>());
+            aggregation.put(NGSIConstants.FIWARE_SERVICE_PATH, new ArrayList<String>());
+            aggregation.put(NGSIConstants.ENTITY_ID, new ArrayList<String>());
+            aggregation.put(NGSIConstants.ENTITY_TYPE, new ArrayList<String>());
+            
+            // iterate on all this context element attributes, if there are attributes
+            ArrayList<ContextAttribute> contextAttributes = cygnusEvent.getContextElement().getAttributes();
+
+            if (contextAttributes == null || contextAttributes.isEmpty()) {
+                return;
+            } // if
+            
+            for (ContextAttribute contextAttribute : contextAttributes) {
+                String attrName = contextAttribute.getName();
+                aggregation.put(attrName, new ArrayList<String>());
+                aggregation.put(attrName + "_md", new ArrayList<String>());
+            } // for
+        } // initialize
+        
+        public void aggregate(NGSIEvent cygnusEvent) throws Exception {
+            // get the event headers
+            long recvTimeTs = cygnusEvent.getRecvTimeTs();
+            String recvTime = NGSIUtils.getHumanReadable(recvTimeTs, true);
+
+            // get the event body
+            NotifyContextRequest.ContextElement contextElement = cygnusEvent.getContextElement();
+            String entityId = contextElement.getId();
+            String entityType = contextElement.getType();
+            LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
+                    + entityType + ")");
+            
+            // iterate on all this context element attributes, if there are attributes
+            ArrayList<ContextAttribute> contextAttributes = contextElement.getAttributes();
+
+            if (contextAttributes == null || contextAttributes.isEmpty()) {
+                LOGGER.warn("No attributes within the notified entity, nothing is done (id=" + entityId
+                        + ", type=" + entityType + ")");
+                return;
+            } // if
+            
+            aggregation.get(NGSIConstants.RECV_TIME).add(recvTime);
+            aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).add(servicePath);
+            aggregation.get(NGSIConstants.ENTITY_ID).add(entityId);
+            aggregation.get(NGSIConstants.ENTITY_TYPE).add(entityType);
+            
+            for (ContextAttribute contextAttribute : contextAttributes) {
+                String attrName = contextAttribute.getName();
+                String attrType = contextAttribute.getType();
+                String attrValue = contextAttribute.getContextValue(false);
+                String attrMetadata = contextAttribute.getContextMetadata();
+                LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
+                        + attrType + ")");
+                aggregation.get(attrName).add(NGSIUtils.getLocation(attrValue, attrMetadata));
+                aggregation.get(attrName + "_md").add(attrMetadata);
+            } // for
+        } // aggregate
+        
+    } // CartoDBAggregator
+    
+    private void persistAggregation(CartoDBAggregator aggregator) throws Exception {
+        String rows = aggregator.getRows();
+        String dbName = aggregator.getDbName(); // enable_lowercase is unncessary, PostgreSQL is case insensitive
+        String tableName = aggregator.getTableName(); // enable_lowercase is unncessary, PostgreSQL is case insensitive
+        String fields = aggregator.getFields();
+        LOGGER.info("[" + this.getName() + "] Persisting data at NGSICartoDBSink. Database (" + dbName
+                + "), Table (" + tableName + "), Data (" + rows + ")");
+        backend.insert(tableName, fields, rows);
+    } // persistAggregation
+    
+    private String buildDbName(String service) throws Exception {
+        String name = NGSIUtils.encodePostgreSQL(service, false);
+
+        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
+            throw new CygnusBadConfiguration("Building database name '" + name
+                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
+        } // if
+
+        return name;
+    } // buildDbName
+    
+    private String buildTableName(String servicePath, String entity, String attribute) throws Exception {
+        String name;
+        
+        switch(dataModel) {
+            case DMBYSERVICEPATH:
+                if (servicePath.equals("/")) {
+                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                            + "dm-by-service-path data model");
+                } // if
+
+                name = NGSIUtils.encodePostgreSQL(servicePath, true);
+                break;
+            case DMBYENTITY:
+                String truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                        + NGSIUtils.encodePostgreSQL(entity, false);
+                break;
+            case DMBYATTRIBUTE:
+                truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                        + NGSIUtils.encodePostgreSQL(entity, false)
+                        + '_' + NGSIUtils.encodePostgreSQL(attribute, false);
+                break;
+            default:
+                throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
+                        + "'. Please, use DMBYSERVICEPATH, DMBYENTITY or DMBYATTRIBUTE");
+        } // switch
+        
+        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
+            throw new CygnusBadConfiguration("Building table name '" + name
+                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
+        } // if
+
+        return name;
+    } // buildTableName
+    
+} // NGSICartoDBSink

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
@@ -77,12 +77,15 @@ public final class NGSIConstants {
     public static final int STH_MAX_NAMESPACE_SIZE_IN_BYTES = 113;
     public static final int STH_MIN_HASH_SIZE_IN_BYTES      = 20;
     
-    // NGSIDynamoDB specific headers
+    // NGSIDynamoDBSink specific headers
     public static final String DYNAMO_DB_PRIMARY_KEY = "ID";
     
-    // NGSIPostgreSQL specific headers
+    // NGSIPostgreSQLSink specific headers
     // http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
     public static final int POSTGRESQL_MAX_ID_LEN = 63;
+    
+    // NGSICartoDBSink specific headers
+    public static final String THE_GEOM = "the_geom";
     
     // log4j specific constants
     public static final String LOG4J_CORR = "correlatorId";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
@@ -73,12 +73,16 @@ public final class NGSIConstants {
     public static final String PARAM_DEFAULT_SERVICE_PATH = "default_service_path";
     public static final String PARAM_NOTIFICATION_TARGET  = "notification_target";
     
-    // OrionSTHSink specific headers
+    // NGSISTHSink specific headers
     public static final int STH_MAX_NAMESPACE_SIZE_IN_BYTES = 113;
     public static final int STH_MIN_HASH_SIZE_IN_BYTES      = 20;
     
-    // OrionDynamoDB specific headers
+    // NGSIDynamoDB specific headers
     public static final String DYNAMO_DB_PRIMARY_KEY = "ID";
+    
+    // NGSIPostgreSQL specific headers
+    // http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    public static final int POSTGRESQL_MAX_ID_LEN = 63;
     
     // log4j specific constants
     public static final String LOG4J_CORR = "correlatorId";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -347,11 +347,24 @@ public final class NGSIUtils {
      * Gets the geolocation value, ready for insertion in CartoDB, given a NGSI attribute value and its metadata.
      * If the attribute is not geo-related, it is returned as it is.
      * @param attrValue
+     * @param attrType
      * @param metadata
      * @param flipCoordinates
      * @return The geolocation value, ready for insertion in CartoDB, or tehe value as it is
      */
-    public static String getLocation(String attrValue, String metadata, boolean flipCoordinates) {
+    public static String getLocation(String attrValue, String attrType, String metadata, boolean flipCoordinates) {
+        // First, check the attribute type
+        if (attrType.equals("geo:point")) {
+            String[] split = attrValue.split(",");
+                
+            if (flipCoordinates) {
+                return "ST_SetSRID(ST_MakePoint(" + split[1].trim() + "," + split[0].trim() + "), 4326)";
+            } else {
+                return "ST_SetSRID(ST_MakePoint(" + split[0].trim() + "," + split[1].trim() + "), 4326)";
+            } // if else
+        } // if
+        
+        // The type was not 'geo:pint', thus try the metadata
         JSONParser parser = new JSONParser();
         JSONArray mds;
         
@@ -379,6 +392,7 @@ public final class NGSIUtils {
             } // if
         } // for
         
+        // The attribute was not related to a geolocation
         return attrValue;
     } // getLocation
         

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -50,6 +50,7 @@ public final class NGSIUtils {
     private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final Pattern ENCODESTHDBPATTERN = Pattern.compile("[\\/\\\\.\\$\" ]");
     private static final Pattern ENCODESTHCOLLECTIONPATTERN = Pattern.compile("\\$");
+    private static final Pattern ENCODEPOSTGRESQLPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final DateTimeFormatter FORMATTER1 = DateTimeFormat.forPattern(
             "yyyy-MM-dd'T'HH:mm:ss'Z'").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER2 = DateTimeFormat.forPattern(
@@ -111,6 +112,22 @@ public final class NGSIUtils {
     public static String encodeSTHCollection(String in) {
         return ENCODESTHCOLLECTIONPATTERN.matcher(in).replaceAll("_");
     } // encodeSTHCollection
+    
+    /**
+     * Encodes a tring replacing all ' ' with '_'.
+     * @param in
+     * @param deleteSlash
+     * @return
+     */
+    public static String encodePostgreSQL(String in, boolean deleteSlash) {
+        // PostgreSQL is case insensitive:
+        // http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+        if (deleteSlash) {
+            return ENCODEPOSTGRESQLPATTERN.matcher(in.substring(1)).replaceAll("_").toLowerCase();
+        } else {
+            return ENCODEPOSTGRESQLPATTERN.matcher(in).replaceAll("_").toLowerCase();
+        } // else
+    } // encodePostgreSQL
     
     /**
      * Encodes a string from an ArrayList.
@@ -254,7 +271,7 @@ public final class NGSIUtils {
         try {
             mds = (JSONArray) parser.parse(metadata);
         } catch (ParseException e) {
-            LOGGER.error("Error while parsing the metadaga. Details: " + e.getMessage());
+            LOGGER.error("Error while parsing the metadata. Details: " + e.getMessage());
             return null;
         } // try catch
         
@@ -325,5 +342,38 @@ public final class NGSIUtils {
         
         return res;
     } // getTimeInstant
+    
+    /**
+     * Gets the geolocation value, ready for insertion in CartoDB, given a NGSI attribute value and its metadata.
+     * If the attribute is not geo-related, it is returned as it is.
+     * @param attrValue
+     * @param metadata
+     * @return The geolocation value, ready for insertion in CartoDB, or tehe value as it is
+     */
+    public static String getLocation(String attrValue, String metadata) {
+        JSONParser parser = new JSONParser();
+        JSONArray mds;
+        
+        try {
+            mds = (JSONArray) parser.parse(metadata);
+        } catch (ParseException e) {
+            LOGGER.error("Error while parsing the metadata. Details: " + e.getMessage());
+            return attrValue;
+        } // try catch
+        
+        for (Object mdObject : mds) {
+            JSONObject md = (JSONObject) mdObject;
+            String mdName = (String) md.get("name");
+            String mdType = (String) md.get("type");
+            String mdValue = (String) md.get("value");
+            
+            if (mdName.equals("location") && mdType.equals("string") && mdValue.equals("WGS84")) {
+                String[] split = attrValue.trim().split(",");
+                return "ST_SetSRID(ST_MakePoint(" + split[0] + "," + split[1] + "), 4326)";
+            } // if
+        } // for
+        
+        return attrValue;
+    } // getLocation
         
 } // NGSIUtils

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -369,12 +369,12 @@ public final class NGSIUtils {
             String mdValue = (String) md.get("value");
             
             if (mdName.equals("location") && mdType.equals("string") && mdValue.equals("WGS84")) {
-                String[] split = attrValue.trim().split(",");
+                String[] split = attrValue.split(",");
                 
-                if(flipCoordinates) {
-                    return "ST_SetSRID(ST_MakePoint(" + split[1] + "," + split[0] + "), 4326)";
+                if (flipCoordinates) {
+                    return "ST_SetSRID(ST_MakePoint(" + split[1].trim() + "," + split[0].trim() + "), 4326)";
                 } else {
-                    return "ST_SetSRID(ST_MakePoint(" + split[0] + "," + split[1] + "), 4326)";
+                    return "ST_SetSRID(ST_MakePoint(" + split[0].trim() + "," + split[1].trim() + "), 4326)";
                 } // if else
             } // if
         } // for

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -348,9 +348,10 @@ public final class NGSIUtils {
      * If the attribute is not geo-related, it is returned as it is.
      * @param attrValue
      * @param metadata
+     * @param flipCoordinates
      * @return The geolocation value, ready for insertion in CartoDB, or tehe value as it is
      */
-    public static String getLocation(String attrValue, String metadata) {
+    public static String getLocation(String attrValue, String metadata, boolean flipCoordinates) {
         JSONParser parser = new JSONParser();
         JSONArray mds;
         
@@ -369,7 +370,12 @@ public final class NGSIUtils {
             
             if (mdName.equals("location") && mdType.equals("string") && mdValue.equals("WGS84")) {
                 String[] split = attrValue.trim().split(",");
-                return "ST_SetSRID(ST_MakePoint(" + split[0] + "," + split[1] + "), 4326)";
+                
+                if(flipCoordinates) {
+                    return "ST_SetSRID(ST_MakePoint(" + split[1] + "," + split[0] + "), 4326)";
+                } else {
+                    return "ST_SetSRID(ST_MakePoint(" + split[0] + "," + split[1] + "), 4326)";
+                } // if else
             } // if
         } // for
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -1,0 +1,797 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.google.gson.JsonPrimitive;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextMetadata;
+import com.telefonica.iot.cygnus.sinks.NGSICartoDBSink.CartoDBAggregator;
+import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import static com.telefonica.iot.cygnus.utils.TestUtils.getTestTraceHead;
+import java.util.ArrayList;
+import org.apache.flume.Context;
+import org.apache.flume.channel.MemoryChannel;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSICartoDBSinkTest {
+    
+    /**
+     * Constructor.
+     */
+    public NGSICartoDBSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSICartoDBSinkTest
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Configured 'endpoint' cannot be null.
+     */
+    @Test
+    public void testConfigureEndpointIsNotNull() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured 'endpoint' cannot be null");
+        String endpoint = null;
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - null value detected for 'endpoint'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - null value not detected for 'endpoint'");
+            throw e;
+        } // try catch
+    } // testConfigureEndpointIsNotNull
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Configured 'endpoint' must be a URI using the 'http' or 'https' schema.
+     */
+    @Test
+    public void testConfigureEndpointUsesHttpSchema() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured 'endpoint' must be a URI using the 'http' or 'https' schema");
+        String endpoint = "localhost:443";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - Invalid or inexistent schema detected for 'endpoint'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - Invalid or inexistent schema not detected for 'endpoint'");
+            throw e;
+        } // try catch
+    } // testConfigureEndpointIsNotNull
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Configured 'api_key' cannot be null.
+     */
+    @Test
+    public void testConfigureApiKeyIsNotNull() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured 'api_key' cannot be null");
+        String endpoint = "https://localhost";
+        String apiKey = null;
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - null value detected for 'api_key'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - null value not detected for 'api_key'");
+            throw e;
+        } // try catch
+    } // testConfigureApiKeyIsNotNull
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Independently of the configured value, enable_lowercase is always 'true'
+     * by default.
+     */
+    @Test
+    public void testConfigureEnableLowercaseAlwaysTrue() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Independently of the configured value, enable_lowercase is always 'true' by default");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = "false";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        try {
+            assertTrue(sink.enableLowercase);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_lowercase=false' was confiured, nevertheless it is always true by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_lowercase=false' was confiured and it is really false");
+            throw e;
+        } // try catch
+    } // testConfigureEnableLowercaseAlwaysTrue
+    
+    /**
+     * [NGSICartoDBSink.start] -------- When started, a CartoDB backend is created.
+     */
+    @Test
+    public void testStartBackendCreated() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- When started, a CartoDB backend is created");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertTrue(sink.getBackend() != null);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - A CartoDB backend has been created");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - A CartoDB backend has not been created");
+            throw e;
+        } // try catch
+    } // testStartBackendCreated
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the CartoDB table name is lower case of <service-path>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNonRootServicePathDataModelByServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the CartoDB table name is the lower case of <servicePath>");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-service-path";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/somePath";
+        String entity = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+        
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+        
+            try {
+                assertEquals("somepath", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of <servicePath>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of <servicePath>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNonRootServicePathDataModelByServicePath
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted
+     * and data_model is 'dm-by-entity' the CartoDB table name is the lower case of
+     * \<service-path\>_\<entity_id\>_\<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNonRootServicePathDataModelByEntity() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is 'dm-by-entity' "
+                + "the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityType>");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+        
+            try {
+                assertEquals("somepath_someid_sometype", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
+                        + "<servicePath>_<entityId>_<entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
+                        + "<servicePath>_<entityId>_<entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNonRootServicePathDataModelByEntity
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted
+     * and data_model is 'dm-by-attribute' the CartoDB table name is the lower
+     * case of \<servicePath\>_\<entityId\>_\<entityYype\>_\<attrName\>_\<attrType\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNonRootServicePathDataModelByAttribute() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-attribute' the CartoDB table name is the lower case of "
+                + "<servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-attribute";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/somePath";
+        String entity = "someId_someType";
+        String attribute = "someName1_someType1";
+        
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+        
+            try {
+                assertEquals("somepath_someid_sometype_somename1_sometype1", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
+                        + "<servicePath>_<entityId>_<entityType>_<attrName>_<attrType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
+                        + "<servicePath>_<entityId>_<entityType>_<attrName>_<attrType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNonRootServicePathDataModelByAttribute
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the CartoDB table name cannot be created.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameRootServicePathDataModelByServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the CartoDB table name cannot be created");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-service-path";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/";
+        String entity = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+        
+        try {
+            sink.buildTableName(servicePath, entity, attribute);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - It was not detected the table name could not be created");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "-  OK  - It was detected the table name could not be created");
+        } // try catch
+    } // testBuildDBNameRootServicePathDataModelByServicePath
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted
+     * and data_model is 'dm-by-entity' the CartoDB table name is the lower case of
+     * \<service-path\>_\<entity_id\>_\<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameRootServicePathDataModelByEntity() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a non service-path is notified/defaulted and data_model is 'dm-by-entity' "
+                + "the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityType>");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+        
+            try {
+                assertEquals("someid_sometype", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
+                        + "<entityId>_<entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
+                        + "<entityId>_<entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameRootServicePathDataModelByEntity
+    
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted
+     * and data_model is 'dm-by-attribute' the CartoDB table name is the lower
+     * case of \<servicePath\>_\<entityId\>_\<entityYype\>_\<attrName\>_\<attrType\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameRootServicePathDataModelByAttribute() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-attribute' the CartoDB table name is the lower case of "
+                + "<servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-attribute";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        String servicePath = "/";
+        String entity = "someId_someType";
+        String attribute = "someName1_someType1";
+        
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+        
+            try {
+                assertEquals("someid_sometype_somename1_sometype1", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
+                        + "<entityId>_<entityType>_<attrName>_<attrType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
+                        + "<entityId>_<entityType>_<attrName>_<attrType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameRootServicePathDataModelByAttribute
+    
+    /**
+     * [CartoDBAggregator.initialize] -------- When initializing through an initial geolocated event, a table
+     * name is created.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testInitializeBuildTable() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                + "-------- When initializing through an initial geolocated event, a table name is created");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+        
+            try {
+                assertTrue(aggregator.getTableName() != null);
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - A table name has been created");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - A table name has not been created");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                    + "- FAIL - There was some problem when initializing CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testInitializeBuildTable
+    
+    /**
+     * [CartoDBAggregator.initialize] -------- When initializing through an initial geolocated event, the
+     * aggregation fields string contains a field and a metadata field for each attribute in the event except
+     * for the geolocation attribute, which is added as a specific field ('the_geom').
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testInitializeFieldsOK() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                + "-------- When initializing through an initial geolocated event, the aggregation fields "
+                + "string contains a field and a metadata field for each attribute in the event except for "
+                + "the geolocation attribute, which is added as a specific field ('the_geom')");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+            String fields = aggregator.getFields();
+        
+            try {
+                assertTrue(!fields.contains("somename1") && !fields.contains("somname1_md"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - 'somename1' and 'somename1_md' are not in the fields '" + fields + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - 'somename1' and 'somename1_md' are in the fields '" + fields + "'");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(fields.contains("somename2") && fields.contains("somename2_md"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - 'somename2' and 'somename2_md' are in the fields '" + fields + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - 'somename2' and 'somename2_md' are not in the fields '" + fields + "'");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(fields.contains(NGSIConstants.THE_GEOM));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - '" + NGSIConstants.THE_GEOM + "' is in the fields '" + fields + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - '" + NGSIConstants.THE_GEOM + "' is not in the fields '" + fields + "'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                    + "- FAIL - There was some problem when initializing CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testInitializeFieldsOK
+    
+    /**
+     * [CartoDBAggregator.initialize] -------- When initializing through an initial geolocated event,
+     * the aggregation fields string is lower case, starts with '(' and finishes with ')'.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testInitializeFieldsStringOK() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                + "-------- When initializing through an initial geolocated event, the aggregation fields "
+                + "string is lower case, starts with '(' and finishes with ')'");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+            String fields = aggregator.getFields();
+        
+            try {
+                assertEquals(fields, fields.toLowerCase());
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - '" + fields + "' is lower case");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - '" + fields + "' is not lower case");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(fields.startsWith("("));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - '" + fields + "' starts with '('");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - '" + fields + "' does not start with '('");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(fields.endsWith(")"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - '" + fields + "' ends with ')'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - '" + fields + "' does not end with ')'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                    + "- FAIL - There was some problem when initializing CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testInitializeFieldsStringOK
+    
+    /**
+     * [CartoDBAggregator.aggregate] -------- When aggregating a single geolocated event, the aggregation
+     * values string contains a value and a metadata value for each attribute in the event except for the
+     * geolocation attribute, which is added as a specific value (a point).
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testAggregateValuesOK() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                + "-------- When aggregating a single geolocated event, the aggregation values string "
+                + "contains a value and a metadata value for each attribute in the event except for the "
+                + "geolocation attribute, which is added as a specific value (a point)");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+            aggregator.aggregate(event);
+            String rows = aggregator.getRows();
+            
+            try {
+                assertTrue(!rows.contains("'-3.7167, 40.3833'")
+                        && !rows.contains("'{\"name\":\"location\",\"type\":\"string\",\"value\":\"WGS84\"}'"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - '-3.7167, 40.3833' and "
+                        + "'{\"name\":\"location\",\"type\":\"string\",\"value\":\"WGS84\"}' "
+                        + "are not in the rows '" + rows + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - '-3.7167, 40.3833' and "
+                        + "'{\"name\":\"location\",\"type\":\"string\",\"value\":\"WGS84\"}' "
+                        + "are in the rows '" + rows + "'");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(rows.contains("'someValue2'") && rows.contains("'[]'"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - 'someValue2' and '[]' are in the rows '" + rows + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - 'someValue2' and '[]' are not in the rows '" + rows + "'");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(rows.contains("ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "-  OK  - 'ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)' is in the rows '" + rows
+                        + "'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                        + "- FAIL - 'ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)' is not in the rows '"
+                        + rows + "'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
+                    + "- FAIL - There was some problem when initializing CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testAggregateValuesOK
+    
+    /**
+     * [CartoDBAggregator.aggregate] -------- When aggregating a single geolocated event, the aggregation
+     * values string starts with '(' and finishes with ')'.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testAggregateValuesStringOK() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                + "-------- When aggregating a single geolocated event, the aggregation values string starts "
+                + "with '(' and finishes with ')'");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+            aggregator.aggregate(event);
+            String rows = aggregator.getRows();
+            
+            try {
+                assertTrue(rows.startsWith("("));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "-  OK  - '" + rows + "' starts with '('");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "- FAIL - '" + rows + "' does not start with '('");
+                throw e;
+            } // try catch
+            
+            try {
+                assertTrue(rows.endsWith(")"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "-  OK  - '" + rows + "' ends with ')'");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "- FAIL - '" + rows + "' does not end with ')'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                    + "- FAIL - There was some problem when aggregating in CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testAggregateValuesStringOK
+    
+    private Context createContext(String endpoint, String apiKey, String dataModel, String enableLowercase) {
+        Context context = new Context();
+        context.put("api_key", apiKey);
+        context.put("batch_size", "100");
+        context.put("batch_timeout", "30");
+        context.put("batch_ttl", "10");
+        context.put("data_model", dataModel);
+        context.put("enable_grouping", "false");
+        context.put("enable_lowercase", enableLowercase);
+        context.put("endpoint", endpoint);
+        return context;
+    } // createContext
+    
+    private ContextElement createContextElement() {
+        NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
+        ContextMetadata contextMetadata = notifyContextRequest.new ContextMetadata();
+        contextMetadata.setName("location");
+        contextMetadata.setType("string");
+        contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
+        ArrayList<ContextMetadata> metadata = new ArrayList<ContextMetadata>();
+        metadata.add(contextMetadata);
+        ContextAttribute contextAttribute1 = notifyContextRequest.new ContextAttribute();
+        contextAttribute1.setName("someName1");
+        contextAttribute1.setType("someType1");
+        contextAttribute1.setContextValue(new JsonPrimitive("-3.7167, 40.3833"));
+        contextAttribute1.setContextMetadata(metadata);
+        ContextAttribute contextAttribute2 = notifyContextRequest.new ContextAttribute();
+        contextAttribute2.setName("someName2");
+        contextAttribute2.setType("someType2");
+        contextAttribute2.setContextValue(new JsonPrimitive("someValue2"));
+        contextAttribute2.setContextMetadata(null);
+        ArrayList<ContextAttribute> attributes = new ArrayList<ContextAttribute>();
+        attributes.add(contextAttribute1);
+        attributes.add(contextAttribute2);
+        ContextElement contextElement = notifyContextRequest.new ContextElement();
+        contextElement.setId("someId");
+        contextElement.setType("someType");
+        contextElement.setIsPattern("false");
+        contextElement.setAttributes(attributes);
+        return contextElement;
+    } // createContextElement
+    
+} // NGSICartoDBSinkTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -58,8 +58,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -83,8 +84,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -108,8 +110,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = null;
         String dataModel = null; // default one
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -134,8 +137,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
         String enableLowercase = "false";
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -149,6 +153,32 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableLowercaseAlwaysTrue
     
     /**
+     * [NGSICartoDBSink.configure] -------- Configured `flip_coordinates` cannot be different than `true` or `false`.
+     */
+    @Test
+    public void testConfigureFlipCoordinatesOK() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured `flip_coordinates` cannot be different than `true` or `false`");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = "false";
+        String flipCoordinates = "falso";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
+        
+        try {
+            assertTrue(sink.enableLowercase);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'flip_coordinates=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'flip_coordinates=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureFlipCoordinatesOK
+    
+    /**
      * [NGSICartoDBSink.start] -------- When started, a CartoDB backend is created.
      */
     @Test
@@ -159,8 +189,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -189,8 +220,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-service-path";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -229,8 +261,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/somePath";
         String entity = "someId_someType";
         String attribute = null; // irrelevant for this test
@@ -272,8 +305,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-attribute";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/somePath";
         String entity = "someId_someType";
         String attribute = "someName1_someType1";
@@ -313,8 +347,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-service-path";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -346,8 +381,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/";
         String entity = "someId_someType";
         String attribute = null; // irrelevant for this test
@@ -389,8 +425,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-attribute";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         String servicePath = "/";
         String entity = "someId_someType";
         String attribute = "someName1_someType1";
@@ -431,8 +468,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -483,8 +521,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -554,8 +593,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -627,8 +667,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -673,7 +714,7 @@ public class NGSICartoDBSinkTest {
             } // try catch
             
             try {
-                assertTrue(rows.contains("ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)"));
+                assertTrue(rows.contains("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)"));
                 System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
                         + "-  OK  - 'ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)' is in the rows '" + rows
                         + "'");
@@ -706,8 +747,9 @@ public class NGSICartoDBSinkTest {
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
         String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase));
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -752,7 +794,61 @@ public class NGSICartoDBSinkTest {
         } // try catch
     } // testAggregateValuesStringOK
     
-    private Context createContext(String endpoint, String apiKey, String dataModel, String enableLowercase) {
+    /**
+     * [CartoDBAggregator.aggregate] -------- When aggregating a single geolocated event, if flip_coordinates=true
+     * then the_geom field contains a point with exchanged latitude and longitude.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testAggregateCoordinatesAreFlipped() throws Exception {
+        System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                + "-------- When aggregating a single geolocated event, if flip_coordinates=true then the_geom "
+                + "field contains a point with exchanged latitude and longitude.");
+        
+        // Create a NGSICartoDBSink
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-entity";
+        String enableLowercase = null; // default one
+        String flipCoordinates = "true";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates));
+        
+        // Create a CartoDBAggregator
+        CartoDBAggregator aggregator = sink.new CartoDBAggregator();
+        
+        // Create a NGSIEvent
+        long recvTimeTs = 1461136795801L;
+        String service = "someService";
+        String servicePath = "somePath";
+        String entity = "someId_someType";
+        String attribute = null; // irrelevant for this test
+        ContextElement contextElement = createContextElement();
+        NGSIEvent event = new NGSIEvent(recvTimeTs, service, servicePath, entity, attribute, contextElement);
+        
+        try {
+            aggregator.initialize(event);
+            aggregator.aggregate(event);
+            String rows = aggregator.getRows();
+            
+            try {
+                assertTrue(rows.contains("40.3833,-3.7167"));
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "-  OK  - '" + rows + "' contains the coordinates '-3.7167, 40.3833' flipped");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                        + "- FAIL - '" + rows + "' done not contain the coordinates '-3.7167, 40.3833' flipped");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
+                    + "- FAIL - There was some problem when aggregating in CartoDBAggregator");
+            throw e;
+        } // try catch
+    } // testAggregateCoordinatesAreFlipped
+    
+    private Context createContext(String endpoint, String apiKey, String dataModel, String enableLowercase,
+            String flipCoordinates) {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("batch_size", "100");
@@ -762,6 +858,7 @@ public class NGSICartoDBSinkTest {
         context.put("enable_grouping", "false");
         context.put("enable_lowercase", enableLowercase);
         context.put("endpoint", endpoint);
+        context.put("flip_coordinates", flipCoordinates);
         return context;
     } // createContext
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,14 +43,14 @@ public class NGSIUtilsTest {
     } // NGSIUtilsTest
 
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp without
- miliseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when passing
+     * a valid ISO 8601 timestamp without miliseconds.
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithoutMiliseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid ISO 8601 "
-                + "timestamp without miliseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "ISO 8601 timestamp without miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -71,13 +72,14 @@ public class NGSIUtilsTest {
     } // testGetTimeInstantISO8601TimestampWithoutMiliseconds
     
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp with
- miliseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when passing
+     * a valid ISO 8601 timestamp with miliseconds.
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithMiliseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid ISO 8601 timestamp with miliseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "ISO 8601 timestamp with miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -99,13 +101,14 @@ public class NGSIUtilsTest {
     } // testGetTimeInstantISO8601TimestampWithMiliseconds
     
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid ISO 8601 timestamp with
- microseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when
+     * passing a valid ISO 8601 timestamp with microseconds.
      */
     @Test
     public void testGetTimeInstantISO8601TimestampWithMicroseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid ISO 8601 timestamp with microseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "ISO 8601 timestamp with microseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -127,13 +130,14 @@ public class NGSIUtilsTest {
     } // testGetTimeInstantISO8601TimestampWithMicroseconds
     
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp without
- miliseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when
+     * passing a valid SQL timestamp without miliseconds.
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithoutMiliseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid SQL timestamp without miliseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "SQL timestamp without miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -155,12 +159,14 @@ public class NGSIUtilsTest {
     } // testGetTimeInstantSQLTimestampWithoutMiliseconds
     
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp with miliseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when
+     * passing a valid SQL timestamp with miliseconds.
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithMiliseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid SQL timestamp with miliseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "SQL timestamp with miliseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -183,12 +189,14 @@ public class NGSIUtilsTest {
     } // testGetTimeInstantSQLTimestampWithMiliseconds
     
     /**
-     * [NGSIUtils.getTimeInstant] -------- A time instant is obtained when passing a valid SQL timestamp with microseconds.
+     * [NGSIUtils.getTimeInstant] -------- When getting a time instant, it is properly obtained when
+     * passing a valid SQL timestamp with microseconds.
      */
     @Test
     public void testGetTimeInstantSQLTimestampWithMicroseconds() {
         System.out.println(getTestTraceHead("[Utils.getTimeInstant]")
-                + "-------- A time instant is obtained when passing a valid SQL timestamp with microseconds");
+                + "-------- When getting a time instant, it is properly obtained when passing a valid "
+                + "SQL timestamp with microseconds");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "TimeInstant");
         metadataJson.put("type", "SQL timestamp");
@@ -209,5 +217,93 @@ public class NGSIUtilsTest {
             throw e;
         } // try catch
     } // testGetTimeInstantSQLTimestampWithMicroseconds
+    
+    /**
+     * [NGSIUtils.getLocation] -------- When getting a location, a CartoDB point is obtained when passing
+     * an attribute of type 'geo:point'.
+     */
+    @Test
+    public void testGetLocationType() {
+        System.out.println(getTestTraceHead("[Utils.getLocation]")
+                + "-------- When getting a location, a CartoDB point is obtained when passing an attribute "
+                + "of type 'geo:point'");
+        String attrMetadataStr = "[]";
+        String attrValue = "-3.7167, 40.3833";
+        String attrType = "geo:point";
+        boolean flipCoordinates = false; // irrelevant for this test
+        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+
+        try {
+            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", location);
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "-  OK  - Location '" + location + "' obtained for an attribute of type '" + attrType
+                    + "' and value '" + attrValue + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "- FAIL - Location '" + location + "' obtained for an attribute of type '" + attrType
+                    + "' and value '" + attrValue + "'");
+            throw e;
+        } // try catch
+    } // testGetLocationType
+    
+    /**
+     * [NGSIUtils.getLocation] -------- When getting a location, a CartoDB point is obtained when passing
+     * an attribute of type 'geo:point'.
+     */
+    @Test
+    public void testGetLocationMetadata() {
+        System.out.println(getTestTraceHead("[Utils.getLocation]")
+                + "-------- When getting a location, a CartoDB point is obtained when passing an attribute "
+                + "of type 'geo:point'");
+        JSONObject metadataJson = new JSONObject();
+        metadataJson.put("name", "location");
+        metadataJson.put("type", "string");
+        metadataJson.put("value", "WGS84");
+        JSONArray metadatasJson = new JSONArray();
+        metadatasJson.add(metadataJson);
+        String attrMetadataStr = metadatasJson.toJSONString();
+        String attrValue = "-3.7167, 40.3833";
+        String attrType = "coordinates"; // irrelevant for this test
+        boolean flipCoordinates = false; // irrelevant for this test
+        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+
+        try {
+            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", location);
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "-  OK  - Location '" + location + "' obtained for an attribute with metadata '"
+                    + attrMetadataStr + "' and value '" + attrValue + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "- FAIL - Location '" + location + "' obtained for an attribute with metadata '"
+                    + attrMetadataStr + "' and value '" + attrValue + "'");
+            throw e;
+        } // try catch
+    } // testGetLocationMetadata
+    
+    /**
+     * [NGSIUtils.getLocation] -------- When getting a location, the original attribute is returned when the
+     * attribute type is not geo:point and there is no WGS84 location metadata.
+     */
+    @Test
+    public void testGetLocationNoGeolocation() {
+        System.out.println(getTestTraceHead("[Utils.getLocation]")
+                + "-------- When getting a location, the original attribute is returned when the attribute "
+                + "type is not geo:point and there is no WGS84 location metadata");
+        String attrMetadataStr = "[]";
+        String attrValue = "-3.7167, 40.3833";
+        String attrType = "coordinates";
+        boolean flipCoordinates = false; // irrelevant for this test
+        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+
+        try {
+            assertEquals(attrValue, location);
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "-  OK  - Location '" + location + "' obtained for a not geolocated attribute");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "- FAIL - Location '" + location + "' obtained for a not geolocated attribute");
+            throw e;
+        } // try catch
+    } // testGetLocationNoGeolocation
     
 } // NGSIUtilsTest


### PR DESCRIPTION
* Implements issue #927 
* 100% unit tests passed:
```
Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
```

Specific tests:
```
Running com.telefonica.iot.cygnus.sinks.NGSICartoDBSinkTest
[NGSICartoDBSink.configure] --------------------- Configured `flip_coordinates` cannot be different than `true` or `false`
[NGSICartoDBSink.configure] --------------  OK  - 'flip_coordinates=falso' was detected
[CartoDBAggregator.initialize] ------------------ When initializing through an initial geolocated event, a table name is created
[CartoDBAggregator.initialize] -----------  OK  - A table name has been created
[NGSICartoDBSink.configure] --------------------- Configured 'api_key' cannot be null
[NGSICartoDBSink.configure] --------------  OK  - null value detected for 'api_key'
[NGSICartoDBSink.buildTableName] ---------------- When a root service-path is notified/defaulted and data_model is 'dm-by-service-path' the CartoDB table name cannot be created
[NGSICartoDBSink.buildTableName] ---------  OK  - It was detected the table name could not be created
[CartoDBAggregator.aggregate] ------------------- When aggregating a single geolocated event, the aggregation values string starts with '(' and finishes with ')'
[CartoDBAggregator.aggregate] ------------  OK  - '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326),'someValue2','[]')' starts with '('
[CartoDBAggregator.aggregate] ------------  OK  - '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326),'someValue2','[]')' ends with ')'
[CartoDBAggregator.initialize] ------------------ When initializing through an initial geolocated event, the aggregation fields string is lower case, starts with '(' and finishes with ')'
[CartoDBAggregator.initialize] -----------  OK  - '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)' is lower case
[CartoDBAggregator.initialize] -----------  OK  - '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)' starts with '('
[CartoDBAggregator.initialize] -----------  OK  - '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)' ends with ')'
[NGSICartoDBSink.start] ------------------------- When started, a CartoDB backend is created
[NGSICartoDBSink.start] ------------------  OK  - A CartoDB backend has been created
[NGSICartoDBSink.buildTableName] ---------------- When a non root service-path is notified/defaulted and data_model is 'dm-by-service-path' the CartoDB table name is the lower case of <servicePath>
[NGSICartoDBSink.buildTableName] ---------  OK  - 'somepath' is equals to the lower case of <servicePath>
[NGSICartoDBSink.configure] --------------------- Independently of the configured value, enable_lowercase is always 'true' by default
[NGSICartoDBSink.configure] --------------  OK  - 'enable_lowercase=false' was confiured, nevertheless it is always true by default
[NGSICartoDBSink.buildTableName] ---------------- When a root service-path is notified/defaulted and data_model is 'dm-by-attribute' the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>
[NGSICartoDBSink.buildTableName] ---------  OK  - 'someid_sometype_somename1_sometype1' is equals to the lower case of <entityId>_<entityType>_<attrName>_<attrType>
[CartoDBAggregator.aggregate] ------------------- When aggregating a single geolocated event, the aggregation values string contains a value and a metadata value for each attribute in the event except for the geolocation attribute, which is added as a specific value (a point)
[CartoDBAggregator.initialize] -----------  OK  - '-3.7167, 40.3833' and '{"name":"location","type":"string","value":"WGS84"}' are not in the rows '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326),'someValue2','[]')'
[CartoDBAggregator.initialize] -----------  OK  - 'someValue2' and '[]' are in the rows '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326),'someValue2','[]')'
[CartoDBAggregator.initialize] -----------  OK  - 'ST_SetSRID(ST_MakePoint(-3.7167, 40.3833), 4326)' is in the rows '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326),'someValue2','[]')'
[CartoDBAggregator.initialize] ------------------ When initializing through an initial geolocated event, the aggregation fields string contains a field and a metadata field for each attribute in the event except for the geolocation attribute, which is added as a specific field ('the_geom')
[CartoDBAggregator.initialize] -----------  OK  - 'somename1' and 'somename1_md' are not in the fields '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)'
[CartoDBAggregator.initialize] -----------  OK  - 'somename2' and 'somename2_md' are in the fields '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)'
[CartoDBAggregator.initialize] -----------  OK  - 'the_geom' is in the fields '(recvtime,fiwareservicepath,entityid,entitytype,the_geom,somename2,somename2_md)'
[CartoDBAggregator.aggregate] ------------------- When aggregating a single geolocated event, if flip_coordinates=true then the_geom field contains a point with exchanged latitude and longitude.
[CartoDBAggregator.aggregate] ------------  OK  - '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(40.3833,-3.7167), 4326),'someValue2','[]')' contains the coordinates '-3.7167, 40.3833' flipped
[NGSICartoDBSink.buildTableName] ---------------- When a non service-path is notified/defaulted and data_model is 'dm-by-entity' the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityType>
[NGSICartoDBSink.buildTableName] ---------  OK  - 'someid_sometype' is equals to the lower case of <entityId>_<entityType>
[NGSICartoDBSink.buildTableName] ---------------- When a non root service-path is notified/defaulted and data_model is 'dm-by-attribute' the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>
[NGSICartoDBSink.buildTableName] ---------  OK  - 'somepath_someid_sometype_somename1_sometype1' is equals to the lower case of <servicePath>_<entityId>_<entityType>_<attrName>_<attrType>
[NGSICartoDBSink.buildTableName] ---------------- When a non root service-path is notified/defaulted and data_model is 'dm-by-entity' the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityType>
[NGSICartoDBSink.buildTableName] ---------  OK  - 'somepath_someid_sometype' is equals to the lower case of <servicePath>_<entityId>_<entityType>
[NGSICartoDBSink.configure] --------------------- Configured 'endpoint' cannot be null
[NGSICartoDBSink.configure] --------------  OK  - null value detected for 'endpoint'
[NGSICartoDBSink.configure] --------------------- Configured 'endpoint' must be a URI using the 'http' or 'https' schema
[NGSICartoDBSink.configure] --------------  OK  - Invalid or inexistent schema detected for 'endpoint'
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.634 sec
Running com.telefonica.iot.cygnus.utils.NGSIUtilsTest
[Utils.getLocation] ----------------------------- When getting a location, a CartoDB point is obtained when passing an attribute of type 'geo:point'
[Utils.getLocation] ----------------------  OK  - Location 'ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)' obtained for an attribute with metadata '[{"name":"location","type":"string","value":"WGS84"}]' and value '-3.7167, 40.3833'
[Utils.getLocation] ----------------------------- When getting a location, the original attribute is returned when the attribute type is not geo:point and there is no WGS84 location metadata
[Utils.getLocation] ----------------------  OK  - Location '-3.7167, 40.3833' obtained for a not geolocated attribute
[Utils.getLocation] ----------------------------- When getting a location, a CartoDB point is obtained when passing an attribute of type 'geo:point'
[Utils.getLocation] ----------------------  OK  - Location 'ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)' obtained for an attribute of type 'geo:point' and value '-3.7167, 40.3833'
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.53 sec
```
* (unofficial) e2e tests passed:
```
time=2016-04-19T09:14:33.277CEST | lvl=INFO | corr=c225acb3-af31-4948-a34b-458f77f738f6 | trans=c225acb3-af31-4948-a34b-458f77f738f6 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[244] : Starting internal transaction (c225acb3-af31-4948-a34b-458f77f738f6)
time=2016-04-19T09:14:33.277CEST | lvl=INFO | corr=c225acb3-af31-4948-a34b-458f77f738f6 | trans=c225acb3-af31-4948-a34b-458f77f738f6 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[260] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "-3.716667, 40.383333",            "metadatas": [                        {                            "name": "location",                            "type": "string",                            "value": "WGS84"                        }                    ]          }        ],        "type" : "temp",        "isPattern" : "false",        "id" : "s1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-19T09:14:33.790CEST | lvl=INFO | corr=a37ae88e-a454-49f8-b83a-8f5dabbd2469 | trans=a37ae88e-a454-49f8-b83a-8f5dabbd2469 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[244] : Starting internal transaction (a37ae88e-a454-49f8-b83a-8f5dabbd2469)
time=2016-04-19T09:14:33.790CEST | lvl=INFO | corr=a37ae88e-a454-49f8-b83a-8f5dabbd2469 | trans=a37ae88e-a454-49f8-b83a-8f5dabbd2469 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[260] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "-3.716667, 40.383333",            "metadatas": [                        {                            "name": "location",                            "type": "string",                            "value": "WGS84"                        }                    ]          }        ],        "type" : "temp",        "isPattern" : "false",        "id" : "s1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-19T09:14:34.270CEST | lvl=INFO | corr=2450bae5-4e90-4553-9772-1954427e784c | trans=2450bae5-4e90-4553-9772-1954427e784c | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[244] : Starting internal transaction (2450bae5-4e90-4553-9772-1954427e784c)
time=2016-04-19T09:14:34.270CEST | lvl=INFO | corr=2450bae5-4e90-4553-9772-1954427e784c | trans=2450bae5-4e90-4553-9772-1954427e784c | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[260] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "-3.716667, 40.383333",            "metadatas": [                        {                            "name": "location",                            "type": "string",                            "value": "WGS84"                        }                    ]          }        ],        "type" : "temp",        "isPattern" : "false",        "id" : "s1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-19T09:14:35.846CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[244] : Starting internal transaction (f0498376-c83f-407e-9ed8-069cb4034bf6)
time=2016-04-19T09:14:35.847CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=getEvents | comp=Cygnus | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[260] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "-3.716667, 40.383333",            "metadatas": [                        {                            "name": "location",                            "type": "string",                            "value": "WGS84"                        }                    ]          }        ],        "type" : "temp",        "isPattern" : "false",        "id" : "s1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-04-19T09:14:56.875CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSISink[341] : Batch accumulation time reached, the batch will be processed as it is
time=2016-04-19T09:14:56.875CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSISink[395] : Batch completed, persisting it
time=2016-04-19T09:14:56.877CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=persistAggregation | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[295] : [cartodb-sink] Persisting data at NGSICartoDBSink. Database (default), Table (sensors_s1_temp), Data (('2016-04-19T07:14:33.278Z','/sensors','s1','temp','26.5','[]',ST_SetSRID(ST_MakePoint(-3.716667, 40.383333), 4326),'[{"name":"location","type":"string","value":"WGS84"}]'),('2016-04-19T07:14:33.790Z','/sensors','s1','temp','26.5','[]',ST_SetSRID(ST_MakePoint(-3.716667, 40.383333), 4326),'[{"name":"location","type":"string","value":"WGS84"}]'),('2016-04-19T07:14:34.272Z','/sensors','s1','temp','26.5','[]',ST_SetSRID(ST_MakePoint(-3.716667, 40.383333), 4326),'[{"name":"location","type":"string","value":"WGS84"}]'),('2016-04-19T07:14:35.847Z','/sensors','s1','temp','26.5','[]',ST_SetSRID(ST_MakePoint(-3.716667, 40.383333), 4326),'[{"name":"location","type":"string","value":"WGS84"}]'))
time=2016-04-19T09:14:58.208CEST | lvl=INFO | corr=f0498376-c83f-407e-9ed8-069cb4034bf6 | trans=f0498376-c83f-407e-9ed8-069cb4034bf6 | svc=default | subsvc=/sensors | function=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSISink[399] : Finishing internal transaction (c225acb3-af31-4948-a34b-458f77f738f6,a37ae88e-a454-49f8-b83a-8f5dabbd2469,2450bae5-4e90-4553-9772-1954427e784c,f0498376-c83f-407e-9ed8-069cb4034bf6)
```
* Assignee @pcoello25 but LGTM from @gtorodelvalle is also required