### PR TITLE
hardening/997_continuous_doc_fixing 

### DIFF
--- a/cygnus-ngsi/README.md
+++ b/cygnus-ngsi/README.md
@@ -95,7 +95,7 @@ cygnusagent.sources.http-source.handler.default_service_path = def_servpath
 cygnusagent.sources.http-source.handler.events_ttl = 10
 cygnusagent.sources.http-source.interceptors = ts gi
 cygnusagent.sources.http-source.interceptors.ts.type = timestamp
-cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$Builder
+cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
 cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = /usr/cygnus/conf/grouping_rules.conf
 
 cygnusagent.channels.test-channel.type = memory
@@ -138,7 +138,7 @@ Running the tests require [Apache Maven](https://maven.apache.org/) installed an
 [Top](#top)
 
 ###<a name="section2.6"></a>e2e testing
-cygnus-ngsi works by receiving NGSI-like notifications, which are finaly persisted. In order to test this, you can run any of the notificacion scripts located in the [resources folder](./resources/ngsi-examples) of this repo, which emulate certain notification types.
+cygnus-ngsi works by receiving NGSI-like notifications, which are finally persisted. In order to test this, you can run any of the notification scripts located in the [resources folder](./resources/ngsi-examples) of this repo, which emulate certain notification types.
 
 ```
 $ ./notification-json-simple.sh http://localhost:5050/notify myservice myservicepath
@@ -229,11 +229,11 @@ Detailed information regarding cygus-ngsi can be found in the [Installation and 
 
 * [Installation with docker](doc/installation_and_administration_guide/install_with_docker). An alternative to RPM installation, docker is one of the main options when installing FIWARE components.
 * [Installation from sources](doc/installation_and_administration_guide/install_from_sources.md). Sometimes you will need to install from sources, particularly when some of the dependencies must be modified, e.g. the `hadoop-core` libraries.
-* [Running as a process](doc/installation_and_administration_guide/running_as_process.md). Running cygus-ngsi as a process is very useful for testing and debuging purposes.
+* [Running as a process](doc/installation_and_administration_guide/running_as_process.md). Running cygus-ngsi as a process is very useful for testing and debugging purposes.
 * [Management Interface](doc/installation_and_administration_guide/management_interface.md). From Cygnus 0.5 there is a REST-based management interface for administration purposes.
 * [Pattern-based grouping](doc/). Designed as a Flume interceptor, this feature <i>overwrites</i> the default behaviour when building the `destination` header within the Flume events. It creates specific `fiware-servicePath` per notified context element as well.
 * [Multi-instance](doc/installation_and_administration_guide/configuration.md). Several instances of cygus-ngsi can be run as a service.
-* [Performance tips](doc/installation_and_administration_guide/performance_tips.md). If you are experiencing performance issues or want to improve your statistics, take a look on how to obtaint the best from cygus-ngsi.
+* [Performance tips](doc/installation_and_administration_guide/performance_tips.md). If you are experiencing performance issues or want to improve your statistics, take a look on how to obtain the best from cygus-ngsi.
 * [New sink development](doc/user_and_programmer_guide/adding_new_sink.md). Addressed to those developers aiming to contribute to cygus-ngsi with new sinks.
 
 [Top](#top)

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -39,7 +39,7 @@ cygnusagent.sources.http-source.type = org.apache.flume.source.http.HTTPSource
 # listening port the Flume source will use for receiving incoming notifications
 cygnusagent.sources.http-source.port = 5050
 # Flume handler that will parse the notifications, must not be changed
-cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.OrionRestHandler
+cygnusagent.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.NGSIRestHandler
 # URL target
 # cygnusagent.sources.http-source.handler.notification_target = /notify
 # Default service (service semantic depends on the persistence sink)
@@ -51,17 +51,17 @@ cygnusagent.sources.http-source.interceptors = ts gi
 # TimestampInterceptor, do not change
 cygnusagent.sources.http-source.interceptors.ts.type = timestamp
 # GroupinInterceptor, do not change
-cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$Builder
+cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
 # Grouping rules for the GroupingInterceptor, put the right absolute path to the file if necessary
 # See the doc/design/interceptors document for more details
 cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = /usr/cygnus/conf/grouping_rules.conf
 
 # ============================================
-# OrionHDFSSink configuration
+# NGSIHDFSSink configuration
 # channel name from where to read notification events
 cygnusagent.sinks.hdfs-sink.channel = hdfs-channel
 # sink class, must not be changed
-cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.OrionHDFSSink
+cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.NGSIHDFSSink
 # true if the grouping feature is enabled for this sink, false otherwise
 # cygnusagent.sinks.hdfs-sink.enable_grouping = false
 # true if lower case is wanted to forced in all the element names, false otherwise
@@ -115,11 +115,11 @@ cygnusagent.sinks.hdfs-sink.krb5_auth.krb5_password = xxxxxxxxxxxxx
 # cygnusagent.sinks.hdfs-sink.krb5_auth.krb5_conf_file = /usr/cygnus/conf/krb5.conf
 
 # ============================================
-# OrionCKANSink configuration
+# NGSICKANSink configuration
 # channel name from where to read notification events
 cygnusagent.sinks.ckan-sink.channel = ckan-channel
 # sink class, must not be changed
-cygnusagent.sinks.ckan-sink.type = com.telefonica.iot.cygnus.sinks.OrionCKANSink
+cygnusagent.sinks.ckan-sink.type = com.telefonica.iot.cygnus.sinks.NGSICKANSink
 # true if the grouping feature is enabled for this sink, false otherwise
 # cygnusagent.sinks.ckan-sink.enable_grouping = false
 # true if lower case is wanted to forced in all the element names, false otherwise
@@ -146,11 +146,11 @@ cygnusagent.sinks.ckan-sink.api_key = ckanapikey
 # cygnusagent.sinks.ckan-sink.batch_ttl = 10
 
 # ============================================
-# OrionMySQLSink configuration
+# NGSIMySQLSink configuration
 # channel name from where to read notification events
 cygnusagent.sinks.mysql-sink.channel = mysql-channel
 # sink class, must not be changed
-cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.OrionMySQLSink
+cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.NGSIMySQLSink
 # true if the grouping feature is enabled for this sink, false otherwise
 # cygnusagent.sinks.mysql-sink.enable_grouping = false
 # true if lower case is wanted to forced in all the element names, false otherwise
@@ -177,11 +177,11 @@ cygnusagent.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.OrionMySQLSi
 # cygnusagent.sinks.mysql-sink.batch_ttl = 10
 
 # ============================================
-# OrionPostgreSQLSink configuration
+# NGSIPostgreSQLSink configuration
 # channel name from where to read notification events
 cygnusagent.sinks.postgresql-sink.channel = postgresql-channel
 # sink class, must not be changed
-cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.OrionPostgreSQLSink
+cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.NGSIPostgreSQLSink
 # true if the grouping feature is enabled for this sink, false otherwise
 # cygnusagent.sinks.postgresql-sink.enable_grouping = false
 # true if lower case is wanted to forced in all the element names, false otherwise
@@ -208,9 +208,9 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.OrionPo
 # cygnusagent.sinks.postgresql-sink.batch_ttl = 10
 
 # ============================================
-# OrionMongoSink configuration
+# NGSIMongoSink configuration
 # sink class, must not be changed
-cygnusagent.sinks.mongo-sink.type = com.telefonica.iot.cygnus.sinks.OrionMongoSink
+cygnusagent.sinks.mongo-sink.type = com.telefonica.iot.cygnus.sinks.NGSIMongoSink
 # channel name from where to read notification events
 cygnusagent.sinks.mongo-sink.channel = mongo-channel
 # true if the grouping feature is enabled for this sink, false otherwise
@@ -249,9 +249,9 @@ cygnusagent.sinks.mongo-sink.channel = mongo-channel
 # cygnusagent.sinks.mongo-sink.ignore_white_spaces = true
 
 # ============================================
-# OrionSTHSink configuration
+# NGSISTHSink configuration
 # sink class, must not be changed
-cygnusagent.sinks.sth-sink.type = com.telefonica.iot.cygnus.sinks.OrionSTHSink
+cygnusagent.sinks.sth-sink.type = com.telefonica.iot.cygnus.sinks.NGSISTHSink
 # channel name from where to read notification events
 cygnusagent.sinks.sth-sink.channel = sth-channel
 # true if the grouping feature is enabled for this sink, false otherwise
@@ -284,9 +284,9 @@ cygnusagent.sinks.sth-sink.channel = sth-channel
 # cygnusagent.sinks.sth-sink.ignore_white_spaces = true
 
 #=============================================
-# OrionKafkaSink configuration
+# NGSIKafkaSink configuration
 # sink class, must not be changed
-cygnusagent.sinks.kafka-sink.type = com.telefonica.iot.cygnus.sinks.OrionKafkaSink
+cygnusagent.sinks.kafka-sink.type = com.telefonica.iot.cygnus.sinks.NGSIKafkaSink
 # channel name from where to read notification events
 cygnusagent.sinks.kafka-sink.channel = kafka-channel
 # true if the grouping feature is enabled for this sink, false otherwise
@@ -311,9 +311,9 @@ cygnusagent.sinks.kafka-sink.channel = kafka-channel
 # cygnusagent.sinks.kafka-sink.batch_ttl = 10
 
 # ============================================
-# OrionDynamoDBSink configuration
+# NGSIDynamoDBSink configuration
 # sink class, must not be changed
-cygnusagent.sinks.dynamodb-sink.type = com.telefonica.iot.cygnus.sinks.OrionDynamoDBSink
+cygnusagent.sinks.dynamodb-sink.type = com.telefonica.iot.cygnus.sinks.NGSIDynamoDBSink
 # channel name from where to read notification events
 cygnusagent.sinks.dynamodb-sink.channel = dynamo-channel
 # AWS Access Key Id

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/grouping_interceptor.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/grouping_interceptor.md
@@ -105,7 +105,7 @@ The grouping rules file is usually placed at `[FLUME_HOME_DIR]/conf/`, and there
 The usage of such an Interceptor is:
 
     cygnusagent.sources.http-source.interceptors = gi <other-interceptors>
-    cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$Builder
+    cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
     cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = [FLUME_HOME_DIR]/conf/grouping_rules.conf
 
 It is <b>very important</b> to configure the <b>absolute path to the grouping rules file</b>.

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
@@ -334,7 +334,7 @@ Nevertheless, Cygnus needs this process to be automated. Let's see how through t
 [Top](#top)
 
 ####`conf/cygnus.conf`
-This file can be built from the distributed `conf/cugnus.conf.template`. Edit appropriately this part of the `NGSIHDFSSink` configuration:
+This file can be built from the distributed `conf/cygnus.conf.template`. Edit appropriately this part of the `NGSIHDFSSink` configuration:
 
     # Kerberos-based authentication enabling
     cygnusagent.sinks.hdfs-sink.krb5_auth = true

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -41,7 +41,7 @@ cygnusagent.sources.http-source.interceptors = ts gi
 # TimestampInterceptor, do not change
 cygnusagent.sources.http-source.interceptors.ts.type = timestamp
 # GroupingInterceptor, do not change
-cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$Builder
+cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
 # Grouping rules for the GroupingIntercetor, put the right absolute path to the file if necessary
 # See the doc/design/interceptors document for more details
 cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = /usr/cygnus/conf/grouping_rules.conf

--- a/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
@@ -11,7 +11,7 @@ Once the `cygnus_instance_<id>.conf` and `agent_<id>.conf` files are properly co
 
     $ sudo service cygnus stop
 
-Previous commands afefcts to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after the action must be specified:
+Previous commands afects to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after the action must be specified:
 
     $ sudo service cygnus status <id>
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
@@ -11,7 +11,7 @@ Once the `cygnus_instance_<id>.conf` and `agent_<id>.conf` files are properly co
 
     $ sudo service cygnus stop
 
-Previous commands afects to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after the action must be specified:
+Previous commands affects to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after the action must be specified:
 
     $ sudo service cygnus status <id>
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/running_as_service.md
@@ -11,7 +11,7 @@ Once the `cygnus_instance_<id>.conf` and `agent_<id>.conf` files are properly co
 
     $ sudo service cygnus stop
 
-Previous commands afefcts to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after de the action must be specified:
+Previous commands afefcts to **all** of Cygnus instances configured. If only one instance is wanted to be managed by the service script then the instance identifier after the action must be specified:
 
     $ sudo service cygnus status <id>
 
@@ -22,4 +22,3 @@ Previous commands afefcts to **all** of Cygnus instances configured. If only one
     $ sudo service cygnus stop <id>
 
 Where `<id>` is the suffix at the end of the `cygnus_instace_<id>.conf` or `agent_<id>.conf` files you used to configure the instance.
-

--- a/doc/cygnus-ngsi/quick_start_guide.md
+++ b/doc/cygnus-ngsi/quick_start_guide.md
@@ -52,7 +52,7 @@ cygnusagent.sources.http-source.handler.default_service_path = def_servpath
 cygnusagent.sources.http-source.handler.events_ttl = 2
 cygnusagent.sources.http-source.interceptors = ts gi
 cygnusagent.sources.http-source.interceptors.ts.type = timestamp
-cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.GroupingInterceptor$Builder
+cygnusagent.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
 cygnusagent.sources.http-source.interceptors.gi.grouping_rules_conf_file = /Applications/apache-flume-1.4.0-bin/conf/grouping_rules.conf
 
 cygnusagent.channels.test-channel.type = memory


### PR DESCRIPTION
* Partially implements issue #997
  * Fixing checks:
    *  Fix bad-formed words in `running_as_service.md` & `performance_tips.md`
    *  File `agent_ngsi.conf.template` has names as `OrionHDFSSink`, `OrionCKANSink`..., but the must be as `NGSIHDFSSink`, `NGSICKANSink`.
    * References to `cugnus` instead of `cygnus`.
    * References to `GroupingInterceptor$Builder` instead of `NGSIGroupingInterceptor$Builder`
* No tests are required
* Assignee: @frbattid 