### PR TITLE
bug/1055_api_getting_port_forwarding

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [cygnus-ngsi] [feature] Add MongoDB and STH sinks to docker agent (#1044)
 - [cygnus-ngsi] [hardening] Remove support to deprecated 'matching_table' parameter (#1048)
 - [cygnus-ngsi] [hardening] Add checks for invalid configuration in NGSIGroupingInterceptor.java (#1049)
+- [cygnus-common] [bug] Getting API port fails when using port forwarding (#1055)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -125,7 +125,7 @@ public class ManagementInterface extends AbstractHandler {
         } // if
 
         response.setContentType("text/html;charset=utf-8");
-        int port = request.getServerPort();
+        int port = request.getLocalPort();
         String uri = request.getRequestURI();
         String method = request.getMethod();
         LOGGER.info("Management interface request. Method: " + method + ", URI: " + uri);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -196,7 +196,7 @@ public class ManagementInterface extends AbstractHandler {
                 response.getWriter().println(method + " " + uri + " Not implemented");
             } // if else
         } else {
-            LOGGER.debug("Attending a request in a non expected port!!");
+            LOGGER.info("Attending a request in a non expected port: " + port);
         } // if else
     } // handle
 


### PR DESCRIPTION
* Fixes issue #1055 
* (unofficial) e2e tests passed:
```
Starting a Jetty server listening on port 8081 (Management Interface)
Management interface request. Method: GET, URI: /v1/version
...
$ curl -X GET "http://localhost:8081/v1/version"
{"success":"true","version":"1.0.0_SNAPSHOT.4550fbcc65aacc978710a0a3178ce6894db0d6c2"}
```
* Assignee @mariolg 