### PR TITLE
feature/1028_multitenancy_cartodbsink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,3 +8,4 @@
 - [cygnus] [doc] Add CartoDB related documentation (#1016)
 - [cygnus] [hardening] Add service port and api port as environment variables to Dockerfiles (#1020)
 - [cygnus-ngsi] [feature] Add distance analysis support to NGSICartoDBSink (#1026)
+- [cygnus-ngsi] [feature] Add multitenancy support to NGSICartoDBSink (#1028)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
@@ -25,11 +25,12 @@ public interface CartoDBBackend {
     
     /**
      * Gets if the given table is empty ot not.
+     * @param schema
      * @param tableName
      * @return True if the given table is empty, false otherwise
      * @throws Exception
      */
-    boolean isEmpty(String tableName) throws Exception;
+    boolean isEmpty(String schema, String tableName) throws Exception;
     
     /**
      * Creates a table with the given name.
@@ -42,12 +43,13 @@ public interface CartoDBBackend {
     
     /**
      * Inserts the given rows regarding the given fields in the given table; withs are prefixed to the query.
+     * @param schema
      * @param tableName
      * @param withs
      * @param fields
      * @param rows
      * @throws java.lang.Exception
      */
-    void insert(String tableName, String withs, String fields, String rows) throws Exception;
+    void insert(String schema, String tableName, String withs, String fields, String rows) throws Exception;
     
 } // CartoDBBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
@@ -37,8 +37,8 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
      * Constructor.
      * @param host
      * @param port
-     * @param apiKey
      * @param ssl
+     * @param apiKey
      */
     public CartoDBBackendImpl(String host, String port, boolean ssl, String apiKey) {
         super(new String[]{host}, port, ssl, false, null, null, null, null);
@@ -46,8 +46,8 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
     } // CartoDBBackendImpl
     
     @Override
-    public boolean isEmpty(String tableName) throws Exception {
-        String query = "SELECT COUNT(*) FROM " + tableName;
+    public boolean isEmpty(String schema, String tableName) throws Exception {
+        String query = "SELECT COUNT(*) FROM " + schema + "." + tableName;
         String encodedQuery = URLEncoder.encode(query, "UTF-8");
         String relativeURL = BASE_URL + encodedQuery + "&api_key=" + apiKey;
         JsonResponse response = doRequest("GET", relativeURL, true, null, null);
@@ -67,7 +67,7 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
     @Override
     public void createTable(String schema, String tableName, String fields) throws Exception {
         // Create the table
-        String query = "CREATE TABLE " + tableName + " " + fields;
+        String query = "CREATE TABLE " + schema + "." + tableName + " " + fields;
         String encodedQuery = URLEncoder.encode(query, "UTF-8");
         String relativeURL = BASE_URL + encodedQuery + "&api_key=" + apiKey;
         JsonResponse response = doRequest("GET", relativeURL, true, null, null);
@@ -90,8 +90,8 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
     } // createTable
     
     @Override
-    public void insert(String tableName, String withs, String fields, String rows) throws Exception {
-        String query = withs + "INSERT INTO " + tableName + " " + fields + " VALUES " + rows;
+    public void insert(String schema, String tableName, String withs, String fields, String rows) throws Exception {
+        String query = withs + "INSERT INTO " + schema + "." + tableName + " " + fields + " VALUES " + rows;
         String encodedQuery = URLEncoder.encode(query, "UTF-8");
         String relativeURL = BASE_URL + encodedQuery + "&api_key=" + apiKey;
         JsonResponse response = doRequest("GET", relativeURL, true, null, null);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/interceptors/CygnusGroupingRules.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/interceptors/CygnusGroupingRules.java
@@ -18,17 +18,12 @@
 package com.telefonica.iot.cygnus.interceptors;
 
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
+import com.telefonica.iot.cygnus.utils.JsonUtils;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.regex.Matcher;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 
 /**
  *
@@ -49,24 +44,26 @@ public class CygnusGroupingRules {
         lastIndex = 0;
         
         // read the grouping rules file
-        // a JSONParse(groupingRulesFileName) method cannot be used since the file may contain comment lines
-        // starting by the '#' character (comments)
-        String jsonStr = readGroupingRulesFile(groupingRulesFileName);
-
-        if (jsonStr == null) {
-            LOGGER.info("No grouping rules have been read");
+        String jsonStr;
+        
+        try {
+            jsonStr = JsonUtils.readJsonFile(groupingRulesFileName);
+        } catch (Exception e) {
+            LOGGER.info("No grouping rules have been read. Details: " + e.getMessage());
             return;
-        } // if
+        } // try catch
 
         LOGGER.info("Grouping rules read: " + jsonStr);
 
         // parse the Json containing the grouping rules
-        JSONArray jsonGroupingRules = (JSONArray) parseGroupingRules(jsonStr);
-
-        if (jsonGroupingRules == null) {
-            LOGGER.warn("Grouping rules syntax has errors");
+        JSONArray jsonGroupingRules;
+        
+        try {
+            jsonGroupingRules = (JSONArray) JsonUtils.parseJsonString(jsonStr).get("grouping_rules");
+        } catch (Exception e) {
+            LOGGER.warn("Grouping rules syntax has errors. Details: " + e.getMessage());
             return;
-        } // if
+        } // try catch
 
         LOGGER.info("Grouping rules syntax is OK");
 
@@ -239,53 +236,5 @@ public class CygnusGroupingRules {
             } // if else
         } // for
     } // setRules
-    
-    private String readGroupingRulesFile(String groupingRulesFileName) {
-        if (groupingRulesFileName == null) {
-            return null;
-        } // if
-
-        String jsonStr = "";
-        BufferedReader reader;
-
-        try {
-            reader = new BufferedReader(new FileReader(groupingRulesFileName));
-        } catch (FileNotFoundException e) {
-            LOGGER.error("File not found. Details=" + e.getMessage() + ")");
-            return null;
-        } // try catch
-
-        String line;
-
-        try {
-            while ((line = reader.readLine()) != null) {
-                if (line.startsWith("#") || line.length() == 0) {
-                    continue;
-                } // if
-
-                jsonStr += line;
-            } // while
-
-            return jsonStr;
-        } catch (IOException e) {
-            LOGGER.error("Error while reading the Json-based grouping rules file. Details=" + e.getMessage() + ")");
-            return null;
-        } // try catch
-    } // readGroupingRulesFile
-
-    private JSONArray parseGroupingRules(String jsonStr) {
-        if (jsonStr == null) {
-            return null;
-        } // if
-
-        JSONParser jsonParser = new JSONParser();
-
-        try {
-            return (JSONArray) ((JSONObject) jsonParser.parse(jsonStr)).get("grouping_rules");
-        } catch (ParseException e) {
-            LOGGER.error("Error while parsing the Json-based grouping rules file. Details=" + e.getMessage());
-            return null;
-        } // try catch
-    } // parseGroupingRules
 
 } // CygnusGroupingRules

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/JsonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/JsonUtils.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.utils;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+/**
+ *
+ * @author frb
+ */
+public final class JsonUtils {
+    
+    /**
+     * Constructor. It is private since utility classes should not have a public or default constructor.
+     */
+    private JsonUtils() {
+    } // JsonUtils
+    
+    /**
+     * Reads a Json file. It ignores white spaces and comments (starting with '#').
+     * @param fileName
+     * @return A String containing the Json read
+     * @throws java.lang.Exception
+     */
+    public static String readJsonFile(String fileName) throws Exception {
+        if (fileName == null) {
+            return null;
+        } // if
+
+        String jsonStr = "";
+        BufferedReader reader;
+        reader = new BufferedReader(new FileReader(fileName));
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+            if (line.startsWith("#") || line.length() == 0) {
+                continue;
+            } // if
+
+            jsonStr += line;
+        } // while
+
+        return jsonStr;
+    } // readJsonFile
+
+    /**
+     * Parses a Json string.
+     * @param jsonStr
+     * @return A JSONObject
+     * @throws java.lang.Exception
+     */
+    public static JSONObject parseJsonString(String jsonStr) throws Exception {
+        if (jsonStr == null) {
+            return null;
+        } // if
+
+        JSONParser jsonParser = new JSONParser();
+        return (JSONObject) jsonParser.parse(jsonStr);
+    } // parseJsonString
+    
+} // Jsonu-tils

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -23,12 +23,16 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribut
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
+import com.telefonica.iot.cygnus.utils.JsonUtils;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import org.apache.flume.Context;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 
 /**
  *
@@ -37,15 +41,11 @@ import org.apache.flume.Context;
 public class NGSICartoDBSink extends NGSISink {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(NGSICartoDBSink.class);
-    private String host;
-    private String port;
-    private boolean ssl;
-    private String apiKey;
+    private String keysConfFile;
     private boolean flipCoordinates;
     protected boolean enableRaw;
     protected boolean enableDistance;
-    private String schema;
-    private CartoDBBackendImpl backend;
+    private HashMap<String, CartoDBBackendImpl> backends;
     
     /**
      * Constructor.
@@ -58,66 +58,37 @@ public class NGSICartoDBSink extends NGSISink {
      * Gets the CartoDB backend. It is protected since it is only used by the tests.
      * @return The CartoDB backend
      */
-    protected CartoDBBackendImpl getBackend() {
-        return backend;
-    } // getBackend
+    protected HashMap<String, CartoDBBackendImpl> getBackends() {
+        return backends;
+    } // getBackends
+    
+    /**
+     * Sets the CartoDB backend. It is protected since it is only used by the tests.
+     * @param backends
+     */
+    protected void setBackends(HashMap<String, CartoDBBackendImpl> backends) {
+        this.backends = backends;
+    } // setBackends
     
     @Override
     public void configure(Context context) {
         // Read NGSISink general configuration
         super.configure(context);
         
-        // Impose enable ower case, since PostgreSQL only accepts lower case
+        // Impose enable lower case, since PostgreSQL only accepts lower case
         enableLowercase = true;
         
-        // Read NGSICartoDB specific configuration
-        String endpoint = context.getString("endpoint");
+        // Read other configuration parameters
+        keysConfFile = context.getString("keys_conf_file");
         
-        if (endpoint == null) {
+        if (keysConfFile == null) {
             invalidConfiguration = true;
-            LOGGER.error("[" + this.getName() + "] Invalid configuration (endpoint=null) -- Must not be empty");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (keys_conf_file=null) "
+                    + "-- Must not be empty");
             return;
         } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (endpoint=" + endpoint + ")");
-        } // else
-        
-        int index;
-        
-        if (endpoint.startsWith("http://")) {
-            port = "80";
-            ssl = false;
-            index = 7;
-        } else if (endpoint.startsWith("https://")) {
-            port = "443";
-            ssl = true;
-            index = 8;
-        } else {
-            invalidConfiguration = true;
-            LOGGER.error("[" + this.getName() + "] Invalid configuration (endpoint=" + endpoint + ") "
-                    + "-- The URI must use the http or https schemes");
-            return;
-        } // if else
-        
-        String hostPort = endpoint.substring(index);
-        String[] split = hostPort.split(":");
-        
-        if (split.length == 2) {
-            host = split[0];
-            port = split[1];
-        } else {
-            host = split[0];
-        } // if else
-        
-        apiKey = context.getString("api_key");
-        String[] split2 = host.split("\\.");
-        schema = split2[0];
-        
-        if (apiKey == null) {
-            invalidConfiguration = true;
-            LOGGER.error("[" + this.getName() + "] Invalid configuration (apiKey=null) -- Must not be empty");
-            return;
-        } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (apiKey=" + apiKey + ")");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (keys_conf_file="
+                    + keysConfFile + ")");
         } // if else
         
         String flipCoordinatesStr = context.getString("flip_coordinates", "false");
@@ -130,6 +101,7 @@ public class NGSICartoDBSink extends NGSISink {
             invalidConfiguration = true;
             LOGGER.error("[" + this.getName() + "] Invalid configuration (flip_coordinates="
                     + flipCoordinatesStr + ") -- Must be 'true' or 'false'");
+            return;
         } // if else
         
         String enableRawStr = context.getString("enable_raw", "true");
@@ -142,6 +114,7 @@ public class NGSICartoDBSink extends NGSISink {
             invalidConfiguration = true;
             LOGGER.error("[" + this.getName() + "] Invalid configuration (enable_raw="
                     + enableRawStr + ") -- Must be 'true' or 'false'");
+            return;
         } // if else
 
         String enableDistanceStr = context.getString("enable_distance", "false");
@@ -160,15 +133,91 @@ public class NGSICartoDBSink extends NGSISink {
     @Override
     public void start() {
         try {
-            // create the persistence backend
-            backend = new CartoDBBackendImpl(host, port, ssl, apiKey);
+            initializeBackend();
             LOGGER.debug("[" + this.getName() + "] CartoDB persistence backend created");
         } catch (Exception e) {
-            LOGGER.error("Error while creating the CartoDB persistence backend. Details: " + e.getMessage());
+            backends = null;
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Error while creating the CartoDB persistence backend. Details: "
+                    + e.getMessage());
         } // try catch
 
         super.start();
     } // start
+    
+    private void initializeBackend() throws Exception {
+        // Read the keys file
+        String jsonStr = JsonUtils.readJsonFile(keysConfFile);
+        LOGGER.info("[" + this.getName() + "] Json containing CartoDB API keys has been read");
+
+        // Parse the Json containing the keys
+        JSONArray apiKeys = (JSONArray) JsonUtils.parseJsonString(jsonStr).get("cartodb_keys");
+        LOGGER.info("[" + this.getName() + "] Json containing CartoDB API keys is syntactically OK");
+
+        // Create the persistence backend
+        backends = new HashMap<String, CartoDBBackendImpl>();
+
+        // Iterate on the JSONObject containing the API keys
+        for (Object apiKey : apiKeys) {
+            JSONObject obj = (JSONObject) apiKey;
+            String endpoint = (String) obj.get("endpoint");
+
+            if (endpoint == null || endpoint.isEmpty()) {
+                LOGGER.warn("Invalid API key entry, endpoint is null or empty. Discarding it.");
+                continue;
+            } // if
+
+            String host;
+            String port;
+            boolean ssl;
+            int index;
+
+            if (endpoint.startsWith("http://")) {
+                port = "80";
+                ssl = false;
+                index = 7;
+            } else if (endpoint.startsWith("https://")) {
+                port = "443";
+                ssl = true;
+                index = 8;
+            } else {
+                LOGGER.warn("Invalid API key entry, the endpoint URI must use the http or https schemes. "
+                        + "Discarding it.");
+                continue;
+            } // if else
+
+            String hostPort = endpoint.substring(index);
+            String[] split = hostPort.split(":");
+
+            if (split.length == 2) {
+                host = split[0];
+                port = split[1];
+            } else {
+                host = split[0];
+            } // if else
+
+            String username = (String) obj.get("username");
+
+            if (username == null || username.isEmpty()) {
+                LOGGER.warn("[" + this.getName() + "] Invalid API key entry, username is null or empty. "
+                        + "Discarding it.");
+                continue;
+            } // if
+
+            String key = (String) obj.get("key");
+
+            if (key == null || key.isEmpty()) {
+                LOGGER.warn("[" + this.getName() + "] Invalid API key entry, key is null or empty. Discarding it.");
+                continue;
+            } // if
+
+            backends.put(username, new CartoDBBackendImpl(host, port, ssl, key));
+        } // for
+        
+        if (backends.isEmpty()) {
+            throw new Exception("All the API key entries were discarded");
+        } // if
+    } // initializeBackend
 
     @Override
     void persistBatch(NGSIBatch batch) throws Exception {
@@ -176,7 +225,7 @@ public class NGSICartoDBSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
         } // if
-
+        
         // iterate on the destinations, for each one a single create / append will be performed
         for (String destination : batch.getDestinations()) {
             LOGGER.debug("[" + this.getName() + "] Processing sub-batch regarding the " + destination
@@ -221,12 +270,12 @@ public class NGSICartoDBSink extends NGSISink {
         private String servicePath;
         private String entity;
         private String attribute;
-        private String dbName;
+        private String schemaName;
         private String tableName;
         
-        public String getDbName() {
-            return dbName;
-        } // getDbName
+        public String getSchemaName() {
+            return schemaName;
+        } // getSchemaName
         
         public String getTableName() {
             return tableName;
@@ -304,7 +353,7 @@ public class NGSICartoDBSink extends NGSISink {
             servicePath = event.getServicePath();
             entity = event.getEntity();
             attribute = event.getAttribute();
-            //dbName = buildDbName(service);
+            schemaName = buildSchemaName(service);
             tableName = buildTableName(servicePath, entity, attribute);
             
             // aggregation initialization
@@ -387,76 +436,21 @@ public class NGSICartoDBSink extends NGSISink {
         
     } // CartoDBAggregator
     
-    /*
-    private String buildDbName(String service) throws Exception {
-        String name = NGSIUtils.encodePostgreSQL(service, false);
-
-        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
-            throw new CygnusBadConfiguration("Building database name '" + name
-                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
-        } // if
-
-        return name;
-    } // buildDbName
-    */
-    
-    /**
-     * Builds a table name for CartoDB given a service path, an entity and an attribute.
-     * @param servicePath
-     * @param entity
-     * @param attribute
-     * @return The table name for CartoDB
-     * @throws Exception
-     */
-    protected String buildTableName(String servicePath, String entity, String attribute) throws Exception {
-        String name;
-        
-        switch(dataModel) {
-            case DMBYSERVICEPATH:
-                if (servicePath.equals("/")) {
-                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
-                            + "dm-by-service-path data model");
-                } // if
-
-                name = NGSIUtils.encodePostgreSQL(servicePath, true);
-                break;
-            case DMBYENTITY:
-                String truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
-                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
-                        + NGSIUtils.encodePostgreSQL(entity, false);
-                break;
-            case DMBYATTRIBUTE:
-                truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
-                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
-                        + NGSIUtils.encodePostgreSQL(entity, false)
-                        + '_' + NGSIUtils.encodePostgreSQL(attribute, false);
-                break;
-            default:
-                throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
-                        + "'. Please, use DMBYSERVICEPATH, DMBYENTITY or DMBYATTRIBUTE");
-        } // switch
-        
-        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
-            throw new CygnusBadConfiguration("Building table name '" + name
-                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
-        } // if
-
-        return name;
-    } // buildTableName
-    
     private void persistRawAggregation(CartoDBAggregator aggregator) throws Exception {
         //String dbName = aggregator.getDbName(); // enable_lowercase is unncessary, PostgreSQL is case insensitive
         String tableName = aggregator.getTableName(); // enable_lowercase is unncessary, PostgreSQL is case insensitive
+        String schema = aggregator.getSchemaName();
         String withs = "";
         String fields = aggregator.getFields();
         String rows = aggregator.getRows();
         LOGGER.info("[" + this.getName() + "] Persisting data at NGSICartoDBSink. Schema (" + schema
                 + "), Table (" + tableName + "), Data (" + rows + ")");
-        backend.insert(tableName, withs, fields, rows);
+        backends.get(schema).insert(schema, tableName, withs, fields, rows);
     } // persistRawAggregation
     
     private void persistDistanceEvent(NGSIEvent event) throws Exception {
         // Get some values
+        String schema = buildSchemaName(event.getService());
         String servicePath = event.getServicePath();
         String entityId = event.getContextElement().getId();
         String entityType = event.getContextElement().getType();
@@ -474,8 +468,7 @@ public class NGSICartoDBSink extends NGSISink {
             String attrValue = contextAttribute.getContextValue(false);
             String attrMetadata = contextAttribute.getContextMetadata();
             String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadata, flipCoordinates);
-            String tableName = schema
-                    + "." + buildTableName(event.getServicePath(), event.getEntity(), event.getAttribute())
+            String tableName = buildTableName(event.getServicePath(), event.getEntity(), event.getAttribute())
                     + "_distance";
 
             if (location.startsWith("ST_SetSRID(ST_MakePoint(")) {
@@ -488,7 +481,7 @@ public class NGSICartoDBSink extends NGSISink {
                             + "sumTime float, sumSpeed float, sum2Distance float, sum2Time float, sum2Speed float, "
                             + "maxDistance float, minDistance float, maxTime float, minTime float, maxSpeed float, "
                             + "minSpeed float, numSamples bigint)";
-                    backend.createTable(schema, tableName, typedFields);
+                    backends.get(schema).createTable(schema, tableName, typedFields);
                     
                     // Once created, insert the first row
                     String withs = "";
@@ -501,7 +494,7 @@ public class NGSICartoDBSink extends NGSISink {
                             + ",1)";
                     LOGGER.info("[" + this.getName() + "] Persisting data at NGSICartoDBSink. Schema (" + schema
                             + "), Table (" + tableName + "), Data (" + rows + ")");
-                    backend.insert(tableName, withs, fields, rows);
+                    backends.get(schema).insert(schema, tableName, withs, fields, rows);
                 } catch (Exception e) {
                     String withs = ""
                             + "WITH geom AS ("
@@ -574,10 +567,65 @@ public class NGSICartoDBSink extends NGSISink {
                             + "(SELECT num_samples FROM inserts))";
                     LOGGER.info("[" + this.getName() + "] Persisting data at NGSICartoDBSink. Schema (" + schema
                             + "), Table (" + tableName + "), Data (" + rows + ")");
-                    backend.insert(tableName, withs, fields, rows);
+                    backends.get(schema).insert(schema, tableName, withs, fields, rows);
                 } // try catch
             } // if
         } // for
     } // persistDistanceEvent
+    
+    protected String buildSchemaName(String service) throws Exception {
+        String name = NGSIUtils.encodePostgreSQL(service, false);
+
+        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
+            throw new CygnusBadConfiguration("Building schema name '" + name
+                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
+        } // if
+
+        return name;
+    } // buildSchemaName
+    
+    /**
+     * Builds a table name for CartoDB given a service path, an entity and an attribute.
+     * @param servicePath
+     * @param entity
+     * @param attribute
+     * @return The table name for CartoDB
+     * @throws Exception
+     */
+    protected String buildTableName(String servicePath, String entity, String attribute) throws Exception {
+        String name;
+        
+        switch(dataModel) {
+            case DMBYSERVICEPATH:
+                if (servicePath.equals("/")) {
+                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
+                            + "dm-by-service-path data model");
+                } // if
+
+                name = NGSIUtils.encodePostgreSQL(servicePath, true);
+                break;
+            case DMBYENTITY:
+                String truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                        + NGSIUtils.encodePostgreSQL(entity, false);
+                break;
+            case DMBYATTRIBUTE:
+                truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
+                        + NGSIUtils.encodePostgreSQL(entity, false)
+                        + '_' + NGSIUtils.encodePostgreSQL(attribute, false);
+                break;
+            default:
+                throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
+                        + "'. Please, use DMBYSERVICEPATH, DMBYENTITY or DMBYATTRIBUTE");
+        } // switch
+        
+        if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
+            throw new CygnusBadConfiguration("Building table name '" + name
+                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_ID_LEN);
+        } // if
+
+        return name;
+    } // buildTableName
     
 } // NGSICartoDBSink

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -25,6 +25,9 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextMetadata
 import com.telefonica.iot.cygnus.sinks.NGSICartoDBSink.CartoDBAggregator;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import org.apache.flume.Context;
 import org.apache.flume.channel.MemoryChannel;
@@ -32,7 +35,9 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -40,99 +45,15 @@ import org.junit.Test;
  */
 public class NGSICartoDBSinkTest {
     
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    
     /**
      * Constructor.
      */
     public NGSICartoDBSinkTest() {
         LogManager.getRootLogger().setLevel(Level.FATAL);
     } // NGSICartoDBSinkTest
-    
-    /**
-     * [NGSICartoDBSink.configure] -------- Configured 'endpoint' cannot be null.
-     */
-    @Test
-    public void testConfigureEndpointIsNotNull() {
-        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured 'endpoint' cannot be null");
-        String endpoint = null;
-        String apiKey = "1234567890abcdef";
-        String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String enableDistance = null; // default one
-        NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
-        
-        try {
-            assertTrue(sink.invalidConfiguration);
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - null value detected for 'endpoint'");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - null value not detected for 'endpoint'");
-            throw e;
-        } // try catch
-    } // testConfigureEndpointIsNotNull
-    
-    /**
-     * [NGSICartoDBSink.configure] -------- Configured 'endpoint' must be a URI using the 'http' or 'https' schema.
-     */
-    @Test
-    public void testConfigureEndpointUsesHttpSchema() {
-        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured 'endpoint' must be a URI using the 'http' or 'https' schema");
-        String endpoint = "localhost:443";
-        String apiKey = "1234567890abcdef";
-        String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String enableDistance = null; // default one
-        NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
-        
-        try {
-            assertTrue(sink.invalidConfiguration);
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - Invalid or inexistent schema detected for 'endpoint'");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - Invalid or inexistent schema not detected for 'endpoint'");
-            throw e;
-        } // try catch
-    } // testConfigureEndpointIsNotNull
-    
-    /**
-     * [NGSICartoDBSink.configure] -------- Configured 'api_key' cannot be null.
-     */
-    @Test
-    public void testConfigureApiKeyIsNotNull() {
-        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured 'api_key' cannot be null");
-        String endpoint = "https://localhost";
-        String apiKey = null;
-        String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String enableDistance = null; // default one
-        NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
-        
-        try {
-            assertTrue(sink.invalidConfiguration);
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - null value detected for 'api_key'");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - null value not detected for 'api_key'");
-            throw e;
-        } // try catch
-    } // testConfigureApiKeyIsNotNull
     
     /**
      * [NGSICartoDBSink.configure] -------- Independently of the configured value, enable_lowercase is always 'true'
@@ -149,9 +70,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -178,9 +100,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = "falso";
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -207,9 +130,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default value
         String enableRaw = "falso";
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -235,10 +159,11 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
+        String keysConfFile = "/keys.conf";
         String enableDistance = "falso";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -252,12 +177,56 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableDistanceOK
     
     /**
-     * [NGSICartoDBSink.start] -------- When started, a CartoDB backend is created.
+     * [NGSICartoDBSink.configure] -------- Configured `keys_conf_file` cannot be empty.
+     */
+    @Test
+    public void testConfigureKeysConfFileOK() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured `keys_conf_file` cannot be empty");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default_one
+        String keysConfFile = null; // empty file
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_distance=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_distance=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureKeysConfFileOK
+    
+    /**
+     * [NGSICartoDBSink.start] -------- When started, a CartoDB backend is created from a valid keys file.
      */
     @Test
     public void testStartBackendCreated() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
-                + "-------- When started, a CartoDB backend is created");
+                + "-------- When started, a CartoDB backend is created from a valid keys file");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"endpoint\":\"http://frb.com\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
@@ -265,14 +234,15 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
         try {
-            assertTrue(sink.getBackend() != null);
+            assertTrue(sink.getBackends() != null);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
                     + "-  OK  - A CartoDB backend has been created");
         } catch (AssertionError e) {
@@ -282,6 +252,376 @@ public class NGSICartoDBSinkTest {
         } // try catch
     } // testStartBackendCreated
     
