### PR TITLE
hardening/932_add_fiware_correlator_to_response_http_messages

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-common] [hardening] Added a fiware-correlator header to messages of API responses (#932)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -29,6 +29,7 @@ import com.telefonica.iot.cygnus.backends.orion.OrionBackendImpl;
 import com.telefonica.iot.cygnus.containers.CygnusSubscriptionV1;
 import com.telefonica.iot.cygnus.containers.CygnusSubscriptionV2;
 import com.telefonica.iot.cygnus.containers.OrionEndpoint;
+import com.telefonica.iot.cygnus.handlers.CygnusHandler;
 import com.telefonica.iot.cygnus.interceptors.CygnusGroupingRule;
 import com.telefonica.iot.cygnus.interceptors.CygnusGroupingRules;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
@@ -63,7 +64,6 @@ import org.mortbay.jetty.HttpConnection;
 import org.mortbay.jetty.Request;
 import org.mortbay.jetty.handler.AbstractHandler;
 import org.json.simple.JSONObject;
-import com.telefonica.iot.cygnus.handlers.CygnusHandler;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
 import org.slf4j.MDC;
 /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -32,7 +32,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.regex.Pattern;
+import static org.eclipse.jetty.ajp.Ajp13PacketMethods.LOCK;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -304,5 +306,22 @@ public final class CommonUtils {
     public static boolean isMAdeOfAlphaNumericsOrUnderscores(String s) {
         return PATTERN.matcher(s).matches();
     } // isMAdeOfAlphaNumericsOrUnderscores
+    
+    /**
+     * Generates a new unique identifier. The format for this notifiedId is:
+     * bootTimeSecond-bootTimeMilliseconds-transactionCount%10000000000
+     * @param notifiedId An alrady existent identifier, most probably a notified one
+     * @param transactionId An already existent internal identifier
+     * @return A new unique identifier
+     */
+    public static String generateUniqueId(String notifiedId, String transactionId) {
+        if (notifiedId != null) {
+            return notifiedId;
+        } else if (transactionId != null) {
+            return transactionId;
+        } else {
+            return UUID.randomUUID().toString();
+        } // else
+    } // generateUniqueId
 
 } // CommonUtils

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -34,7 +34,6 @@ import java.util.Properties;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import static org.eclipse.jetty.ajp.Ajp13PacketMethods.LOCK;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -36,7 +36,6 @@ import org.apache.http.MethodNotSupportedException;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import org.apache.flume.event.EventBuilder;
 import org.slf4j.MDC;
-import java.util.UUID;
 
 /**
  *
@@ -236,11 +235,11 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         MDC.put(CommonConstants.LOG4J_SUBSVC, servicePath == null ? defaultServicePath : servicePath);
         
         // Get an internal transaction ID.
-        String transId = generateUniqueId(null, null);
+        String transId = CommonUtils.generateUniqueId(null, null);
         
         // Get also a correlator ID if not sent in the notification. Id correlator ID is not notified
         // then correlator ID and transaction ID must have the same value.
-        corrId = generateUniqueId(corrId, transId);
+        corrId = CommonUtils.generateUniqueId(corrId, transId);
         
         // Store both of them in the log4j Mapped Diagnostic Context (MDC), this way it will be accessible
         // by the whole source code.
@@ -288,27 +287,5 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         numProcessedEvents++;
         return eventList;
     } // getEvents
-    
-    /**
-     * Generates a new unique identifier. The format for this notifiedId is:
-     * bootTimeSecond-bootTimeMilliseconds-transactionCount%10000000000
-     * @param notifiedId An alrady existent identifier, most probably a notified one
-     * @param transactionId An already existent internal identifier
-     * @return A new unique identifier
-     */
-    protected String generateUniqueId(String notifiedId, String transactionId) {
-        if (notifiedId != null) {
-            return notifiedId;
-        } else if (transactionId != null) {
-            return transactionId;
-        } else {
-            // Check this SOF link: A bug doesn't allow to uuid be thread-safe
-            // For that reason we use LOCK in order to avoid problems with treads
-            // http://stackoverflow.com/questions/7212635/is-java-util-uuid-thread-safe
-            synchronized (LOCK) {
-                return UUID.randomUUID().toString();
-            } // synchronized
-        } // else
-    } // generateUniqueId
  
 } // NGSIRestHandler

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
@@ -42,6 +42,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.junit.Test;
 import org.mockito.Mock;
 import static org.mockito.Mockito.when;
