### PR TITLE
hardening/985_force_alphanumeric_underscores_default_serv_and_servpath

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -41,3 +41,4 @@
 - [cygnus] [hardening] Add documentation in orion_ckan_sink.md about the creation of resources & datastores for column mode (#971)
 - [cygnus-ngsi] [bug] Fix collection name building when data_model is dm-by-service-path in Mongo sinks (#977)
 - [cygnus-ngsi] [bug] Fix attribute-based accumulation (#982)
+- [cygnus-ngsi] [hardening] Force default service and service path to use only alphanumerics and underscores (#985)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -55,6 +56,7 @@ public final class CommonUtils {
             "yyyy-MM-dd HH:mm:ss").withOffsetParsed().withZoneUTC();
     private static final DateTimeFormatter FORMATTER4 = DateTimeFormat.forPattern(
             "yyyy-MM-dd HH:mm:ss.SSS").withOffsetParsed().withZoneUTC();
+    private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9_]*$");
     
     /**
      * Constructor. It is private since utility classes should not have a public or default constructor.
@@ -293,5 +295,14 @@ public final class CommonUtils {
         
         return res;
     } // getTimeInstant
+    
+    /**
+     * Gets is a string is made of alphanumerics and/or underscores.
+     * @param s
+     * @return True is the string is made of alphanumerics and/or underscores, otherwise false.
+     */
+    public static boolean isMAdeOfAlphaNumericsOrUnderscores(String s) {
+        return PATTERN.matcher(s).matches();
+    } // isMAdeOfAlphaNumericsOrUnderscores
 
 } // CommonUtils

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -20,6 +20,7 @@ package com.telefonica.iot.cygnus.handlers;
 
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
+import com.telefonica.iot.cygnus.utils.CommonUtils;
 import java.io.BufferedReader;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -122,9 +123,13 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             invalidConfiguration = true;
             LOGGER.error("Bad configuration ('" + NGSIConstants.PARAM_DEFAULT_SERVICE
                     + "' parameter length greater than " + CommonConstants.SERVICE_HEADER_MAX_LEN + ")");
-        } else {
+        } else if (CommonUtils.isMAdeOfAlphaNumericsOrUnderscores(defaultService)) {
             LOGGER.debug("Reading configuration (" + NGSIConstants.PARAM_DEFAULT_SERVICE + "="
                     + defaultService + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration ('" + NGSIConstants.PARAM_DEFAULT_SERVICE
+                    + "' parameter can only contain alphanumerics or underscores)");
         } // if else
         
         defaultServicePath = context.getString(NGSIConstants.PARAM_DEFAULT_SERVICE_PATH, "/");
@@ -137,10 +142,14 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             invalidConfiguration = true;
             LOGGER.error("Bad configuration ('" + NGSIConstants.PARAM_DEFAULT_SERVICE_PATH
                     + "' must start with '/')");
-        } else {
+        } else if (CommonUtils.isMAdeOfAlphaNumericsOrUnderscores(defaultServicePath.substring(1))) {
             LOGGER.debug("Reading configuration (" + NGSIConstants.PARAM_DEFAULT_SERVICE_PATH + "="
                     + defaultServicePath + ")");
-        } // if else
+        } else {
+            invalidConfiguration = true;
+            LOGGER.error("Bad configuration ('" + NGSIConstants.PARAM_DEFAULT_SERVICE_PATH
+                    + "' parameter can only contain alphanumerics or underscores");
+        } // else
         
         LOGGER.info("Startup completed");
     } // configure

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
@@ -132,6 +132,56 @@ public class NGSIRestHandlerTest {
     } // testConfigureNotMandatoryParameters
     
     /**
+     * [NGSIRestHandler.configure] -------- The configured default service can only contain alphanumerics and
+     * underscores.
+     */
+    @Test
+    public void testConfigureDefaultServiceIsLegal() {
+        System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                + "-------- The configured default service can only contain alphanumerics and underscores");
+        NGSIRestHandler handler = new NGSIRestHandler();
+        String configuredDefaultService = "default-service!!";
+        handler.configure(createContext(null, configuredDefaultService, null));
+        
+        try {
+            assertTrue(handler.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The configured default service '" + configuredDefaultService
+                    + "' was detected as invalid");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The configured default service '" + configuredDefaultService
+                    + "' was not detected as invalid");
+            throw e;
+        } // try catch
+    } // testConfigureDefaultServiceIsLegal
+    
+    /**
+     * [NGSIRestHandler.configure] -------- The configured default service path can only contain alphanumerics
+     * and underscores.
+     */
+    @Test
+    public void testConfigureDefaultServicePathIsLegal() {
+        System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                + "-------- The configured default service path can only contain alphanumerics and underscores");
+        NGSIRestHandler handler = new NGSIRestHandler();
+        String configuredDefaultServicePath = "/something.?";
+        handler.configure(createContext(null, null, configuredDefaultServicePath));
+        
+        try {
+            assertTrue(handler.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "-  OK  - The configured default service path '" + configuredDefaultServicePath
+                    + "' was detected as invalid");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[OrionRestHandler.configure]")
+                    + "- FAIL - The configured default service path '" + configuredDefaultServicePath
+                    + "' was not detected as invalid");
+            throw e;
+        } // try catch
+    } // testConfigureDefaultServicePathIsLegal
+    
+    /**
      * [NGSIRestHandler.configure] -------- The configured default service path must start with '/'.
      */
     @Test

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/orion_rest_handler.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/orion_rest_handler.md
@@ -131,8 +131,8 @@ As said, Flume events are not much more different than the above representation:
 | Parameter | Mandatory | Default value | Comments |
 |---|---|---|---|
 | notification\_target | no | `notify/` | Any other configured value must start with `/`. |