+    /**
+     * [NGSICartoDBSink.start] -------- Username field must appear within an entry in the keys file.
+     */
+    @Test
+    public void testStartUsernameNotNullKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Username field must appear within an entry in the keys file");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"endpoint\":\"http://frb.com\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Null username has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Null username has not been detected");
+            throw e;
+        } // try catch
+    } // testStartUsernameNotNullKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Username within an entry in the keys file cannot be empty.
+     */
+    @Test
+    public void testStartUsernameNotEmptyKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Username within an entry in the keys file cannot be empty");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"\",\"endpoint\":\"http://frb.com\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Empty username has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Empty username has not been detected");
+            throw e;
+        } // try catch
+    } // testStartUsernameNotEmptyKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Endpoint field must appear within an entry in the keys file.
+     */
+    @Test
+    public void testStartEndpointNotNullKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Endpoint field must appear within an entry in the keys file");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Null endpoint has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Null endpoint has not been detected");
+            throw e;
+        } // try catch
+    } // testStartEndpointNotNullKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Endpoint within an entry in the keys file cannot be empty.
+     */
+    @Test
+    public void testStartEndpointNotEmptyKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Endpoint within an entry in the keys file cannot be empty");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"endpoint\":\"\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Empty endpoint has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Empty endpoint has not been detected");
+            throw e;
+        } // try catch
+    } // testStartEndpointNotEmptyKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Endpoint within an entry in the keys file must be a URI using the http or
+     * https schema.
+     */
+    @Test
+    public void testStartEndpointSchemaOKKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Endpoint within an entry in the keys file must be a URI using the http or https schema");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"endpoint\":\"htt://frb.com\",\"key\":\"xxx\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Invalid 'htt' schema in the endpoint has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Invalid 'htt' schema in the endpoint has not been detected");
+            throw e;
+        } // try catch
+    } // testStartEndpointSchemaOKKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Key field must appear within an entry in the keys file.
+     */
+    @Test
+    public void testStartKeyNotNullKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Key field must appear within an entry in the keys file");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"endpoint\":\"http://frb.com\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Null key has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Null key has not been detected");
+            throw e;
+        } // try catch
+    } // testStartKeyNotNullKeysFile
+    
+    /**
+     * [NGSICartoDBSink.start] -------- Key within an entry in the keys file cannot be empty.
+     */
+    @Test
+    public void testStartKeyNotEmptyKeysFile() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                + "-------- Key within an entry in the keys file cannot be empty");
+        File file;
+        
+        try {
+            file = folder.newFile("keys.conf");
+            PrintWriter out = new PrintWriter(file);
+            out.println("{\"cartodb_keys\":[{\"username\":\"frb\",\"endpoint\":\"http://frb.com\",\"key\":\"\"}]}");
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - There was some problem when mocking the keys file");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = file.getAbsolutePath();
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        sink.setChannel(new MemoryChannel());
+        sink.start();
+        
+        try {
+            assertEquals(null, sink.getBackends());
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "-  OK  - Empty key has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.start]")
+                    + "- FAIL - Empty key has not been detected");
+            throw e;
+        } // try catch
+    } // testStartKeyNotEmptyKeysFile
+    
+    /**
+     * [NGSICartoDBSink.buildSchemaName] -------- The schema name is equals to the notified/defaulted service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildSchemaName() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
+                + "-------- The schema name is equals to the notified/defaulted service");
+        String endpoint = "https://localhost";
+        String apiKey = "1234567890abcdef";
+        String dataModel = null; // default one
+        String enableLowercase = null; // default one
+        String flipCoordinates = null; // default one
+        String enableRaw = null; // default one
+        String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
+                enableDistance, keysConfFile));
+        String service = "someService";
+        
+        try {
+            String builtSchemaName = sink.buildSchemaName(service);
+        
+            try {
+                assertEquals("someservice", builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
+                        + "-  OK  - '" + builtSchemaName + "' is equals to the lower case of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
+                        + "- FAIL - '" + builtSchemaName + "' is not equals to the lower case of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
+                    + "- FAIL - There was some problem when building the schema name");
+            throw e;
+        } // try catch
+    } // testBuildSchemaName
+
     /**
      * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted and
      * data_model is 'dm-by-service-path' the CartoDB table name is lower case of <service-path>.
@@ -299,9 +639,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -343,9 +684,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId_someType";
         String attribute = null; // irrelevant for this test
@@ -390,9 +732,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId_someType";
         String attribute = "someName1_someType1";
@@ -435,9 +778,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -472,9 +816,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/";
         String entity = "someId_someType";
         String attribute = null; // irrelevant for this test
@@ -519,9 +864,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         String servicePath = "/";
         String entity = "someId_someType";
         String attribute = "someName1_someType1";
@@ -565,9 +911,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -621,9 +968,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -696,9 +1044,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -773,9 +1122,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -856,9 +1206,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = null; // default one
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -922,9 +1273,10 @@ public class NGSICartoDBSinkTest {
         String flipCoordinates = "true";
         String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance));
+                enableDistance, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -960,7 +1312,7 @@ public class NGSICartoDBSinkTest {
     } // testAggregateCoordinatesAreFlipped
     
     private Context createContext(String endpoint, String apiKey, String dataModel, String enableLowercase,
-            String flipCoordinates, String enableRaw, String enableDistance) {
+            String flipCoordinates, String enableRaw, String enableDistance, String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("batch_size", "100");
@@ -973,6 +1325,7 @@ public class NGSICartoDBSinkTest {
         context.put("enable_raw", enableRaw);
         context.put("endpoint", endpoint);
         context.put("flip_coordinates", flipCoordinates);
+        context.put("keys_conf_file", keysConfFile);
         return context;
     } // createContext
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -78,10 +78,10 @@ public class NGSICartoDBSinkTest {
         try {
             assertTrue(sink.enableLowercase);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'enable_lowercase=false' was confiured, nevertheless it is always true by default");
+                    + "-  OK  - 'enable_lowercase=false' was configured, nevertheless it is always true by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_lowercase=false' was confiured and it is really false");
+                    + "- FAIL - 'enable_lowercase=false' was configured and it is really false");
             throw e;
         } // try catch
     } // testConfigureEnableLowercaseAlwaysTrue

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -87,12 +87,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableLowercaseAlwaysTrue
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured `flip_coordinates` cannot be different than `true` or `false`.
+     * [NGSICartoDBSink.configure] -------- Configured 'flip_coordinates' cannot be different than 'true' or 'false'.
      */
     @Test
     public void testConfigureFlipCoordinatesOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured `flip_coordinates` cannot be different than `true` or `false`");
