### PR TITLE
hardening/1029_new_encoding__charset

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -68,6 +68,7 @@ public final class CommonConstants {
     public static final String LOG4J_COMP = "agent";
     
     // encoding
+    public static final String INTERNAL_CONCATENATOR = "=";
     public static final String CONCATENATOR = "x0000";
     
 } // CommonConstants

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIGroupingInterceptor.java
@@ -128,7 +128,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
 
                 if (matchingRule == null) {
                     groupedDestinations.add(contextElement.getId()
-                            + (enableNewEncoding ? CommonConstants.CONCATENATOR : "_")
+                            + (enableNewEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
                             + contextElement.getType());
                     groupedServicePaths.add(splitedNotifiedServicePaths[i]);
                 } else {
@@ -137,7 +137,7 @@ public class NGSIGroupingInterceptor implements Interceptor {
                 } // if else
 
                 defaultDestinations.add(contextElement.getId()
-                        + (enableNewEncoding ? CommonConstants.CONCATENATOR : "_")
+                        + (enableNewEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
                         + contextElement.getType());
             } // for
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -26,6 +26,7 @@ import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import com.telefonica.iot.cygnus.utils.JsonUtils;
+import com.telefonica.iot.cygnus.utils.NGSICharsets;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
 import java.util.ArrayList;
@@ -590,7 +591,7 @@ public class NGSICartoDBSink extends NGSISink {
      * @throws Exception
      */
     protected String buildSchemaName(String service) throws Exception {
-        String name = NGSIUtils.encodePostgreSQL(service, false);
+        String name = NGSICharsets.cartoDBEncode(service);
 
         if (name.length() > NGSIConstants.POSTGRESQL_MAX_ID_LEN) {
             throw new CygnusBadConfiguration("Building schema name '" + name
@@ -618,18 +619,18 @@ public class NGSICartoDBSink extends NGSISink {
                             + "dm-by-service-path data model");
                 } // if
 
-                name = NGSIUtils.encodePostgreSQL(servicePath, true);
+                name = NGSICharsets.cartoDBEncode(servicePath.substring(1));
                 break;
             case DMBYENTITY:
-                String truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                String truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath.substring(1));
                 name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + CommonConstants.CONCATENATOR)
-                        + NGSIUtils.encodePostgreSQL(entity, false);
+                        + NGSICharsets.cartoDBEncode(entity);
                 break;
             case DMBYATTRIBUTE:
-                truncatedServicePath = NGSIUtils.encodePostgreSQL(servicePath, true);
+                truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath.substring(1));
                 name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + CommonConstants.CONCATENATOR)
-                        + NGSIUtils.encodePostgreSQL(entity, false) + CommonConstants.CONCATENATOR
-                        + NGSIUtils.encodePostgreSQL(attribute, false);
+                        + NGSICharsets.cartoDBEncode(entity) + CommonConstants.CONCATENATOR
+                        + NGSICharsets.cartoDBEncode(attribute);
                 break;
             default:
                 throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -614,20 +614,15 @@ public class NGSICartoDBSink extends NGSISink {
         
         switch(dataModel) {
             case DMBYSERVICEPATH:
-                if (servicePath.equals("/")) {
-                    throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
-                            + "dm-by-service-path data model");
-                } // if
-
-                name = NGSICharsets.cartoDBEncode(servicePath.substring(1));
+                name = NGSICharsets.cartoDBEncode(servicePath);
                 break;
             case DMBYENTITY:
-                String truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath.substring(1));
+                String truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath);
                 name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + CommonConstants.CONCATENATOR)
                         + NGSICharsets.cartoDBEncode(entity);
                 break;
             case DMBYATTRIBUTE:
