### PR TITLE
feature/829_cygnus_gui_disable_if_port_0

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
@@ -48,11 +48,13 @@ public class JettyServer extends Thread {
         conn1.setPort(mgmtIfPort);
         server.addConnector(conn1);
         
-        // add the GUI connector
-        SelectChannelConnector conn2 = new SelectChannelConnector();
-        conn2.setHost("0.0.0.0");
-        conn2.setPort(guiPort);
-        server.addConnector(conn2);
+        if (guiPort != 0) {
+            // add the GUI connector
+            SelectChannelConnector conn2 = new SelectChannelConnector();
+            conn2.setHost("0.0.0.0");
+            conn2.setPort(guiPort);
+            server.addConnector(conn2);
+        } // if
         
         // set the handler
         server.setHandler(handler);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -211,7 +211,9 @@ public class CygnusApplication extends Application {
             
             if (commandLine.hasOption('g')) {
                 guiPort = new Integer(commandLine.getOptionValue('g'));
-            } // if
+            } else {
+                guiPort = 0;
+            } // if else
             
             int pollingInterval = DEF_POLLING_INTERVAL;
             


### PR DESCRIPTION
* Partially implements issue #829 
* 100% tests passed:
```
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0 (cygnus-common)
Tests run: 82, Failures: 0, Errors: 0, Skipped: 0 (cygnus-ngsi)
```
* (unofficial) e2e tests passed:
```
$ curl "http://localhost:8081"
GET / Not implemented
$ curl "http://localhost:8082"
curl: (7) Failed to connect to localhost port 8082: Connection refused
```
* Assignee @pcoello25 