### PR TITLE
bug/1009_fix_logging_folder_creation_docker

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - [cygnus-common,cygnus-ngsi][hardening] Add sanity checks and diagnosis procedures (#627, #628)
+- [cygnus-ngsi][bug] Fix logging folder creation in Dockerfile (#1009)

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -82,7 +82,7 @@ RUN yum -y install tar nc which git java-1.6.0-openjdk-devel && \
     cp ${CYGNUS_HOME}/cygnus-common/conf/log4j.properties.template ${FLUME_HOME}/conf/log4j.properties && \
     cp ${CYGNUS_HOME}/cygnus-ngsi/conf/grouping_rules.conf.template ${FLUME_HOME}/conf/grouping_rules.conf && \
     # Create Cygnus log folder
-    mkdir ${FLUME_HOME}/log && \
+    mkdir /var/log/cygnus && \
     # Cleanup to thin the final image
     cd ${CYGNUS_HOME}/cygnus-common && \
     ${MVN_HOME}/bin/mvn clean && \


### PR DESCRIPTION
* Fixes issue #1009 
* Tests done:
```
$ docker run -e CYGNUS_LOG_APPENDER='LOGFILE' cygnus-ngsi
...
$ docker ps
CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS              PORTS                NAMES
0e616d72299d        cygnus-ngsi         "/cygnus-entrypoint.   7 minutes ago       Up 7 minutes        5050/tcp, 8081/tcp   trusting_wright
$ docker exec -t -i 0e616d72299d /bin/bash
[root@0e616d72299d /]# cat /var/log/cygnus/cygnus.log
time=2016-05-09T13:08:57.697UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp= | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[166] : Starting Cygnus, version 1.0.0_SNAPSHOT.af57cbbb1a7de94f6d2806d7f59778f3de0384a5
time=2016-05-09T13:08:57.834UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[277] : Waiting for valid Flume components references...
time=2016-05-09T13:08:57.835UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=start | comp=cygnus-ngsi | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[61] : Configuration provider starting
...
...
```
* Assignee @AlvaroVega 