### PR TITLE
bug/977_fix_collection_name_when_dm_by_service_path

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -39,3 +39,4 @@
 - [cygnus-ngsi] [hardening] Add documentation for API about /v1/subscriptions in ManagementInterface (#808)
 - [cygnus-ngsi] [feature] Add NGSICartoDBSink (#927)
 - [cygnus] [hardening] Add documentation in orion_ckan_sink.md about the creation of resources & datastores for column mode (#971)
+- [cygnus-ngsi] [bug] Fix collection name building when data_model is dm-by-service-path in Mongo sinks (#977)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtilsForTests.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtilsForTests.java
@@ -20,6 +20,7 @@ package com.telefonica.iot.cygnus.utils;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.event.EventBuilder;
 import org.json.simple.JSONArray;
@@ -94,5 +95,32 @@ public final class CommonUtilsForTests {
         notification.put("contextResponses", contextResponses);
         return notification;
     } // createNotification
+    
+    /**
+     * Creates a Flume context for Mongo/STH sinks.
+     * @param collectionPrefix
+     * @param dbPrefix
+     * @return A Flume context for Mongo/STH sinks.
+     */
+    public static Context createContextForMongoSTH(String collectionPrefix, String dbPrefix, String dataModel) {
+        Context context = new Context();
+        context.put("attr_persistence", "row");
+        context.put("batch_size", "100");
+        context.put("batch_timeout", "30");
+        context.put("batch_ttl", "10");
+        context.put("collection_prefix", collectionPrefix);
+        context.put("collection_size", "0");
+        context.put("data_expiration", "0");
+        context.put("data_model", dataModel);
+        context.put("db_prefix", dbPrefix);
+        context.put("enable_grouping", "false");
+        context.put("enable_lowercase", "false");
+        context.put("max_documents", "0");
+        context.put("mongo_hosts", "localhost:27017");
+        context.put("mongo_password", "");
+        context.put("mongo_username", "");
+        context.put("should_hash", "false");
+        return context;
+    } // createContextForMongoSTH
     
 } // CommonUtilsForTests

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSink.java
@@ -203,11 +203,6 @@ public abstract class NGSIMongoBaseSink extends NGSISink {
 
         switch (dataModel) {
             case DMBYSERVICEPATH:
-                if (fiwareServicePath.equals("/")) {
-                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
-                            + "dm-by-service-path data model");
-                } // if
-                
                 collectionName = NGSIUtils.encodeSTHCollection(fiwareServicePath);
                 break;
             case DMBYENTITY:

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.telefonica.iot.cygnus.utils.CommonUtilsForTests;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSIMongoBaseSinkTest {
+    
+    /**
+     * This class is used to test once and only once the common functionality shared by all the real extending sinks.
+     */
+    private class NGSIMongoBaseSinkImpl extends NGSIMongoBaseSink {
+
+        @Override
+        void persistBatch(NGSIBatch batch) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet.");
+        } // persistBatch
+        
+    } // NGSIMongoBaseSinkImpl
+    
+    /**
+     * Constructor.
+     */
+    public NGSIMongoBaseSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSIMongoBaseSinkTest
+    
+    /**
+     * [NGSIMongoBaseSink.buildCollectionName] -------- When / service-path is notified/defaulted and
+     * data_model=dm-by-service-path, the MongoDB collection name is <prefix>/.
+     */
+    @Test
+    public void testBuildCollectionNameDMByServicePathRootServicePath() {
+        System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                + "-------- When / service-path is notified/defaulted and data_model=dm-by-service-path, "
+                + "the MongoDB collection name is <prefix>/");
+        String collectionPrefix = "sth_";
+        String dbPrefix = "sth_";
+        String dataModel = "dm-by-service-path";
+        NGSIMongoSink sink = new NGSIMongoSink();
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
+        String dbName = "sth_default";
+        String fiwareService = "default";
+        String fiwareServicePath = "/";
+        String entity = "someId_someType";
+        String attribute = "someName_someType";
+        boolean isAggregated = false;
+        String entityId = "someId";
+        String entityType = "someType";
+        
+        try {
+            String collectionName = sink.buildCollectionName(dbName, fiwareServicePath, entity, attribute,
+                    isAggregated, entityId, entityType, fiwareService);
+            
+            try {
+                assertEquals("sth_/", collectionName);
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "-  OK  - '" + collectionName + "' was crated as collection name");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - '" + collectionName + "' was crated as collection name instead of 'sth_/'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - There was some problem when building the collection name");
+            assertTrue(false);
+        } // catch
+    } // testBuildCollectionNameDMByServicePathRootServicePath
+    
+    /**
+     * [NGSIMongoBaseSink.buildCollectionName] -------- When / service-path is notified/defaulted and
+     * data_model=dm-by-entity, the MongoDB collections name is <prefix>/_<entityId>_<entityType>.
+     */
+    @Test
+    public void testBuildCollectionNameDMByEntityRootServicePath() {
+        System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                + "-------- When / service-path is notified/defaulted and data_model=dm-by-entity, the MongoDB"
+                + "collections name is <prefix>/_<entityId>_<entityType>");
+        String collectionPrefix = "sth_";
+        String dbPrefix = "sth_";
+        String dataModel = "dm-by-entity";
+        NGSIMongoSink sink = new NGSIMongoSink();
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
+        String dbName = "sth_default";
+        String fiwareService = "default";
+        String fiwareServicePath = "/";
+        String entity = "someId_someType";
+        String attribute = "someName_someType";
+        boolean isAggregated = false;
+        String entityId = "someId";
+        String entityType = "someType";
+        
+        try {
+            String collectionName = sink.buildCollectionName(dbName, fiwareServicePath, entity, attribute,
+                    isAggregated, entityId, entityType, fiwareService);
+            
+            try {
+                assertEquals("sth_/_someId_someType", collectionName);
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "-  OK  - '" + collectionName + "' was crated as collection name");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - '" + collectionName + "' was crated as collection name instead of "
+                        + "'sth_/_someId_someType'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - There was some problem when building the collection name");
+            assertTrue(false);
+        } // catch
+    } // testBuildCollectionNameDMByEntityRootServicePath
+    
+    /**
+     * [NGSIMongoBaseSink.buildCollectionName] -------- When / service-path is notified/defaulted and
+     * data_model=dm-by-attribute, the MongoDB collections name is
+     * <prefix>/_<entityId>_<entityType>_<attrName>_<attrType>.
+     */
+    @Test
+    public void testBuildCollectionNameDMByAttributeRootServicePath() {
+        System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                + "-------- When / service-path is notified/defaulted and data_model=dm-by-attribute, the "
+                + "MongoDB collections name is <prefix>/_<entityId>_<entityType>_<attrName>_<attrType>");
+        String collectionPrefix = "sth_";
+        String dbPrefix = "sth_";
+        String dataModel = "dm-by-attribute";
+        NGSIMongoSink sink = new NGSIMongoSink();
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
+        String dbName = "sth_default";
+        String fiwareService = "default";
+        String fiwareServicePath = "/";
+        String entity = "someId_someType";
+        String attribute = "someName_someType";
+        boolean isAggregated = false;
+        String entityId = "someId";
+        String entityType = "someType";
+        
+        try {
+            String collectionName = sink.buildCollectionName(dbName, fiwareServicePath, entity, attribute,
+                    isAggregated, entityId, entityType, fiwareService);
+            
+            try {
+                assertEquals("sth_/_someId_someType_someName_someType", collectionName);
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "-  OK  - '" + collectionName + "' was crated as collection name");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - '" + collectionName + "' was crated as collection name instead of "
+                        + "'sth_/_someId_someType_someName_someType'");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIMongoBaseSink.buildCollectionName]")
+                        + "- FAIL - There was some problem when building the collection name");
+            assertTrue(false);
+        } // catch
+    } // testBuildCollectionNameDMByEntityRootServicePath
+    
+} // NGSIMongoBaseSinkTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoSinkTest.java
@@ -17,9 +17,9 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import com.telefonica.iot.cygnus.utils.CommonUtilsForTests;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
-import org.apache.flume.Context;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +50,9 @@ public class NGSIMongoSinkTest {
                 + "-------- Configured 'collection_prefix' cannot be 'system.'");
         String collectionPrefix = "system.";
         String dbPrefix = "sth_";