+                + "-------- Configured 'flip_coordinates' cannot be different than 'true' or 'false'");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
@@ -117,12 +117,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureFlipCoordinatesOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured `enable_raw` cannot be different than `true` or `false`.
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_raw' cannot be different than 'true' or 'false'.
      */
     @Test
     public void testConfigureEnableRawOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured `enable_raw` cannot be different than `true` or `false`");
+                + "-------- Configured 'enable_raw' cannot be different than 'true' or 'false'");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
@@ -147,12 +147,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableRawOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured `enable_distance` cannot be different than `true` or `false`.
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_distance' cannot be different than 'true' or 'false'.
      */
     @Test
     public void testConfigureEnableDistanceOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured `enable_distance` cannot be different than `true` or `false`");
+                + "-------- Configured 'enable_distance' cannot be different than 'true' or 'false'");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
@@ -177,12 +177,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableDistanceOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured `keys_conf_file` cannot be empty.
+     * [NGSICartoDBSink.configure] -------- Configured 'keys_conf_file' cannot be empty.
      */
     @Test
     public void testConfigureKeysConfFileOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured `keys_conf_file` cannot be empty");
+                + "-------- Configured 'keys_conf_file' cannot be empty");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = null; // default one
@@ -198,10 +198,10 @@ public class NGSICartoDBSinkTest {
         try {
             assertTrue(sink.invalidConfiguration);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'enable_distance=falso' was detected");
+                    + "-  OK  - Empty 'keys_conf_file' was detected");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_distance=falso' was not detected");
+                    + "- FAIL - Empty 'keys_conf_file' was not detected");
             throw e;
         } // try catch
     } // testConfigureKeysConfFileOK