-| default\_service | no | `default` || 
-| default\_service\_path | no | `/` | `/` is the root service path (also know as root subservice). Any other configured value must start with `/`. |
+| default\_service | no | `default` | Alphanumerics and underscores are only accepted. | 
+| default\_service\_path | no | `/` | `/` is the root service path (also know as root subservice). Any other configured value must start with `/`. Apart from the initial slash, alphanumerics and underscores are onlyu accepted. |
 
 A configuration example could be:
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/orion_rest_handler.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/orion_rest_handler.md
@@ -132,7 +132,7 @@ As said, Flume events are not much more different than the above representation:
 |---|---|---|---|
 | notification\_target | no | `notify/` | Any other configured value must start with `/`. |
 | default\_service | no | `default` | Alphanumerics and underscores are only accepted. | 
-| default\_service\_path | no | `/` | `/` is the root service path (also know as root subservice). Any other configured value must start with `/`. Apart from the initial slash, alphanumerics and underscores are onlyu accepted. |
+| default\_service\_path | no | `/` | `/` is the root service path (also know as root subservice). Any other configured value must start with `/`. Apart from the initial slash, alphanumerics and underscores are only accepted. |
 
 A configuration example could be:
 


### PR DESCRIPTION
* Implements issue #985 
* 100% unit tests passed:
```
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-common
Tests run: 87, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-ngsi
```

Specific tests:
```
[OrionRestHandler.configure] -------------------- The configured default service path can only contain alphanumerics and underscores
[OrionRestHandler.configure] -------------  OK  - The configured default service path '/something.?' was detected as invalid
[OrionRestHandler.configure] -------------------- The configured default service can only contain alphanumerics and underscores
[OrionRestHandler.configure] -------------  OK  - The configured default service 'default-service!!' was detected as invalid
```
* (unofficial) e2e tests:

Received data:
```
time=2016-05-04T08:27:58.202CEST | lvl=INFO | corr=9c4cbd11-d68c-4f56-97c9-ea4f5aa94780 | trans=9c4cbd11-d68c-4f56-97c9-ea4f5aa94780 | svc=default2 | subsvc=/ | function=getEvents | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[249] : Starting internal transaction (9c4cbd11-d68c-4f56-97c9-ea4f5aa94780)
time=2016-05-04T08:27:58.203CEST | lvl=INFO | corr=9c4cbd11-d68c-4f56-97c9-ea4f5aa94780 | trans=9c4cbd11-d68c-4f56-97c9-ea4f5aa94780 | svc=default2 | subsvc=/ | function=getEvents | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[265] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
```

```
Persisting data at OrionMongoSink. Database: sth_default2, Collection: sth_/_Room1_Room_temperature, Data: [Document{{recvTime=Wed May 04 08:27:58 CEST 2016, attrType=centigrade, attrValue=26.5}}]
```
* Assignee @pcoello25 