+import com.telefonica.iot.cygnus.utils.CommonUtils;
 
 /**
  *
@@ -457,7 +458,7 @@ public class NGSIRestHandlerTest {
         System.out.println(getTestTraceHead("[OrionRestHandler.generateUniqueId]")
                 + "-------- An internal transaction ID is generated");
         NGSIRestHandler handler = new NGSIRestHandler();
-        String generatedTransId = handler.generateUniqueId(null, null);
+        String generatedTransId = CommonUtils.generateUniqueId(null, null);
         
         try {
             assertTrue(generatedTransId != null);
@@ -481,7 +482,7 @@ public class NGSIRestHandlerTest {
         NGSIRestHandler handler = new NGSIRestHandler();
         String generatedTransId = "1111111111-111-1111111111";
         String notifiedCorrId = "1234567890-123-1234567890";
-        String generatedCorrId = handler.generateUniqueId(notifiedCorrId, generatedTransId);
+        String generatedCorrId = CommonUtils.generateUniqueId(notifiedCorrId, generatedTransId);
         
         try {
             assertEquals(notifiedCorrId, generatedCorrId);
@@ -507,7 +508,7 @@ public class NGSIRestHandlerTest {
         String notifiedCorrId = null;
         
         try {
-            assertTrue(handler.generateUniqueId(notifiedCorrId, generatedTransId) != null);
+            assertTrue(CommonUtils.generateUniqueId(notifiedCorrId, generatedTransId) != null);
             System.out.println(getTestTraceHead("[OrionRestHandler.generateUniqueId]")
                     + "-  OK  - The transaction ID has been generated");
         } catch (AssertionError e) {
@@ -529,7 +530,7 @@ public class NGSIRestHandlerTest {
         NGSIRestHandler handler = new NGSIRestHandler();
         String generatedTransId = "1234567890-123-1234567890";
         String notifiedCorrId = null;
-        String generatedCorrId = handler.generateUniqueId(notifiedCorrId, generatedTransId);
+        String generatedCorrId = CommonUtils.generateUniqueId(notifiedCorrId, generatedTransId);
         
         try {
             assertEquals(generatedTransId, generatedCorrId);


### PR DESCRIPTION
* Fix issue #932 
* 100% unit test passed:
```
Results :
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0 [cygnus-common]
Tests run: 84, Failures: 0, Errors: 0, Skipped: 0 [cygnus-ngsi]
```
* e2e (unofficial) test passed:
```
[WITHOUT CORRELATOR IN THE REQUEST]
curl -v -X GET "http://localhost:8081/v1/subscriptions?ngsi_version=2&subscription_id=5332502b1860a3453d395e95" -d '{"host":"orion.lab.fi-ware.org", "port":"1026", "ssl":"false", "xauthtoken":"QsENv67AJj7blC2qJ0YvfSc5hMWYrs"}'

--> header got with -v option 
< fiware-correlator: e8814475-c2a7-4419-b3ce-bfbd547034d0

--> cygnus logs
time=2016-05-09T12:20:19.136WEST | lvl=DEBUG | corr=e8814475-c2a7-4419-b3ce-bfbd547034d0 | trans=e8814475-c2a7-4419-b3ce-bfbd547034d0 | srv= | subsrv= | function=doRequest | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[187] : Http request: GET http://orion.lab.fi-ware.org:1026/v2/subscriptions/5332502b1860a3453d395e95 HTTP/1.1

[WITH CORRELATOR]
curl -v -X GET "http://localhost:8081/v1/subscriptions?ngsi_version=2&subscription_id=5332502b1860a3453d395e95" --header 'fiware-correlator: correlatorId' -d '{"host":"orion.lab.fi-ware.org", "port":"1026", "ssl":"false", "xauthtoken":"QsENv67AJj7blC2qJ0YvfSc5hMWYrs"}'

--> header got with -v option
< fiware-correlator: correlatorId

--> cygnus logs
time=2016-05-09T12:22:26.681WEST | lvl=DEBUG | corr=correlatorId | trans=e17d926e-5601-4808-80db-dd6df79c6934 | srv= | subsrv= | function=doRequest | comp=Cygnus | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[187] : Http request: GET http://orion.lab.fi-ware.org:1026/v2/subscriptions/5332502b1860a3453d395e95 HTTP/1.1
```
* Assignee: @frbattid 