### PR TITLE
hardening/1030_remove_data_model_by_attribute_cartodbsink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,3 +8,4 @@
 - [cygnus] [doc] Add CartoDB related documentation (#1016)
 - [cygnus] [hardening] Add service port and api port as environment variables to Dockerfiles (#1020)
 - [cygnus-ngsi] [feature] Add distance analysis support to NGSICartoDBSink (#1026)
+- [cygnus-ngsi] [hardening] Remove data model by attribute support in NGSICartoDBSink (#1030)

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -252,6 +252,51 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableDitanceOK
     
     /**
+     * [NGSICartoDBSink.configure] -------- Configured `data_model` cannot be different than `dm-by-service-path`
+     * or `dm-by-entity`.
+     */
+    @Test
+    public void testConfigureDataModelOK() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured `data_model` cannot be different than `dm-by-service-path` or `dm-by-entity`");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = "dm-by-service";
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-service' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-service' was not detected");
+            throw e;
+        } // try catch
+        
+        dataModel = "dm-by-attribute";
+        sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-attribute' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-attribute' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureDataModelOK
+    
+    /**
      * [NGSICartoDBSink.start] -------- When started, a CartoDB backend is created.
      */
     @Test
@@ -372,53 +417,6 @@ public class NGSICartoDBSinkTest {
     } // testBuildDBNameNonRootServicePathDataModelByEntity
     
     /**
-     * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted
-     * and data_model is 'dm-by-attribute' the CartoDB table name is the lower
-     * case of \<servicePath\>_\<entityId\>_\<entityYype\>_\<attrName\>_\<attrType\>.
-     * @throws java.lang.Exception
-     */
-    @Test
-    public void testBuildDBNameNonRootServicePathDataModelByAttribute() throws Exception {
-        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                + "-------- When a non root service-path is notified/defaulted and data_model is "
-                + "'dm-by-attribute' the CartoDB table name is the lower case of "
-                + "<servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>");
-        String endpoint = "https://localhost";
-        String apiKey = "1234567890abcdef";
-        String dataModel = "dm-by-attribute";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String enableDistance = null; // default one
-        NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
-        String servicePath = "/somePath";
-        String entity = "someId_someType";
-        String attribute = "someName1_someType1";
-        
-        try {
-            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
-        
-            try {
-                assertEquals("somepath_someid_sometype_somename1_sometype1", builtTableName);
-                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
-                        + "<servicePath>_<entityId>_<entityType>_<attrName>_<attrType>");
-            } catch (AssertionError e) {
-                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
-                        + "<servicePath>_<entityId>_<entityType>_<attrName>_<attrType>");
-                throw e;
-            } // try catch
-        } catch (Exception e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                    + "- FAIL - There was some problem when building the table name");
-            throw e;
-        } // try catch
-    } // testBuildDBNameNonRootServicePathDataModelByAttribute
-    
-    /**
      * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted and
      * data_model is 'dm-by-service-path' the CartoDB table name cannot be created.
      * @throws java.lang.Exception
@@ -499,53 +497,6 @@ public class NGSICartoDBSinkTest {
             throw e;
         } // try catch
     } // testBuildDBNameRootServicePathDataModelByEntity
-    
-    /**
-     * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted
-     * and data_model is 'dm-by-attribute' the CartoDB table name is the lower
-     * case of \<servicePath\>_\<entityId\>_\<entityYype\>_\<attrName\>_\<attrType\>.
-     * @throws java.lang.Exception
-     */
-    @Test
-    public void testBuildDBNameRootServicePathDataModelByAttribute() throws Exception {
-        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                + "-------- When a root service-path is notified/defaulted and data_model is "
-                + "'dm-by-attribute' the CartoDB table name is the lower case of "
-                + "<servicePath>_<entityId>_<entityYype>_<attrName>_<attrType>");
-        String endpoint = "https://localhost";
-        String apiKey = "1234567890abcdef";
-        String dataModel = "dm-by-attribute";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String enableDistance = null; // default one
-        NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
-        String servicePath = "/";
-        String entity = "someId_someType";
-        String attribute = "someName1_someType1";
-        
-        try {
-            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
-        
-            try {
-                assertEquals("someid_sometype_somename1_sometype1", builtTableName);
-                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
-                        + "<entityId>_<entityType>_<attrName>_<attrType>");
-            } catch (AssertionError e) {
-                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
-                        + "<entityId>_<entityType>_<attrName>_<attrType>");
-                throw e;
-            } // try catch
-        } catch (Exception e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                    + "- FAIL - There was some problem when building the table name");
-            throw e;
-        } // try catch
-    } // testBuildDBNameRootServicePathDataModelByAttribute
     
     /**
      * [CartoDBAggregator.initialize] -------- When initializing through an initial geolocated event, a table

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -7,7 +7,7 @@ Content:
         * [PostgreSQL databases and schemas naming conventions](#section1.2.1)
         * [PostgreSQL tables naming conventions](#section1.2.2)
         * [Raw-based storing](#section1.2.3)
-        * [Distance-based storing (beta)](#section1.2.4)
+        * [Distance-based storing](#section1.2.4)
     * [Example](#section1.3)
         * [Flume event](#section1.3.1)
         * [Table names](#section1.3.2)
@@ -65,10 +65,10 @@ It must be said PostgreSQL only accepts alphanumeric characters and the undersco
 
 The following table summarizes the table name composition:
 
-| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-attribute` |
-|---|---|---|---|
-| `/` | N/A | `<entityId>_<entityType>` | `<entityId>_<entityType>_<attrName>_<attrType>` |
-| `/<svcPath>` | `<svcPath>` | `<svcPath>_<entityId>_<entityType>` | `<svcPath>_<entityId>_<entityType>_<attrName>_<attrType>` |
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
+|---|---|---|
+| `/` | N/A | `<entityId>_<entityType>` |
+| `/<svcPath>` | `<svcPath>` | `<svcPath>_<entityId>_<entityType>` |
 
 [Top](#top)
 
@@ -88,7 +88,7 @@ A single insert is composed for each notified entity, containing such insert the
 
 [Top](#top)
 
-####<a name="section1.2.4"></a>Distance-based storing (beta)
+####<a name="section1.2.4"></a>Distance-based storing
 If `enable_distance` parameter is set to `true` (by default, this kind of storing is not run) then the notified data is processed based on a distance analysis. As said, the linear distance and elapsed time with regards to the previous geolocation of the entity is obtained, and this information is used to update certain aggregations: total amount of distance, total amount of time and many others. The speed is obtained as well as the result of dividing the distance by the time, and such speed calculation is used as well for updating certain aggregations.
 
 The final goal is to **pre-compute a set of distance-based measures** as a function of the geolocation of an entity, allowing for querying about <i>"the total amount of time this entity took to arrive to this point"</i>, or <i>"which was the average speed of this entity when passing through this point"</i>, etc. **without performing any computation at querying time**.
@@ -166,10 +166,10 @@ Assuming the following Flume event is created from a notified NGSI context data 
 ####<a name="section1.3.2"></a>Table names
 The PostgreSQL table names will be, depending on the configured data model, the following ones:
 
-| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-attribute` |
-|---|---|---|---|
-| `/` | N/A | `car1_car` | `car1_car_speed_float`<br>`car1_car_oil_level_float` |
-| `/4wheels` | `4wheels` | `4wheels_car1_car` | `4wheels_car1_car_speed_float`<br>`4wheels_car1_car_oil_level_float` |
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
+|---|---|---|
+| `/` | N/A | `car1_car` |
+| `/4wheels` | `4wheels` | `4wheels_car1_car` |
     
 [Top](#top)
 
@@ -382,8 +382,8 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheels_car1_car
 | channel | yes | N/A ||
 | enable\_grouping | no | false | <i>true</i> or <i>false</i>. |
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity |  <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <i>dm-by-attribute</i>. |
-| keys_conf_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/CartoDB usernames and CartoDB API Keys. |
+| data_model | no | dm-by-entity |  <i>dm-by-service-path</i> or <i>dm-by-entity</i>. |
+| keys\_conf\_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/CartoDB usernames and CartoDB API Keys. |
 | flip\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
 | enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw based storage is done. |
 | enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance based storage is done. |

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -59,7 +59,6 @@ The name of these tables depends on the configured data model (see the [Configur
 
 * Data model by service path (`data_model=dm-by-service-path`). As the data model name denotes, the notified FIWARE service path (or the configured one as default in [`NGSIRestHandler`](.ngsi_rest_handler.md)) is used as the name of the table. This allows the data about all the NGSI entities belonging to the same service path is stored in this unique table. The only constraint regarding this data model is the FIWARE service path cannot be the root one (`/`).
 * Data model by entity (`data_model=dm-by-entity`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity ID and entityType in order to compose the table name. The concatenation character is `_` (underscore). If the FIWARE service path is the root one (`/`) then only the entity ID and type are concatenated.
-* Data model by attribute (`data_model=dm-by-attribute`). For each entity and entity's attribute, the notified/default FIWARE service path, the notified entityId and entityType, and the attribute name and type are concatenated in order to compose the table name. The concatenation character is `_` (underscore). If the FIWARE service path is the root one (`/`) then only the entity ID and type and the attribute name and type are concatenated.
 
 It must be said PostgreSQL only accepts alphanumeric characters and the underscore (`_`). All the other characters will be escaped to underscore (`_`) when composing the table names.
 


### PR DESCRIPTION
* Implements issue #1030 
* 100% unit tests passed:
```
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[NGSICartoDBSink.configure] --------------------- Configured `data_model` cannot be different than `dm-by-service-path` or `dm-by-entity`
[NGSICartoDBSink.configure] --------------  OK  - 'data_model=dm-by-service' was detected
[NGSICartoDBSink.configure] --------------  OK  - 'data_model=dm-by-attribute' was detected
```
* Assignee @pcoello25 but LGTM from @gtorodelvalle is also required