### PR TITLE
feature/1044_mongodb_sth_agent_docker

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -13,3 +13,4 @@
 - [cygnus-common] [bug] Fixed error when POST a CygnusSubscription without subscription field (#1034)
 - [cygnus] [doc] Update the sink docs regarding the naming conventions (#630)
 - [cygnus-ngsi] [hardening] Change default credentials for docker MySQL agent (#1038)
+- [cygnus-ngsi] [feature] Add MongoDB and STH sinks to docker agent (#1044)

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -33,6 +33,8 @@ ENV CYGNUS_SERVICE_PORT "5050"
 ENV CYGNUS_API_PORT "8081"
 ENV CYGNUS_MYSQL_USER "mysql"
 ENV CYGNUS_MYSQL_PASS "mysql"
+ENV CYGNUS_MONGO_USER "mongo"
+ENV CYGNUS_MONGO_PASS "mongo"
 
 ENV GIT_URL_CYGNUS "https://github.com/telefonicaid/fiware-cygnus.git"
 ENV GIT_REV_CYGNUS "develop"

--- a/docker/cygnus-ngsi/agent.conf
+++ b/docker/cygnus-ngsi/agent.conf
@@ -17,11 +17,11 @@
 #
 
 cygnus-ngsi.sources = http-source
-cygnus-ngsi.sinks = mysql-sink
-cygnus-ngsi.channels = mysql-channel
+cygnus-ngsi.sinks = mysql-sink mongo-sink sth-sink
+cygnus-ngsi.channels = mysql-channel mongo-channel sth-channel
 
-cygnus-ngsi.sources.http-source.channels = mysql-channel
 cygnus-ngsi.sources.http-source.type = org.apache.flume.source.http.HTTPSource
+cygnus-ngsi.sources.http-source.channels = mysql-channel mongo-channel sth-channel
 cygnus-ngsi.sources.http-source.port = 5050
 cygnus-ngsi.sources.http-source.handler = com.telefonica.iot.cygnus.handlers.NGSIRestHandler
 cygnus-ngsi.sources.http-source.handler.notification_target = /notify
@@ -32,8 +32,8 @@ cygnus-ngsi.sources.http-source.interceptors.ts.type = timestamp
 cygnus-ngsi.sources.http-source.interceptors.gi.type = com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder
 cygnus-ngsi.sources.http-source.interceptors.gi.grouping_rules_conf_file = /opt/apache-flume/conf/grouping_rules.conf
 
-cygnus-ngsi.sinks.mysql-sink.channel = mysql-channel
 cygnus-ngsi.sinks.mysql-sink.type = com.telefonica.iot.cygnus.sinks.NGSIMySQLSink
+cygnus-ngsi.sinks.mysql-sink.channel = mysql-channel
 cygnus-ngsi.sinks.mysql-sink.enable_grouping = false
 cygnus-ngsi.sinks.mysql-sink.enable_lowercase = false
 cygnus-ngsi.sinks.mysql-sink.mysql_host = mysql
@@ -46,7 +46,53 @@ cygnus-ngsi.sinks.mysql-sink.batch_size = 10
 cygnus-ngsi.sinks.mysql-sink.batch_timeout = 5
 cygnus-ngsi.sinks.mysql-sink.batch_ttl = 0
 
+cygnus-ngsi.sinks.mongo-sink.type = com.telefonica.iot.cygnus.sinks.NGSIMongoSink
+cygnus-ngsi.sinks.mongo-sink.channel = mongo-channel
+cygnus-ngsi.sinks.mongo-sink.enable_grouping = false
+cygnus-ngsi.sinks.mongo-sink.enable_lowercase = false
+cygnus-ngsi.sinks.mongo-sink.mongo_hosts = mongo:27017
+cygnus-ngsi.sinks.mongo-sink.mongo_username =
+cygnus-ngsi.sinks.mongo-sink.mongo_password =
+cygnus-ngsi.sinks.mongo-sink.db_prefix = sth_
+cygnus-ngsi.sinks.mongo-sink.collection_prefix = sth_
+cygnus-ngsi.sinks.mongo-sink.should_hash = false
+cygnus-ngsi.sinks.mongo-sink.data_model = dm-by-entity
+cygnus-ngsi.sinks.mongo-sink.attr_persistence = row
+cygnus-ngsi.sinks.mongo-sink.batch_size = 10
+cygnus-ngsi.sinks.mongo-sink.batch_timeout = 5
+cygnus-ngsi.sinks.mongo-sink.batch_ttl = 0
+cygnus-ngsi.sinks.mongo-sink.data_expiration = 0
+cygnus-ngsi.sinks.mongo-sink.collections_size = 0
+cygnus-ngsi.sinks.mongo-sink.max_documents = 0
+
+cygnus-ngsi.sinks.sth-sink.type = com.telefonica.iot.cygnus.sinks.NGSISTHSink
+cygnus-ngsi.sinks.sth-sink.channel = sth-channel
+cygnus-ngsi.sinks.sth-sink.enable_grouping = false
+cygnus-ngsi.sinks.sth-sink.enable_lowercase = false
+cygnus-ngsi.sinks.sth-sink.mongo_hosts = mongo:27017
+cygnus-ngsi.sinks.sth-sink.mongo_username =
+cygnus-ngsi.sinks.sth-sink.mongo_password =
+cygnus-ngsi.sinks.sth-sink.db_prefix = sth_
+cygnus-ngsi.sinks.sth-sink.collection_prefix = sth_
+cygnus-ngsi.sinks.sth-sink.should_hash = false
+cygnus-ngsi.sinks.sth-sink.data_model = dm-by-entity
+cygnus-ngsi.sinks.sth-sink.attr_persistence = row
+cygnus-ngsi.sinks.sth-sink.batch_size = 10
+cygnus-ngsi.sinks.sth-sink.batch_timeout = 5
+cygnus-ngsi.sinks.sth-sink.batch_ttl = 0
+cygnus-ngsi.sinks.sth-sink.data_expiration = 0
+cygnus-ngsi.sinks.sth-sink.collections_size = 0
+cygnus-ngsi.sinks.sth-sink.max_documents = 0
+
 cygnus-ngsi.channels.mysql-channel.type = com.telefonica.iot.cygnus.channels.CygnusMemoryChannel
 cygnus-ngsi.channels.mysql-channel.capacity = 1000
 cygnus-ngsi.channels.mysql-channel.transactionCapacity = 100
+
+cygnus-ngsi.channels.mongo-channel.type = com.telefonica.iot.cygnus.channels.CygnusMemoryChannel
+cygnus-ngsi.channels.mongo-channel.capacity = 1000
+cygnus-ngsi.channels.mongo-channel.transactionCapacity = 100
+
+cygnus-ngsi.channels.sth-channel.type = com.telefonica.iot.cygnus.channels.CygnusMemoryChannel
+cygnus-ngsi.channels.sth-channel.capacity = 1000
+cygnus-ngsi.channels.sth-channel.transactionCapacity = 100
 

--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -20,6 +20,10 @@
 # Change the MySQL user and password in the agent configuration file
 sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.mysql-sink.mysql_username/c '${CYGNUS_AGENT_NAME}'.sinks.mysql-sink.mysql_username = '${CYGNUS_MYSQL_USER} ${FLUME_HOME}/conf/agent.conf
 sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.mysql-sink.mysql_password/c '${CYGNUS_AGENT_NAME}'.sinks.mysql-sink.mysql_password = '${CYGNUS_MYSQL_PASS} ${FLUME_HOME}/conf/agent.conf
+sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.mongo-sink.mongo_username/c '${CYGNUS_AGENT_NAME}'.sinks.mongo-sink.mongo_username = '${CYGNUS_MONGO_USER} ${FLUME_HOME}/conf/agent.conf
+sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.mongo-sink.mongo_password/c '${CYGNUS_AGENT_NAME}'.sinks.mongo-sink.mongo_password = '${CYGNUS_MONGO_PASS} ${FLUME_HOME}/conf/agent.conf
+sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.sth-sink.mongo_username/c '${CYGNUS_AGENT_NAME}'.sinks.sth-sink.mongo_username = '${CYGNUS_MONGO_USER} ${FLUME_HOME}/conf/agent.conf
+sed -i '/'${CYGNUS_AGENT_NAME}'.sinks.sth-sink.mongo_password/c '${CYGNUS_AGENT_NAME}'.sinks.sth-sink.mongo_password = '${CYGNUS_MONGO_PASS} ${FLUME_HOME}/conf/agent.conf
 
 # Run the Cygnus command
 ${FLUME_HOME}/bin/cygnus-flume-ng agent --conf ${CYGNUS_CONF_PATH} -f ${CYGNUS_CONF_FILE} -n ${CYGNUS_AGENT_NAME} -p ${CYGNUS_API_PORT} -Dflume.root.logger=${CYGNUS_LOG_LEVEL},${CYGNUS_LOG_APPENDER}


### PR DESCRIPTION
* Implements issue #1044 
* Tests passed:
```
$ docker run -e CYGNUS_LOG_LEVEL='DEBUG' -e CYGNUS_MYSQL_USER='myuser' -e CYGNUS_MYSQL_PASS='mypass' -e CYGNUS_MONGO_USER='myotheruser' -e CYGNUS_MONGO_PASS='myotherpass' cygnus-ngsi
...
time=2016-05-25T06:32:32.708UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=getClass | comp=cygnus-ngsi | msg=org.apache.flume.sink.DefaultSinkFactory[61] : Sink type com.telefonica.iot.cygnus.sinks.NGSIMySQLSink is a custom type
time=2016-05-25T06:32:32.711UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMySQLSink[132] : [mysql-sink] Reading configuration (mysql_username=myuser)
time=2016-05-25T06:32:32.711UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMySQLSink[135] : [mysql-sink] Reading configuration (mysql_password=mypass)
...
time=2016-05-25T06:32:32.693UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=getClass | comp=cygnus-ngsi | msg=org.apache.flume.sink.DefaultSinkFactory[61] : Sink type com.telefonica.iot.cygnus.sinks.NGSIMongoSink is a custom type
time=2016-05-25T06:32:32.703UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink[109] : [mongo-sink] Reading configuration (mongo_username=myotheruser)
time=2016-05-25T06:32:32.703UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink[112] : [mongo-sink] Reading configuration (mongo_password=myotherpass)
...
time=2016-05-25T06:32:32.713UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=getClass | comp=cygnus-ngsi | msg=org.apache.flume.sink.DefaultSinkFactory[61] : Sink type com.telefonica.iot.cygnus.sinks.NGSISTHSink is a custom type
time=2016-05-25T06:32:32.715UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink[109] : [sth-sink] Reading configuration (mongo_username=myotheruser)
time=2016-05-25T06:32:32.715UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink[112] : [sth-sink] Reading configuration (mongo_password=myotherpass)
```
* Assignee @pcoello25 but LGTM from @AlvaroVega is also required