### PR DESCRIPTION
* Implements issue #1028 
* 100% unit tests passed:
```
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-common
Tests run: 91, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-ngsi
```

Relevant tests for this PR:
```
[NGSICartoDBSink.start] ------------------------- Username field must appear within an entry in the keys file
[NGSICartoDBSink.start] ------------------  OK  - Null username has been detected
[NGSICartoDBSink.start] ------------------------- Username within an entry in the keys file cannot be empty
[NGSICartoDBSink.start] ------------------  OK  - Empty username has been detected
[NGSICartoDBSink.start] ------------------------- Endpoint within an entry in the keys file cannot be empty
[NGSICartoDBSink.start] ------------------  OK  - Empty endpoint has been detected
[NGSICartoDBSink.start] ------------------------- When started, a CartoDB backend is created from a valid keys file
[NGSICartoDBSink.start] ------------------  OK  - A CartoDB backend has been created
[NGSICartoDBSink.start] ------------------------- Key within an entry in the keys file cannot be empty
[NGSICartoDBSink.start] ------------------  OK  - Empty key has been detected
[NGSICartoDBSink.start] ------------------------- Key field must appear within an entry in the keys file
[NGSICartoDBSink.start] ------------------  OK  - Null key has been detected
[NGSICartoDBSink.start] ------------------------- Endpoint field must appear within an entry in the keys file
[NGSICartoDBSink.start] ------------------  OK  - Null endpoint has been detected
[NGSICartoDBSink.start] ------------------------- Endpoint within an entry in the keys file must be a URI using the http or https schema
[NGSICartoDBSink.start] ------------------  OK  - Invalid 'htt' schema in the endpoint has been detected
[NGSICartoDBSink.configure] --------------------- Configured `keys_conf_file` cannot be empty
[NGSICartoDBSink.configure] --------------  OK  - Empty 'keys_conf_file' was detected
```
* (unofficial) e2e tests passed:

