### PR TITLE
hardening/1049_detect_invalid_configuration_in_grouping_rules

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -15,3 +15,4 @@
 - [cygnus-ngsi] [hardening] Change default credentials for docker MySQL agent (#1038)
 - [cygnus-ngsi] [feature] Add MongoDB and STH sinks to docker agent (#1044)
 - [cygnus-ngsi] [hardening] Remove support to deprecated 'matching_table' parameter (#1048)
+- [cygnus-ngsi] [hardening] Add checks for invalid configuration in NGSIGroupingInterceptor.java (#1049)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
@@ -44,14 +44,14 @@ public class NGSIGroupingInterceptor implements Interceptor {
     private final String groupingRulesFileName;
     private CygnusGroupingRules groupingRules;
     private ConfigurationReader configurationReader;
-    private Boolean invalidConfiguration = false;
+    private boolean invalidConfiguration = false;
     
     /**
      * Constructor.
      * @param groupingRulesFileName
      * @param invalidConfiguration
      */
-    public NGSIGroupingInterceptor(String groupingRulesFileName, Boolean invalidConfiguration) {
+    public NGSIGroupingInterceptor(String groupingRulesFileName, boolean invalidConfiguration) {
         this.groupingRulesFileName = groupingRulesFileName;
         this.invalidConfiguration = invalidConfiguration;
     } // NGSIGroupingInterceptor
@@ -191,7 +191,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
      */
     public static class Builder implements Interceptor.Builder {
         private String groupingRulesFileName;
-        private Boolean invalidConfiguration;
+        private boolean invalidConfiguration;
  
         @Override
         public void configure(Context context) {
@@ -211,7 +211,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
             return new NGSIGroupingInterceptor(groupingRulesFileName, invalidConfiguration);
         } // build
         
-        protected Boolean getInvalidConfiguration() {
+        protected boolean getInvalidConfiguration() {
             return invalidConfiguration;
         }
         

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
@@ -172,14 +172,18 @@ public class NGSIGroupingInterceptor implements Interceptor {
  
     @Override
     public void close() {
-        configurationReader.signalForStop();
+        if (!invalidConfiguration) {
+            configurationReader.signalForStop();
         
-        try {
-            configurationReader.join();
-        } catch (InterruptedException e) {
-            LOGGER.error("There was a problem while joining the ConfigurationReader. Details: "
-                    + e.getMessage());
-        } // try catch
+            try {
+                 configurationReader.join();
+            } catch (InterruptedException e) {
+                 LOGGER.error("There was a problem while joining the ConfigurationReader. Details: "
+                        + e.getMessage());
+            } // try catch
+            
+        } // if
+        
     } // close
  
     /**
@@ -206,6 +210,11 @@ public class NGSIGroupingInterceptor implements Interceptor {
         public Interceptor build() {
             return new NGSIGroupingInterceptor(groupingRulesFileName, invalidConfiguration);
         } // build
+        
+        protected Boolean getInvalidConfiguration() {
+            return invalidConfiguration;
+        }
+        
     } // Builder
     
     /**

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
@@ -202,7 +202,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
                 LOGGER.debug("[gi] Reading configuration (grouping_rules_file=" + groupingRulesFileName + ")");
             } else {
                 invalidConfiguration = true;
-                LOGGER.debug("[gi] Grouping rules file cannot be empty");
+                LOGGER.debug("[gi] Grouping rules file cannot be empty or null");
             } // if else
         } // configure
  

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
@@ -44,13 +44,16 @@ public class NGSIGroupingInterceptor implements Interceptor {
     private final String groupingRulesFileName;
     private CygnusGroupingRules groupingRules;
     private ConfigurationReader configurationReader;
+    private Boolean invalidConfiguration = false;
     
     /**
      * Constructor.
      * @param groupingRulesFileName
+     * @param invalidConfiguration
      */
-    public NGSIGroupingInterceptor(String groupingRulesFileName) {
+    public NGSIGroupingInterceptor(String groupingRulesFileName, Boolean invalidConfiguration) {
         this.groupingRulesFileName = groupingRulesFileName;
+        this.invalidConfiguration = invalidConfiguration;
     } // NGSIGroupingInterceptor
     
     /**
@@ -63,94 +66,108 @@ public class NGSIGroupingInterceptor implements Interceptor {
     
     @Override
     public void initialize() {
-        groupingRules = new CygnusGroupingRules(groupingRulesFileName);
-        configurationReader = new ConfigurationReader(30000);
-        configurationReader.start();
+        if (!invalidConfiguration) {
+            groupingRules = new CygnusGroupingRules(groupingRulesFileName);
+            configurationReader = new ConfigurationReader(30000);
+            configurationReader.start();
+        }
     } // initialize
     
     @Override
     public Event intercept(Event event) {
-        LOGGER.debug("Event intercepted, id=" + event.hashCode());
         
-        // get the original headers and body
-        Map<String, String> headers = event.getHeaders();
-        String body = new String(event.getBody());
-        
-        // get some original header values
-        String fiwareServicePath = headers.get(CommonConstants.HEADER_FIWARE_SERVICE_PATH);
-        
-        // parse the original body; this part may be unnecessary if notifications are parsed at the source only once
-        // see --> https://github.com/telefonicaid/fiware-cygnus/issues/359
-        NotifyContextRequest notification;
-        Gson gson = new Gson();
+        if (invalidConfiguration) {
+            return event;
+        } else {
+            LOGGER.debug("Event intercepted, id=" + event.hashCode());
 
-        try {
-            notification = gson.fromJson(body, NotifyContextRequest.class);
-        } catch (Exception e) {
-            LOGGER.error("Runtime error (" + e.getMessage() + ")");
-            return null;
-        } // try catch
+            // get the original headers and body
+            Map<String, String> headers = event.getHeaders();
+            String body = new String(event.getBody());
+
+            // get some original header values
+            String fiwareServicePath = headers.get(CommonConstants.HEADER_FIWARE_SERVICE_PATH);
+
+            // parse the original body; this part may be unnecessary if notifications are parsed at the source only once
+            // see --> https://github.com/telefonicaid/fiware-cygnus/issues/359
+            NotifyContextRequest notification;
+            Gson gson = new Gson();
+
+            try {
+                notification = gson.fromJson(body, NotifyContextRequest.class);
+            } catch (Exception e) {
+                LOGGER.error("Runtime error (" + e.getMessage() + ")");
+                return null;
+            } // try catch
+
+            // iterate on the context responses and notified service paths
+            ArrayList<String> defaultDestinations = new ArrayList<String>();
+            ArrayList<String> groupedDestinations = new ArrayList<String>();
+            ArrayList<String> groupedServicePaths = new ArrayList<String>();
+            ArrayList<NotifyContextRequest.ContextElementResponse> contextResponses = notification.getContextResponses();
+
+            if (contextResponses == null || contextResponses.isEmpty()) {
+                LOGGER.warn("No context responses within the notified entity, nothing is done");
+                return null;
+            } // if
+
+            String[] splitedNotifiedServicePaths = fiwareServicePath.split(",");
+
+            for (int i = 0; i < contextResponses.size(); i++) {
+                NotifyContextRequest.ContextElementResponse contextElementResponse = contextResponses.get(i);
+                NotifyContextRequest.ContextElement contextElement = contextElementResponse.getContextElement();
+
+                // get the matching rule
+                CygnusGroupingRule matchingRule = groupingRules.getMatchingRule(fiwareServicePath, contextElement.getId(),
+                        contextElement.getType());
+
+                if (matchingRule == null) {
+                    groupedDestinations.add(contextElement.getId() + "_" + contextElement.getType());
+                    groupedServicePaths.add(splitedNotifiedServicePaths[i]);
+                } else {
+                    groupedDestinations.add((String) matchingRule.getDestination());
+                    groupedServicePaths.add((String) matchingRule.getNewFiwareServicePath());
+                } // if else
+
+                defaultDestinations.add(contextElement.getId() + "_" + contextElement.getType());
+            } // for
+
+            // set the final header values
+            String defaultDestinationsStr = CommonUtils.toString(defaultDestinations);
+            headers.put(NGSIConstants.FLUME_HEADER_NOTIFIED_ENTITIES, defaultDestinationsStr);
+            LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_NOTIFIED_ENTITIES
+                    + ", value=" + defaultDestinationsStr + ")");
+            String groupedDestinationsStr = CommonUtils.toString(groupedDestinations);
+            headers.put(NGSIConstants.FLUME_HEADER_GROUPED_ENTITIES, groupedDestinationsStr);
+            LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_GROUPED_ENTITIES
+                    + ", value=" + groupedDestinationsStr + ")");
+            String groupedServicePathsStr = CommonUtils.toString(groupedServicePaths);
+            headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATHS, groupedServicePathsStr);
+            LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATHS
+                    + ", value=" + groupedServicePathsStr + ")");
+            event.setHeaders(headers);
+            LOGGER.debug("Event put in the channel, id=" + event.hashCode());
+            return event;
+        } // if else
         
-        // iterate on the context responses and notified service paths
-        ArrayList<String> defaultDestinations = new ArrayList<String>();
-        ArrayList<String> groupedDestinations = new ArrayList<String>();
-        ArrayList<String> groupedServicePaths = new ArrayList<String>();
-        ArrayList<NotifyContextRequest.ContextElementResponse> contextResponses = notification.getContextResponses();
-        
-        if (contextResponses == null || contextResponses.isEmpty()) {
-            LOGGER.warn("No context responses within the notified entity, nothing is done");
-            return null;
-        } // if
-        
-        String[] splitedNotifiedServicePaths = fiwareServicePath.split(",");
-        
-        for (int i = 0; i < contextResponses.size(); i++) {
-            NotifyContextRequest.ContextElementResponse contextElementResponse = contextResponses.get(i);
-            NotifyContextRequest.ContextElement contextElement = contextElementResponse.getContextElement();
-            
-            // get the matching rule
-            CygnusGroupingRule matchingRule = groupingRules.getMatchingRule(fiwareServicePath, contextElement.getId(),
-                    contextElement.getType());
-            
-            if (matchingRule == null) {
-                groupedDestinations.add(contextElement.getId() + "_" + contextElement.getType());
-                groupedServicePaths.add(splitedNotifiedServicePaths[i]);
-            } else {
-                groupedDestinations.add((String) matchingRule.getDestination());
-                groupedServicePaths.add((String) matchingRule.getNewFiwareServicePath());
-            } // if else
-            
-            defaultDestinations.add(contextElement.getId() + "_" + contextElement.getType());
-        } // for
-        
-        // set the final header values
-        String defaultDestinationsStr = CommonUtils.toString(defaultDestinations);
-        headers.put(NGSIConstants.FLUME_HEADER_NOTIFIED_ENTITIES, defaultDestinationsStr);
-        LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_NOTIFIED_ENTITIES
-                + ", value=" + defaultDestinationsStr + ")");
-        String groupedDestinationsStr = CommonUtils.toString(groupedDestinations);
-        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_ENTITIES, groupedDestinationsStr);
-        LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_GROUPED_ENTITIES
-                + ", value=" + groupedDestinationsStr + ")");
-        String groupedServicePathsStr = CommonUtils.toString(groupedServicePaths);
-        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATHS, groupedServicePathsStr);
-        LOGGER.debug("Adding flume event header (name=" + NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATHS
-                + ", value=" + groupedServicePathsStr + ")");
-        event.setHeaders(headers);
-        LOGGER.debug("Event put in the channel, id=" + event.hashCode());
-        return event;
     } // intercept
  
     @Override
     public List<Event> intercept(List<Event> events) {
-        List<Event> interceptedEvents = new ArrayList<Event>(events.size());
+
+        if (invalidConfiguration) {
+            return events;
+        } else {
+            List<Event> interceptedEvents = new ArrayList<Event>(events.size());
         
-        for (Event event : events) {
-            Event interceptedEvent = intercept(event);
-            interceptedEvents.add(interceptedEvent);
-        } // for
+            for (Event event : events) {
+                Event interceptedEvent = intercept(event);
+                interceptedEvents.add(interceptedEvent);
+            } // for
  
-        return interceptedEvents;
+            return interceptedEvents;
+        } // if else
+        
     } // intercept
  
     @Override
@@ -170,6 +187,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
      */
     public static class Builder implements Interceptor.Builder {
         private String groupingRulesFileName;
+        private Boolean invalidConfiguration;
  
         @Override
         public void configure(Context context) {
@@ -179,14 +197,14 @@ public class NGSIGroupingInterceptor implements Interceptor {
                 groupingRulesFileName = groupingRulesFileNameTmp;
                 LOGGER.debug("[gi] Reading configuration (grouping_rules_file=" + groupingRulesFileName + ")");
             } else {
-                groupingRulesFileName = null;
-                LOGGER.debug("[gi] Defaulting to grouping_rules_file=null");
+                invalidConfiguration = true;
+                LOGGER.debug("[gi] Grouping rules file cannot be empty");
             } // if else
         } // configure
  
         @Override
         public Interceptor build() {
-            return new NGSIGroupingInterceptor(groupingRulesFileName);
+            return new NGSIGroupingInterceptor(groupingRulesFileName, invalidConfiguration);
         } // build
     } // Builder
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptorTest.java
@@ -20,6 +20,7 @@ package com.telefonica.iot.cygnus.interceptors;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.createEvent;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import java.util.Map;
+import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
@@ -38,6 +39,54 @@ public class NGSIGroupingInterceptorTest {
     public NGSIGroupingInterceptorTest() {
         LogManager.getRootLogger().setLevel(Level.FATAL);
     } // NGSIGroupingInterceptorTest
+    
+     /**
+     * [GroupingInterceptor.Builder.configure] -------- Configured 'grouping_rules_conf_file' cannot be empty.
+     */
+    @Test
+    public void testBuilderConfigureGroupingRulesConfFileNotEmpty() {
+        System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                + "-------- Configured 'grouping_rules_conf_file' cannot be empty");
+        NGSIGroupingInterceptor.Builder builder = new NGSIGroupingInterceptor.Builder();
+        String groupingRulesConfFile = ""; // wrong value
+        String enableNewEncoding = null; // default value
+        Context context = createBuilderContext(enableNewEncoding, groupingRulesConfFile);
+        builder.configure(context);
+        
+        try {
+            assertTrue(builder.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                    + "-  OK  - Empty 'grouping_rules_conf_file' has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                    + "- FAIL - Empty 'grouping_rules_conf_file' has not been detected");
+            throw e;
+        } // try catch
+    } // testBuilderConfigureGroupingRulesConfFileNotEmpty
+    
+    /**
+     * [GroupingInterceptor.Builder.configure] -------- Configured 'grouping_rules_conf_file' cannot be null.
+     */
+    @Test
+    public void testBuilderConfigureGroupingRulesConfFileNotNull() {
+        System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                + "-------- Configured 'grouping_rules_conf_file' cannot be null");
+        NGSIGroupingInterceptor.Builder builder = new NGSIGroupingInterceptor.Builder();
+        String groupingRulesConfFile = null; // wrong value
+        String enableNewEncoding = null; // default value
+        Context context = createBuilderContext(enableNewEncoding, groupingRulesConfFile);
+        builder.configure(context);
+        
+        try {
+            assertTrue(builder.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                    + "-  OK  - Null 'grouping_rules_conf_file' has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[GroupingInterceptor.Builder.configure]")
+                    + "- FAIL - Null 'grouping_rules_conf_file' has not been detected");
+            throw e;
+        } // try catch
+    } // testBuilderConfigureGroupingRulesConfFileNotNull
     
     /**
      * [NGSIGroupingInterceptor.getEvents] -------- When a Flume event is put in the channel, it contains fiware-service,
@@ -125,5 +174,12 @@ public class NGSIGroupingInterceptorTest {
             throw e7;
         } // try catch
     } // testGetEventsHeadersInFlumeEvent
+    
+    private Context createBuilderContext(String enableNewEncoding, String groupingRulesConfFile) {
+        Context context = new Context();
+        context.put("enable_new_encoding", enableNewEncoding);
+        context.put("grouping_rules_conf_file", groupingRulesConfFile);
+        return context;
+    } // createBuilderContext
 
 } // NGSIGroupingInterceptorTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptorTest.java
@@ -50,7 +50,7 @@ public class NGSIGroupingInterceptorTest {
                 + "-------- When a Flume event is put in the channel, it contains fiware-service, fiware-servicepath, "
                 + "fiware-correlator, transaction-id, notified-entities, grouped-servicepaths and grouped-entities "
                 + "headers");
-        NGSIGroupingInterceptor groupingInterceptor = new NGSIGroupingInterceptor("");
+        NGSIGroupingInterceptor groupingInterceptor = new NGSIGroupingInterceptor("", false);
         groupingInterceptor.initialize();
         Event originalEvent = createEvent();
         Map<String, String> interceptedEventHeaders = groupingInterceptor.intercept(originalEvent).getHeaders();


### PR DESCRIPTION
* Fix issue #1049 
* 100% Unit tests passed: 
```
Results : Tests run: 93, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
[Using agent without grouping interceptor file]
time=2016-05-26T08:40:35.412WEST | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder[201] : [gi] Grouping rules file cannot be empty

[Using agent with empty grouping interceptor file]
time=2016-05-26T08:48:41.798WEST | lvl=DEBUG | corr= | trans= | srv= | subsrv= | function=configure | comp=Cygnus | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor$Builder[201] : [gi] Grouping rules file cannot be empty
```
* Tests implemented:
```
Running com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptorTest
[GroupingInterceptor.Builder.configure] --------- Configured 'grouping_rules_conf_file' cannot be empty
[GroupingInterceptor.Builder.configure] --  OK  - Empty 'grouping_rules_conf_file' has been detected
[GroupingInterceptor.Builder.configure] --------- Configured 'grouping_rules_conf_file' cannot be null
[GroupingInterceptor.Builder.configure] --  OK  - Null 'grouping_rules_conf_file' has been detected
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.082 sec
```
* Assignee: @frbattid 