+        String dataModel = null; // defaulting
         NGSIMongoSink sink = new NGSIMongoSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -72,8 +73,9 @@ public class NGSIMongoSinkTest {
                 + "-------- Configured 'collection_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "this\\is/a$prefix.with-forbiden,chars:-.";
         String dbPrefix = "sth_";
+        String dataModel = null; // defaulting
         NGSIMongoSink sink = new NGSIMongoSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         String encodedCollectionPrefix = NGSIUtils.encodeSTHCollection(collectionPrefix);
         
         try {
@@ -97,8 +99,9 @@ public class NGSIMongoSinkTest {
                 + "-------- Configured 'db_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "sth_";
         String dbPrefix = "this\\is/a$prefix.with forbiden\"chars:-,";
+        String dataModel = null; // defaulting
         NGSIMongoSink sink = new NGSIMongoSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         String encodedDbPrefix = NGSIUtils.encodeSTHDB(dbPrefix);
         
         try {
@@ -110,26 +113,5 @@ public class NGSIMongoSinkTest {
                     + "- FAIL - 'db_prefix=" + dbPrefix + "' wrongly encoded as '" + encodedDbPrefix + "'");
         } // try catch
     } // testConfigureDBPrefixIsEncoded
-    
-    private Context createContext(String collectionPrefix, String dbPrefix) {
-        Context context = new Context();
-        context.put("attr_persistence", "row");
-        context.put("batch_size", "100");
-        context.put("batch_timeout", "30");
-        context.put("batch_ttl", "10");
-        context.put("collection_prefix", collectionPrefix);
-        context.put("collection_size", "0");
-        context.put("data_expiration", "0");
-        context.put("data_model", "dm-by-entity");
-        context.put("db_prefix", dbPrefix);
-        context.put("enable_grouping", "false");
-        context.put("enable_lowercase", "false");
-        context.put("max_documents", "0");
-        context.put("mongo_hosts", "localhost:27017");
-        context.put("mongo_password", "");
-        context.put("mongo_username", "");
-        context.put("should_hash", "false");
-        return context;
-    } // createContext
 
 } // NGSIMongoSinkTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISTHSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISTHSinkTest.java
@@ -17,9 +17,9 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import com.telefonica.iot.cygnus.utils.CommonUtilsForTests;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
-import org.apache.flume.Context;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +50,9 @@ public class NGSISTHSinkTest {
                 + "-------- Configured 'collection_prefix' cannot be 'system.'");
         String collectionPrefix = "system.";
         String dbPrefix = "sth_";
+        String dataModel = null; // defaulting
         NGSISTHSink sink = new NGSISTHSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -72,8 +73,9 @@ public class NGSISTHSinkTest {
                 + "-------- Configured 'collection_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "this\\is/a$prefix.with-forbiden,chars:-.";
         String dbPrefix = "sth_";
+        String dataModel = null; // defaulting
         NGSISTHSink sink = new NGSISTHSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         String encodedCollectionPrefix = NGSIUtils.encodeSTHCollection(collectionPrefix);
         
         try {
@@ -97,8 +99,9 @@ public class NGSISTHSinkTest {
                 + "-------- Configured 'db_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "sth_";
         String dbPrefix = "this\\is/a$prefix.with forbiden\"chars:-.";
+        String dataModel = null; // defaulting
         NGSISTHSink sink = new NGSISTHSink();
-        sink.configure(createContext(collectionPrefix, dbPrefix));
+        sink.configure(CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel));
         String encodedDbPrefix = NGSIUtils.encodeSTHDB(dbPrefix);
         
         try {
@@ -110,26 +113,5 @@ public class NGSISTHSinkTest {
                     + "- FAIL - 'db_prefix=" + dbPrefix + "' wrongly encoded as '" + encodedDbPrefix + "'");
         } // try catch
     } // testConfigureDBPrefixIsEncoded
-    
-    private Context createContext(String collectionPrefix, String dbPrefix) {
-        Context context = new Context();
-        context.put("attr_persistence", "row");
-        context.put("batch_size", "100");
-        context.put("batch_timeout", "30");
-        context.put("batch_ttl", "10");
-        context.put("collection_prefix", collectionPrefix);
-        context.put("collection_size", "0");
-        context.put("data_expiration", "0");
-        context.put("data_model", "dm-by-entity");
-        context.put("db_prefix", dbPrefix);
-        context.put("enable_grouping", "false");
-        context.put("enable_lowercase", "false");
-        context.put("max_documents", "0");
-        context.put("mongo_hosts", "localhost:27017");
-        context.put("mongo_password", "");
-        context.put("mongo_username", "");
-        context.put("should_hash", "false");
-        return context;
-    } // createContext
     
 } // NGSISTHSinkTest


### PR DESCRIPTION
* Fixes issue #977 
* 100% unit tests passed:
```
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-common
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-ngsi
```

Specific tests about this issue:
```
Running com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSinkTest
[NGSIMongoBaseSink.buildCollectionName] --------- When / service-path is notified/defaulted and data_model=dm-by-entity, the MongoDBcollections name is <prefix>/_<entityId>_<entityType>
[NGSIMongoBaseSink.buildCollectionName] --  OK  - 'sth_/_someId_someType' was crated as collection name
[NGSIMongoBaseSink.buildCollectionName] --------- When / service-path is notified/defaulted and data_model=dm-by-attribute, the MongoDB collections name is <prefix>/_<entityId>_<entityType>_<attrName>_<attrType>
[NGSIMongoBaseSink.buildCollectionName] --  OK  - 'sth_/_someId_someType_someName_someType' was crated as collection name
[NGSIMongoBaseSink.buildCollectionName] --------- When / service-path is notified/defaulted and data_model=dm-by-service-path, the MongoDB collection name is <prefix>/
[NGSIMongoBaseSink.buildCollectionName] --  OK  - 'sth_/' was crated as collection name
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.305 sec
```
* (unofficial) e2e tests passed:
```
Persisting data at OrionMongoSink. Database: sth_city012, Collection: sth_/ --> NGSIMongoSink
Persisting data at OrionSTHSink. Database: sth_city012, Collection: sth_/.aggr --> NGSISTHSink
```
* Assignee @pcoello25 , but LGTM from @mcarracedo is also required