### PR TITLE
Update CKANBackendImpl.java

### DIFF
--- a/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -158,7 +158,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
     private void insert(String resId, String records) throws Exception {
         String jsonString = "{ \"resource_id\": \"" + resId
                     + "\", \"records\": [ " + records + " ], "
-                    + "\"method\": \"insert\", "
+                    + "\"method\": \"upsert\", "
                     + "\"force\": \"true\" }";
         String urlPath;
         


### PR DESCRIPTION
Provisioning a datastore with a primary key an unhanded error is shown with insert. Otherwise if the upsert method is use it will update the fields instead of throwing an error as said in ckan api docu: http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_upsert