Interesting logs at inititialization:
```
time=2016-05-20T12:00:35.273CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=initializeBackend | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[151] : [distance-sink] Json containing CartoDB API keys has been read
time=2016-05-20T12:00:35.283CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=initializeBackend | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[155] : [distance-sink] Json containing CartoDB API keys is syntactically OK
```

Received notitification:
```
time=2016-05-20T12:00:53.995CEST | lvl=INFO | corr=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | trans=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | svc=myuser | subsvc=/ | function=getEvents | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[264] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.8104, -3.460002",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "Car",        "isPattern" : "false",        "id" : "Car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
```

Persistence logs:
```
time=2016-05-20T12:01:07.416CEST | lvl=INFO | corr=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | trans=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | svc=myuser | subsvc=/ | function=persistDistanceEvent | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[568] : [distance-sink] Persisting data at NGSICartoDBSink. Schema (myuser), Table (car1_car_distance), Data ((1463738454013,'/','Car1','Car',(SELECT point FROM geom),(SELECT stage_distance FROM calcs),(SELECT stage_time FROM calcs),(SELECT stage_speed FROM speed),(SELECT sum_dist FROM inserts),(SELECT sum_time FROM inserts),(SELECT sum_speed FROM inserts),(SELECT sum2_dist FROM inserts),(SELECT sum2_time FROM inserts),(SELECT sum2_speed FROM inserts),(SELECT max_distance FROM inserts),(SELECT min_distance FROM inserts),(SELECT max_time FROM inserts),(SELECT min_time FROM inserts),(SELECT max_speed FROM inserts),(SELECT min_speed FROM inserts),(SELECT num_samples FROM inserts)))
time=2016-05-20T12:01:07.871CEST | lvl=INFO | corr=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | trans=3fc4c457-ea8b-49a8-b010-12d79aad7a8e | svc=myuser | subsvc=/ | function=processNewBatches | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSISink[400] : Finishing internal transaction (3fc4c457-ea8b-49a8-b010-12d79aad7a8e)
```

* Assignee @pcoello25 but LGTM from @gtorodelvalle is also required