-                truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath.substring(1));
+                truncatedServicePath = NGSICharsets.cartoDBEncode(servicePath);
                 name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + CommonConstants.CONCATENATOR)
                         + NGSICharsets.cartoDBEncode(entity) + CommonConstants.CONCATENATOR
                         + NGSICharsets.cartoDBEncode(attribute);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -43,7 +43,23 @@ public final class NGSICharsets {
             
             if (code >= 65 && code <= 90) { // A-Z --> a-z
                 out += (char) (code + 32);
-            } else if (code >= 97 && code <= 122) { // a-z --> a-z
+            } else if (code >= 97 && code <= 119) { // a-w --> a-w
+                out += c;
+            } else if (c == 'x') {
+                String next4;
+            
+                if (i + 4 < in.length()) {
+                    next4 = in.substring(i + 1, i + 5);
+                } else {
+                    next4 = "abcd"; // whatever except a unicode
+                } // if else
+            
+                if (next4.matches("^[0-9]{4}$")) { // x --> xx
+                    out += "xx";
+                } else { // x --> x
+                    out += c;
+                } // if else
+            } else if (code == 121 || code == 122) { // yz --> yz
                 out += c;
             } else if (code >= 48 && code <= 57) { // 0-9 --> 0-9
                 out += c;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.utils;
+
+/**
+ *
+ * @author frb
+ */
+public final class NGSICharsets {
+    
+    /**
+     * Constructor. It is private since utility classes should not have a public or default constructor.
+     */
+    private NGSICharsets() {
+    } // NGSICharsets
+    
+    /**
+     * Encodes a string for CartoDB.
+     * @param in
+     * @return
+     */
+    public static String cartoDBEncode(String in) {
+        String out = "";
+        
+        for (int i = 0; i < in.length(); i++) {
+            char c = in.charAt(i);
+            int code = c;
+            
+            if (code >= 65 && code <= 90) { // A-Z --> a-z
+                out += (char) (code + 32);
+            } else if (code >= 97 && code <= 122) { // a-z --> a-z
+                out += c;
+            } else if (code >= 48 && code <= 57) { // 0-9 --> 0-9
+                out += c;
+            } else if (c == '_') { // _ --> _
+                out += c;
+            } else { // --> xUNICODE
+                String hex = Integer.toHexString(code);
+                out += "x" + ("0000" + hex).substring(hex.length());
+            } // else
+        } // for
+        
+        return out;
+    } // cartoDBEncode
+
+} // NGSICharsets

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -65,6 +65,8 @@ public final class NGSICharsets {
                 out += c;
             } else if (c == '_') { // _ --> _
                 out += c;
+            } else if (c == '=') { // = --> x0000
+                out += "x0000";
             } else { // --> xUNICODE
                 String hex = Integer.toHexString(code);
                 out += "x" + ("0000" + hex).substring(hex.length());

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -37,7 +37,6 @@ public final class NGSIUtils {
     private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final Pattern ENCODESTHDBPATTERN = Pattern.compile("[\\/\\\\.\\$\" ]");
     private static final Pattern ENCODESTHCOLLECTIONPATTERN = Pattern.compile("\\$");
-    private static final Pattern ENCODEPOSTGRESQLPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     
     /**
      * Constructor. It is private since utility classes should not have a public or default constructor.
@@ -91,22 +90,6 @@ public final class NGSIUtils {
     public static String encodeSTHCollection(String in) {
         return ENCODESTHCOLLECTIONPATTERN.matcher(in).replaceAll("_");
     } // encodeSTHCollection
-    
-    /**
-     * Encodes a tring replacing all ' ' with '_'.
-     * @param in
-     * @param deleteSlash
-     * @return
-     */
-    public static String encodePostgreSQL(String in, boolean deleteSlash) {
-        // PostgreSQL is case insensitive:
-        // http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-        if (deleteSlash) {
-            return ENCODEPOSTGRESQLPATTERN.matcher(in.substring(1)).replaceAll("_").toLowerCase();
-        } else {
-            return ENCODEPOSTGRESQLPATTERN.matcher(in).replaceAll("_").toLowerCase();
-        } // else
-    } // encodePostgreSQL
     
     /**
      * Gets the geolocation value, ready for insertion in CartoDB, given a NGSI attribute value and its metadata.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -735,7 +735,7 @@ public class NGSICartoDBSinkTest {
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
                 enableDistance, keysConfFile));
         String servicePath = "/somePath";
-        String entity = "someIdx0000someType";
+        String entity = "someId=someType"; // using the internal concatenator
         String attribute = null; // irrelevant for this test
         
         try {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -670,14 +670,14 @@ public class NGSICartoDBSinkTest {
 
     /**
      * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted and
-     * data_model is 'dm-by-service-path' the CartoDB table name is lower case of <service-path>.
+     * data_model is 'dm-by-service-path' the CartoDB table name is the lower case of x002f<service-path>.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildDBNameNonRootServicePathDataModelByServicePath() throws Exception {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a non root service-path is notified/defaulted and data_model is "
-                + "'dm-by-service-path' the CartoDB table name is the lower case of <servicePath>");
+                + "'dm-by-service-path' the CartoDB table name is the lower case of of x002f<service-path>");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-service-path";
@@ -697,12 +697,12 @@ public class NGSICartoDBSinkTest {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
         
             try {
-                assertEquals("somepath", builtTableName);
+                assertEquals("x002fsomepath", builtTableName);
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of <servicePath>");
+                        + "-  OK  - '" + builtTableName + "' is equals to the lower case of x002f<service-path>");
             } catch (AssertionError e) {
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of <servicePath>");
+                        + "- FAIL - '" + builtTableName + "' is not equals to the lower case of x002f<service-path>");
                 throw e;
             } // try catch
         } catch (Exception e) {
@@ -715,14 +715,14 @@ public class NGSICartoDBSinkTest {
     /**
      * [NGSICartoDBSink.buildTableName] -------- When a non root service-path is notified/defaulted
      * and data_model is 'dm-by-entity' the CartoDB table name is the lower case of
-     * \<service-path\>x0000\<entity_id\>x0000\<entity_type\>.
+     * x002f\<service-path\>x0000\<entity_id\>x0000\<entity_type\>.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildDBNameNonRootServicePathDataModelByEntity() throws Exception {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a non root service-path is notified/defaulted and data_model is 'dm-by-entity' "
-                + "the CartoDB table name is the lower case of <servicePath>x0000<entityId>x0000<entityType>");
+                + "the CartoDB table name is the lower case of x002f<servicePath>x0000<entityId>x0000<entityType>");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
@@ -742,14 +742,14 @@ public class NGSICartoDBSinkTest {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
         
             try {
-                assertEquals("somepathx0000someidx0000sometype", builtTableName);
+                assertEquals("x002fsomepathx0000someidx0000sometype", builtTableName);
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                         + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
-                        + "<servicePath>x0000<entityId>x0000<entityType>");
+                        + "x002f<servicePath>x0000<entityId>x0000<entityType>");
             } catch (AssertionError e) {
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                         + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
-                        + "<servicePath>x0000<entityId>x0000<entityType>");
+                        + "x002f<servicePath>x0000<entityId>x0000<entityType>");
                 throw e;
             } // try catch
         } catch (Exception e) {
@@ -761,14 +761,14 @@ public class NGSICartoDBSinkTest {
     
     /**
      * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted and
-     * data_model is 'dm-by-service-path' the CartoDB table name cannot be created.
+     * data_model is 'dm-by-service-path' the CartoDB table name is x002f.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildDBNameRootServicePathDataModelByServicePath() throws Exception {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a root service-path is notified/defaulted and data_model is "
-                + "'dm-by-service-path' the CartoDB table name cannot be created");
+                + "'dm-by-service-path' the CartoDB table name is x002f");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-service-path";
@@ -785,28 +785,35 @@ public class NGSICartoDBSinkTest {
         String attribute = null; // irrelevant for this test
         
         try {
-            sink.buildTableName(servicePath, entity, attribute);
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                    + "- FAIL - It was not detected the table name could not be created");
-            assertTrue(false);
+            String builtTableName = sink.buildTableName(servicePath, entity, attribute);
+            
+            try {
+                assertEquals("x002f", builtTableName);
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to x002f");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to x002f");
+                throw e;
+            } // try catch
         } catch (Exception e) {
-            assertTrue(true);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
-                    + "-  OK  - It was detected the table name could not be created");
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
         } // try catch
     } // testBuildDBNameRootServicePathDataModelByServicePath
     
     /**
      * [NGSICartoDBSink.buildTableName] -------- When a root service-path is notified/defaulted
      * and data_model is 'dm-by-entity' the CartoDB table name is the lower case of
-     * \<service-path\>_\<entity_id\>_\<entity_type\>.
+     * x002f\<service-path\>_\<entity_id\>_\<entity_type\>.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildDBNameRootServicePathDataModelByEntity() throws Exception {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a non service-path is notified/defaulted and data_model is 'dm-by-entity' "
-                + "the CartoDB table name is the lower case of <servicePath>_<entityId>_<entityType>");
+                + "the CartoDB table name is the lower case of x002fx0000<entityId>x0000<entityType>");
         String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
         String dataModel = "dm-by-entity";
@@ -819,21 +826,21 @@ public class NGSICartoDBSinkTest {
         sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
                 enableDistance, keysConfFile));
         String servicePath = "/";
-        String entity = "someId_someType";
+        String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
         
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
         
             try {
-                assertEquals("someid_sometype", builtTableName);
+                assertEquals("x002fx0000someidx0000sometype", builtTableName);
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                         + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
-                        + "<entityId>_<entityType>");
+                        + "x002fx0000<entityId>x0000<entityType>");
             } catch (AssertionError e) {
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                         + "- FAIL - '" + builtTableName + "' is not equals to the lower case of "
-                        + "<entityId>_<entityType>");
+                        + "x002fx0000<entityId>x0000<entityType>");
                 throw e;
             } // try catch
         } catch (Exception e) {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.utils;
+
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSICharsetsTest {
+    
+    /**
+     * Constructor.
+     */
+    public NGSICharsetsTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSICharsetsTest
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- Upper case not accented characters are encoded.
+     */
+    @Test
+    public void testCartoDBEncodeUpperCase() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- Upper case not accented characters are not encoded");
+        String in = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String expected = "abcdefghijklmnopqrstuvwxyz";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has been encoded as '" + expected + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has not been encoded as '" + expected + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeUpperChars
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- Lower case not accented characters are not encoded.
+     */
+    @Test
+    public void testCartoDBEncodeLowerCase() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- Lower case not accented characters are not encoded");
+        String in = "abcdefghijklmnopqrstuvwxyz";
+        String expected = "abcdefghijklmnopqrstuvwxyz";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeLowerCase
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- Numbers are not encoded.
+     */
+    @Test
+    public void testCartoDBEncodeNums() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- Numbers are not encoded");
+        String in = "0123456789";
+        String expected = "0123456789";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeNums
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- Underscore is not encoded.
+     */
+    @Test
+    public void testCartoDBEncodeUnderscore() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- Underscore is not encoded");
+        String in = "_";
+        String expected = "_";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeUnderscore
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- Non lower case alphanumerics and undersocre are encoded.
+     */
+    @Test
+    public void testCartoDBEncodeRare() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- Non lower case alphanumerics and undersocre are encoded");
+        String in = "ÁÉÍÓÚáéíóúÑñÇç";
+        String expected = "x00c1x00c9x00cdx00d3x00dax00e1x00e9x00edx00f3x00fax00d1x00f1x00c7x00e7";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+        
+        in = "!\"#$%&'()*+,-./";
+        expected = "x0021x0022x0023x0024x0025x0026x0027x0028x0029x002ax002bx002cx002dx002ex002f";
+        out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+        
+        in = ":;<=>?@";
+        expected = "x003ax003bx003cx003dx003ex003fx0040";
+        out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+        
+        in = "[\\]^`";
+        expected = "x005bx005cx005dx005ex0060";
+        out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+        
+        in = "{|}~";
+        expected = "x007bx007cx007dx007e";
+        out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeRare
+    
+} // NGSICharsetsTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
@@ -59,14 +59,14 @@ public class NGSICharsetsTest {
     } // testCartoDBEncodeUpperChars
     
     /**
-     * [NGSICharsets.cartoDBEncode] -------- Lower case not accented characters are not encoded.
+     * [NGSICharsets.cartoDBEncode] -------- Lower case not accented characters except 'x' are not encoded.
      */
     @Test
     public void testCartoDBEncodeLowerCase() {
         System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
                 + "-------- Lower case not accented characters are not encoded");
-        String in = "abcdefghijklmnopqrstuvwxyz";
-        String expected = "abcdefghijklmnopqrstuvwxyz";
+        String in = "abcdefghijklmnopqrstuvwyz";
+        String expected = "abcdefghijklmnopqrstuvwyz";
         String out = NGSICharsets.cartoDBEncode(in);
         
         try {
@@ -123,6 +123,50 @@ public class NGSICharsetsTest {
             throw e;
         } // try catch
     } // testCartoDBEncodeUnderscore
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- A single 'x' is not encoded.
+     */
+    @Test
+    public void testCartoDBEncodeSinglex() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- 'x' is not encoded");
+        String in = "x";
+        String expected = "x";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeSinglex
+    
+    /**
+     * [NGSICharsets.cartoDBEncode] -------- "x0000" is encoded (escaped) as "xx0000".
+     */
+    @Test
+    public void testCartoDBEncodex0000() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- 'x' is encoded (escaped) as 'xx'");
+        String in = "x0000";
+        String expected = "xx0000";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has been encoded as '" + expected + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "' instead of '" + expected + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodex0000
     
     /**
      * [NGSICharsets.cartoDBEncode] -------- Non lower case alphanumerics and undersocre are encoded.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
@@ -125,12 +125,34 @@ public class NGSICharsetsTest {
     } // testCartoDBEncodeUnderscore
     
     /**
+     * [NGSICharsets.cartoDBEncode] -------- '=' (internal concatenator) is encoded as "x0000" (public concatenator).
+     */
+    @Test
+    public void testCartoDBEncodeEquals() {
+        System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                + "-------- '=' (internal concatenator) is encoded as \"x0000\" (public concatenator)");
+        String in = "=";
+        String expected = "x0000";
+        String out = NGSICharsets.cartoDBEncode(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "-  OK  - '" + in + "' has been encoded as '" + expected + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
+                    + "- FAIL - '" + in + "' has not been encoded as '" + out + "' instead of '" + expected + "'");
+            throw e;
+        } // try catch
+    } // testCartoDBEncodeEquals
+    
+    /**
      * [NGSICharsets.cartoDBEncode] -------- A single 'x' is not encoded.
      */
     @Test
     public void testCartoDBEncodeSinglex() {
         System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
-                + "-------- 'x' is not encoded");
+                + "-------- A single 'x' is not encoded");
         String in = "x";
         String expected = "x";
         String out = NGSICharsets.cartoDBEncode(in);
