### PR TITLE
hardening/1020_add_admin_port_environment_variable_to_dockerfile

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - [cygnus] [doc] Move backend documentation to cygnus-common (#1013)
 - [cygnus] [feature] Add cygnus-common docker (#1021)
 - [cygnus] [doc] Add CartoDB related documentation (#1016)
+- [cygnus] [hardening] Add service port and api port environment variables to Dockerfiles (#1020)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,4 +6,4 @@
 - [cygnus] [doc] Move backend documentation to cygnus-common (#1013)
 - [cygnus] [feature] Add cygnus-common docker (#1021)
 - [cygnus] [doc] Add CartoDB related documentation (#1016)
-- [cygnus] [hardening] Add service port and api port environment variables to Dockerfiles (#1020)
+- [cygnus] [hardening] Add service port and api port as environment variables to Dockerfiles (#1020)

--- a/docker/cygnus-common/Dockerfile
+++ b/docker/cygnus-common/Dockerfile
@@ -29,6 +29,8 @@ ENV CYGNUS_CONF_FILE "/opt/apache-flume/conf/agent.conf"
 ENV CYGNUS_AGENT_NAME "cygnus-common"
 ENV CYGNUS_LOG_LEVEL "INFO"
 ENV CYGNUS_LOG_APPENDER "console"
+ENV CYGNUS_SERVICE_PORT "5050"
+ENV CYGNUS_API_PORT "8081"
 
 ENV GIT_URL_CYGNUS "https://github.com/telefonicaid/fiware-cygnus.git"
 ENV GIT_REV_CYGNUS "develop"
@@ -97,5 +99,5 @@ COPY agent.conf ${FLUME_HOME}/conf/
 ENTRYPOINT ["/cygnus-entrypoint.sh"]
 
 # Ports used by cygnus-common
-EXPOSE 5050
-EXPOSE 8081
+EXPOSE ${CYGNUS_SERVICE_PORT}
+EXPOSE ${CYGNUS_API_PORT}

--- a/docker/cygnus-common/agent.conf
+++ b/docker/cygnus-common/agent.conf
@@ -20,11 +20,11 @@ cygnus-common.sources = http-source
 cygnus-common.sinks = logger-sink
 cygnus-common.channels = logger-channel
 
-cygnus-ngsi.sources.http-source.channels = logger-channel
-cygnus-ngsi.sources.http-source.type = org.apache.flume.source.http.HTTPSource
-cygnus-ngsi.sources.http-source.port = 5050
-cygnus-ngsi.sources.http-source.interceptors = ts
-cygnus-ngsi.sources.http-source.interceptors.ts.type = timestamp
+cygnus-common.sources.http-source.channels = logger-channel
+cygnus-common.sources.http-source.type = org.apache.flume.source.http.HTTPSource
+cygnus-common.sources.http-source.port = 5050
+cygnus-common.sources.http-source.interceptors = ts
+cygnus-common.sources.http-source.interceptors.ts.type = timestamp
 
 cygnus-common.sinks.logger-sink.channel = logger-channel
 cygnus-common.sinks.logger-sink.type = logger

--- a/docker/cygnus-common/cygnus-entrypoint.sh
+++ b/docker/cygnus-common/cygnus-entrypoint.sh
@@ -17,4 +17,4 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
-${FLUME_HOME}/bin/cygnus-flume-ng agent --conf ${CYGNUS_CONF_PATH} -f ${CYGNUS_CONF_FILE} -n ${CYGNUS_AGENT_NAME} -Dflume.root.logger=${CYGNUS_LOG_LEVEL},${CYGNUS_LOG_APPENDER}
+${FLUME_HOME}/bin/cygnus-flume-ng agent --conf ${CYGNUS_CONF_PATH} -f ${CYGNUS_CONF_FILE} -n ${CYGNUS_AGENT_NAME} -p ${CYGNUS_API_PORT} -Dflume.root.logger=${CYGNUS_LOG_LEVEL},${CYGNUS_LOG_APPENDER}

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -29,6 +29,8 @@ ENV CYGNUS_CONF_FILE "/opt/apache-flume/conf/agent.conf"
 ENV CYGNUS_AGENT_NAME "cygnus-ngsi"
 ENV CYGNUS_LOG_LEVEL "INFO"
 ENV CYGNUS_LOG_APPENDER "console"
+ENV CYGNUS_SERVICE_PORT "5050"
+ENV CYGNUS_API_PORT "8081"
 
 ENV GIT_URL_CYGNUS "https://github.com/telefonicaid/fiware-cygnus.git"
 ENV GIT_REV_CYGNUS "develop"
@@ -104,6 +106,5 @@ COPY agent.conf ${FLUME_HOME}/conf/
 ENTRYPOINT ["/cygnus-entrypoint.sh"]
 
 # Ports used by cygnus-ngsi
-EXPOSE 5050
-EXPOSE 8081
-
+EXPOSE ${CYGNUS_SERVICE_PORT}
+EXPOSE ${CYGNUS_API_PORT}

--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -17,5 +17,4 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
-${FLUME_HOME}/bin/cygnus-flume-ng agent --conf ${CYGNUS_CONF_PATH} -f ${CYGNUS_CONF_FILE} -n ${CYGNUS_AGENT_NAME} -Dflume.root.logger=${CYGNUS_LOG_LEVEL},${CYGNUS_LOG_APPENDER}
-
+${FLUME_HOME}/bin/cygnus-flume-ng agent --conf ${CYGNUS_CONF_PATH} -f ${CYGNUS_CONF_FILE} -n ${CYGNUS_AGENT_NAME} -p ${CYGNUS_API_PORT} -Dflume.root.logger=${CYGNUS_LOG_LEVEL},${CYGNUS_LOG_APPENDER}


### PR DESCRIPTION
* Fix issue #1020 
* No tests are required  

    * Port can be set when Cygnus starts, as shown below:
```
$ docker run -e CYGNUS_API_PORT='12345' cygnus-common
.............
time=2016-05-18T07:27:59.965UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-common | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 12345 (Management Interface)


[TESTING WITH API TO PORT 12345]

curl -X GET "http://172.17.0.8:12345/v1/subscriptions?ngsi_version=2&subscription_id=573ac3b6aba73680b1905f5c" -d '{"host":"orion.lab.fiware.org", "port":"1026", "ssl":"false", "xauthtoken":"QsENv67AJj7blC2qJ0YvfSc5hMWYrs"}'
{"success":"false","result" : {{"error":"subscriptionId does not correspond to an active subscription","description":""}}
```
* Assignee: @frbattid 