### PR TITLE
bug/1034_v2_subs_without_subscription_field_fails

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [cygnus-ngsi] [feature] Add distance analysis support to NGSICartoDBSink (#1026)
 - [cygnus-ngsi] [feature] Add multitenancy support to NGSICartoDBSink (#1028)
 - [cygnus-ngsi] [hardening] Remove data model by attribute support in NGSICartoDBSink (#1030)
+- [cygnus-common] [bug] Fixed error when POST a CygnusSubscription without subscription field (#1034)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/containers/CygnusSubscriptionV2.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/containers/CygnusSubscriptionV2.java
@@ -61,9 +61,7 @@ public class CygnusSubscriptionV2 {
             // check error messages from subfields of subscription 
             int subjectMsg = isSubjectValid(subject);
             int notificationMsg = isNotificationValid(notification);
-            
-            LOGGER.info("subject: " + subjectMsg + ", notification: " + notificationMsg);
-                        
+                                    
             // check if entire subscription is emtpy        
             if ((description == null) && (subjectMsg == 11) && 
                     (notificationMsg == 1) &&  (expires == null)
@@ -194,9 +192,7 @@ public class CygnusSubscriptionV2 {
             // get error numbers of each field
             int conditionMsg = isConditionValid(condition);
             int entitiesMsg = isEntitiesValid(entities);
-            
-            LOGGER.info("conditions: " + conditionMsg + ", entities: " + entitiesMsg);
-                        
+                                    
             if ((conditionMsg == 1) && (entitiesMsg == 1)) {
                 LOGGER.debug("Field 'subject' is empty");
                 return 12;
@@ -253,9 +249,7 @@ public class CygnusSubscriptionV2 {
         } // isSubjectsValid
         
         private int isNotificationValid (Notification notification) {
-            
-            LOGGER.info(notification);
-            
+                        
             if (notification == null) {
                 LOGGER.debug("Field 'notification' is missing");
                 return 1;
@@ -264,13 +258,8 @@ public class CygnusSubscriptionV2 {
             SubscriptionHttp http = notification.getHttp();
             ArrayList<String> attrs = notification.getAttrs();
             
-            LOGGER.info(http == null);
-            LOGGER.info("http: " + http.toString());
-            
             int httpMsg = isHttpValid(http); 
-            
-            LOGGER.info("httpMessage: " + httpMsg);
-            
+                        
             if ((attrs == null) || (httpMsg == 1)){
                 LOGGER.debug("Field 'notification' has missing fields");
                 return 2;
@@ -343,15 +332,11 @@ public class CygnusSubscriptionV2 {
                 String type = entity.getEntityType();
                 String isPattern = entity.getIdPattern();
                 
-                LOGGER.info("type: " + type + ", pattern: " + isPattern);
-
                 validFields &= ((type != null) && (isPattern != null));
                 emptyFields &= validFields && ((type.length() == 0) || 
                         (isPattern.length() == 0)); 
             } // for
             
-            LOGGER.info("ENTITIES: Valid: " + validFields + ", empty: " + emptyFields);
-
             // check if entities contains all the required fields
             if (!validFields) {
                 LOGGER.debug("There are missing fields in entities");
@@ -491,8 +476,6 @@ public class CygnusSubscriptionV2 {
         int subscriptionMsg = orionSubscription.isValid();  
         int endpointMsg = orionEndpoint.isValid();
         
-        LOGGER.info("Subs: " + subscriptionMsg + ", Endpoint: " + endpointMsg);
-
         switch (subscriptionMsg) {
             // case of missing entire subscription
             case 11:

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -1315,6 +1315,11 @@ public class ManagementInterface extends AbstractHandler {
             // cases of missing endpoint or subscription
             case 11:
                 response.getWriter().println("{\"success\":\"false\","
+                        + "\"error\":\"Empty subscription\"}");
+                LOGGER.error("Empty subscription");
+                return;
+            case 12:
+                response.getWriter().println("{\"success\":\"false\","
                         + "\"error\":\"Missing subscription\"}");
                 LOGGER.error("Missing subscription");
                 return;


### PR DESCRIPTION
* Fix issue #1034 
* 100% Unit tests passed: 
```
Results :
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0   [CYGNUS-COMMON]
Tests run: 91, Failures: 0, Errors: 0, Skipped: 0   [CYGNUS-NGSI]
```
* e2e (unofficial) test: (There was an error between "empty" and "missing". Fixed)
```
$ curl -X POST "http://localhost:8081/v1/subscriptions?ngsi_version=2" -d '{"endpoint":{"host":"orion.lab.fiware.org","port":"1026","ssl":"false","xauthtoken":"QsENv67AJj7blC2qJ0YvfSc5hMWYrs"}}'
{"success":"false","error":"Missing subscription"}

$ curl -X POST "http://localhost:8081/v1/subscriptions?ngsi_version=2" -d '{"subscription":{},"endpoint":{"host":"orion.lab.fiware.org","port":"1026","ssl":"false","xauthtoken":"QsENv67AJj7blC2qJ0YvfSc5hMWYrs"}}' 
{"success":"false","error":"Empty subscription"}
```
* Assignee: @frbattid 