@@ -152,7 +174,7 @@ public class NGSICharsetsTest {
     @Test
     public void testCartoDBEncodex0000() {
         System.out.println(getTestTraceHead("[NGSICharsets.cartoDBEncode]")
-                + "-------- 'x' is encoded (escaped) as 'xx'");
+                + "-------- \"x0000\" is encoded (escaped) as \"xx0000\"");
         String in = "x0000";
         String expected = "xx0000";
         String out = NGSICharsets.cartoDBEncode(in);
@@ -203,8 +225,9 @@ public class NGSICharsetsTest {
             throw e;
         } // try catch
         
-        in = ":;<=>?@";
-        expected = "x003ax003bx003cx003dx003ex003fx0040";
+        // '=' has been excluded from here since it is not notified by Orion and it is used as concatenator
+        in = ":;<>?@";
+        expected = "x003ax003bx003cx003ex003fx0040";
         out = NGSICharsets.cartoDBEncode(in);
         
         try {

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -55,19 +55,21 @@ Here it is assumed the notified/default FIWARE service maps the PostgreSQL schem
 [Top](#top)
 
 ####<a name="section1.2.2"></a>PostgreSQL tables naming conventions
-The name of these tables depends on the configured data model (see the [Configuration](#section2.1) section for more details):
+The name of these tables depend on the configured data model and analysis mode (see the [Configuration](#section2.1) section for more details):
 
 * Data model by service path (`data_model=dm-by-service-path`). As the data model name denotes, the notified FIWARE service path (or the configured one as default in [`NGSIRestHandler`](.ngsi_rest_handler.md)) is used as the name of the table. This allows the data about all the NGSI entities belonging to the same service path is stored in this unique table. The only constraint regarding this data model is the FIWARE service path cannot be the root one (`/`).
-* Data model by entity (`data_model=dm-by-entity`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity ID and entityType in order to compose the table name. The concatenation character is `_` (underscore). If the FIWARE service path is the root one (`/`) then only the entity ID and type are concatenated.
+* Data model by entity (`data_model=dm-by-entity`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity ID and entityType in order to compose the table name. The concatenation string is `0x0000`, closely related to the encoding of not allowed characters (see below). If the FIWARE service path is the root one (`/`) then only the entity ID and type are concatenated.
 
-It must be said PostgreSQL only accepts alphanumeric characters and the underscore (`_`). All the other characters will be escaped to underscore (`_`) when composing the table names.
+The above applies both if `enable_raw` or `enable_distance` es set to `true`. In adddition, the distance analysis mode adds the sufix `x0000distance` to the table name.
+
+It must be said PostgreSQL only accepts alphanumeric characters and the underscore (`_`). All the other characters will be encoded as `xXXXX` when composing the table names, where `XXXX` is the [unicode](https://en.wikipedia.org/wiki/List_of_Unicode_characters) of the character.
 
 The following table summarizes the table name composition:
 
 | FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
 |---|---|---|
-| `/` | N/A | `<entityId>_<entityType>` |
-| `/<svcPath>` | `<svcPath>` | `<svcPath>_<entityId>_<entityType>` |
+| `/` | N/A | `<entityId>x0000<entityType>[x0000distance]` |
+| `/<svcPath>` | `<svcPath>[x0000distance]` | `<svcPath>x0000<entityId>x0000<entityType>[x0000distance]` |
 
 Please observe the concatenation of entity ID and type is already given in the `notified_entities`/`grouped_entities` header values (depending on using or not the grouping rules, see the [Configuration](#section2.1) section for more details) within the Flume event.
 
@@ -165,20 +167,20 @@ Assuming the following Flume event is created from a notified NGSI context data 
 [Top](#top)
 
 ####<a name="section1.3.2"></a>Table names
-The PostgreSQL table names will be, depending on the configured data model, the following ones:
+The PostgreSQL table names will be, depending on the configured data model and analysis mode, the following ones:
 
 | FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
 |---|---|---|
-| `/` | N/A | `car1_car` |
-| `/4wheels` | `4wheels` | `4wheels_car1_car` |
+| `/` | N/A | `car1x0000car[x0000distance]` |
+| `/4wheels` | `4wheels[x0000distance]` | `4wheelsx0000car1x0000car[x0000distance]` |
     
 [Top](#top)
 
 ####<a name="section1.3.3"></a>Raw-based storing
-Let's assume a table name `4wheels_car1_car` (data model by entity, non-root service path). The data stored within this table would be:
+Let's assume a table name `4wheelsx0000car1x0000car` (data model by entity, non-root service path, only raw analysis mode). The data stored within this table would be:
 
 ```
-curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheels_car1_car&api_key=abcdef0123456789"
+curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheelsx0000car1x0000car&api_key=abcdef0123456789"
 {
   "rows": [
     {
@@ -238,10 +240,10 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheels_car1_car
 [Top](#top)
 
 ####<a name="section1.3.4"></a>Distance-based storing
-Let's assume a table name `4wheels_car1_car` (data model by entity, non-root service path) with a previous insertion (on the contrary, this would be the first insertion and almost all the aggregated values will be set to 0). The data stored within this table would be:
+Let's assume a table name `4wheelsx0000car1x0000carx0000distance` (data model by entity, non-root service path, only distance analysis mode) with a previous insertion (on the contrary, this would be the first insertion and almost all the aggregated values will be set to 0). The data stored within this table would be:
 
 ```
-curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheels_car1_car&api_key=abcdef0123456789"
+curl "https://myusername.cartodb.com/api/v2/sql?q=select * from 4wheelsx0000car1x0000carx0000distance&api_key=abcdef0123456789"
 {
   "rows": [
     {

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -55,21 +55,21 @@ Here it is assumed the notified/default FIWARE service maps the PostgreSQL schem
 [Top](#top)
 
 ####<a name="section1.2.2"></a>PostgreSQL tables naming conventions
-The name of these tables depend on the configured data model and analysis mode (see the [Configuration](#section2.1) section for more details):
+The name of these tables depends on the configured data model and analysis mode (see the [Configuration](#section2.1) section for more details):
 
-* Data model by service path (`data_model=dm-by-service-path`). As the data model name denotes, the notified FIWARE service path (or the configured one as default in [`NGSIRestHandler`](.ngsi_rest_handler.md)) is used as the name of the table. This allows the data about all the NGSI entities belonging to the same service path is stored in this unique table. The only constraint regarding this data model is the FIWARE service path cannot be the root one (`/`).
+* Data model by service path (`data_model=dm-by-service-path`). As the data model name denotes, the notified FIWARE service path (or the configured one as default in [`NGSIRestHandler`](.ngsi_rest_handler.md)) is used as the name of the table. This allows the data about all the NGSI entities belonging to the same service path is stored in this unique table.
 * Data model by entity (`data_model=dm-by-entity`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity ID and entityType in order to compose the table name. The concatenation string is `0x0000`, closely related to the encoding of not allowed characters (see below). If the FIWARE service path is the root one (`/`) then only the entity ID and type are concatenated.
 
 The above applies both if `enable_raw` or `enable_distance` es set to `true`. In adddition, the distance analysis mode adds the sufix `x0000distance` to the table name.
 
-It must be said PostgreSQL only accepts alphanumeric characters and the underscore (`_`). All the other characters will be encoded as `xXXXX` when composing the table names, where `XXXX` is the [unicode](https://en.wikipedia.org/wiki/List_of_Unicode_characters) of the character.
+It must be said PostgreSQL only accepts alphanumeric characters and the underscore (`_`). All the other characters will be encoded as `xXXXX` when composing the table names, where `XXXX` is the [unicode](https://en.wikipedia.org/wiki/List_of_Unicode_characters) of the character. For instance, the initial slash (`/`) of the FIWARE service path is encoded as `x002f`.
 
 The following table summarizes the table name composition:
 
 | FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
 |---|---|---|
-| `/` | N/A | `<entityId>x0000<entityType>[x0000distance]` |
-| `/<svcPath>` | `<svcPath>[x0000distance]` | `<svcPath>x0000<entityId>x0000<entityType>[x0000distance]` |
+| `/` | `x002f` | `x002f<entityId>x0000<entityType>[x0000distance]` |
+| `/<svcPath>` | `x002f<svcPath>[x0000distance]` | `x002f<svcPath>x0000<entityId>x0000<entityType>[x0000distance]` |
 
 Please observe the concatenation of entity ID and type is already given in the `notified_entities`/`grouped_entities` header values (depending on using or not the grouping rules, see the [Configuration](#section2.1) section for more details) within the Flume event.
 
@@ -171,8 +171,8 @@ The PostgreSQL table names will be, depending on the configured data model and a
 
 | FIWARE service path | `dm-by-service-path` | `dm-by-entity` |
 |---|---|---|
-| `/` | N/A | `car1x0000car[x0000distance]` |
-| `/4wheels` | `4wheels[x0000distance]` | `4wheelsx0000car1x0000car[x0000distance]` |
+| `/` | `x002f` | `x002fcar1x0000car[x0000distance]` |
+| `/4wheels` | `x002f4wheels[x0000distance]` | `x002f4wheelsx0000car1x0000car[x0000distance]` |
     
 [Top](#top)
 


### PR DESCRIPTION
* Partially implements issue #1029 (charset encoding)
* 100% unit tests passed:
```
Tests run: 64, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-common
Tests run: 103, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-ngsi
```

Relevant tests for this PR:
```
[NGSICharsets.cartoDBEncode] -------------------- Lower case not accented characters are not encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - 'abcdefghijklmnopqrstuvwyz' has not been encoded
[NGSICharsets.cartoDBEncode] -------------------- Numbers are not encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - '0123456789' has not been encoded
[NGSICharsets.cartoDBEncode] -------------------- Non lower case alphanumerics and undersocre are encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - 'ÁÉÍÓÚáéíóúÑñÇç' has not been encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - '!"#$%&'()*+,-./' has not been encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - ':;<>?@' has not been encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - '[\]^`' has not been encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - '{|}~' has not been encoded
[NGSICharsets.cartoDBEncode] -------------------- Upper case not accented characters are not encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' has been encoded as 'abcdefghijklmnopqrstuvwxyz'
[NGSICharsets.cartoDBEncode] -------------------- '=' (internal concatenator) is encoded as "x0000" (public concatenator)
[NGSICharsets.cartoDBEncode] -------------  OK  - '=' has been encoded as 'x0000'
[NGSICharsets.cartoDBEncode] -------------------- A single 'x' is not encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - 'x' has not been encoded
[NGSICharsets.cartoDBEncode] -------------------- Underscore is not encoded
[NGSICharsets.cartoDBEncode] -------------  OK  - '_' has not been encoded
[NGSICharsets.cartoDBEncode] -------------------- "x0000" is encoded (escaped) as "xx0000"
[NGSICharsets.cartoDBEncode] -------------  OK  - 'x0000' has been encoded as 'xx0000'
```

* (unofficial) e2e tests passed:

`enable_new_encoding=false`:

    Persisting data at NGSICartoDBSink. Schema (soyunpaquete), Table (car1_carx0000distance)

`enable_new_encoding=true`:

    Persisting data at NGSICartoDBSink. Schema (soyunpaquete), Table (car1x0000carx0000distance)

* Assignee @pcoello25 but LGTM from @gtorodelvalle is also required