### PR TITLE
hardening/808_add_tests_for_delete_subscriptions

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -823,7 +823,7 @@ public class ManagementInterface extends AbstractHandler {
         
     } // handlePostSubscription
     
-    private void handleDeleteSubscription(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void handleDeleteSubscription(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("json;charset=utf-8");
         
         String subscriptionId = request.getParameter("subscription_id");
@@ -878,6 +878,7 @@ public class ManagementInterface extends AbstractHandler {
         
         try {
             endpoint = gson.fromJson(endpointStr, OrionEndpoint.class);
+            response.setStatus(HttpServletResponse.SC_OK);
         } catch (JsonSyntaxException e) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().println("{\"success\":\"false\","


### PR DESCRIPTION
* Partially implements issue #808 
  * Update CHANGES_NEXT_RELEASE is not neccessary
    * `DELETE /v1/subscriptions?ngsi_version=<ngsi_version>&subscription_id=<subscription_id>` deletes a subscription
* 100% Unit tests passed:
```
[ManagementInterface] -------------------- 'DELETE method deletes a subscription (ngsi_version = 1)'.
[ManagementInterface] --------------------  OK  - Subscription deleted
[ManagementInterface] -------------------- 'DELETE method deletes a subscription (ngsi_version = 2)'.
[ManagementInterface] --------------------  OK  - Subscription deleted
```
* Assignee: @frbattid 