### PR TITLE
hardening/940_configurable_sth_resolution

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi] [hardening] Do configurable the accepted resolutions in NGSISTHSink (#940)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackend.java
@@ -78,10 +78,12 @@ public interface MongoBackend {
      * @param attrType
      * @param attrValue
      * @param attrMd
+     * @param resolutions
      * @throws Exception
      */
     void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs,
-            String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd)
+            String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd,
+            boolean[] resolutions)
         throws Exception;
 
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -200,11 +200,13 @@ public class MongoBackendImpl implements MongoBackend {
      * @param attrType
      * @param attrValue
      * @param attrMd
+     * @param resolutions
      * @throws Exception
      */
     @Override
     public void insertContextDataAggregated(String dbName, String collectionName, long recvTimeTs,
-            String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd)
+            String entityId, String entityType, String attrName, String attrType, String attrValue, String attrMd,
+            boolean[] resolutions)
         throws Exception {
         // preprocess some values
         GregorianCalendar calendar = new GregorianCalendar();
@@ -212,16 +214,30 @@ public class MongoBackendImpl implements MongoBackend {
         calendar.setTimeInMillis(recvTimeTs);
 
         // insert the data in an aggregated fashion for each resolution type
-        insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
-                attrName, attrType, attrValue, Resolution.SECOND);
-        insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
-                attrName, attrType, attrValue, Resolution.MINUTE);
-        insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
-                attrName, attrType, attrValue, Resolution.HOUR);
-        insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
-                attrName, attrType, attrValue, Resolution.DAY);
-        insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
-                attrName, attrType, attrValue, Resolution.MONTH);
+        if (resolutions[0]) {
+            insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
+                    attrName, attrType, attrValue, Resolution.SECOND);
+        } // if
+        
+        if (resolutions[1]) {
+            insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
+                    attrName, attrType, attrValue, Resolution.MINUTE);
+        } // if
+        
+        if (resolutions[2]) {
+            insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
+                    attrName, attrType, attrValue, Resolution.HOUR);
+        } // if
+        
+        if (resolutions[3]) {
+            insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
+                    attrName, attrType, attrValue, Resolution.DAY);
+        } // if
+        
+        if (resolutions[4]) {
+            insertContextDataAggregatedForResoultion(dbName, collectionName, calendar, entityId, entityType,
+                    attrName, attrType, attrValue, Resolution.MONTH);
+        } // if
     } // insertContextDataAggregated
 
     /**

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
@@ -23,12 +23,16 @@ import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import static com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink.LOGGER;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
+import org.apache.flume.Context;
 
 /**
  *
  * @author frb
  */
 public class NGSISTHSink extends NGSIMongoBaseSink {
+    
+    private final boolean[] resolutions = {false, false, false, false, false};
 
     /**
      * Constructor.
@@ -36,6 +40,31 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
     public NGSISTHSink() {
         super();
     } // NGSISTHSink
+    
+    @Override
+    public void configure(Context context) {
+        String resolutionsStr = context.getString("resolutions", "month,day,hour,minute,second");
+        String[] resolutionsArray = resolutionsStr.split(",");
+        
+        for (String resolution : resolutionsArray) {
+            if (resolution.trim().equals("month")) {
+                resolutions[4] = true;
+            } else if (resolution.trim().equals("day")) {
+                resolutions[3] = true;
+            } else if (resolution.trim().equals("hour")) {
+                resolutions[2] = true;
+            } else if (resolution.trim().equals("minute")) {
+                resolutions[1] = true;
+            } else if (resolution.trim().equals("second")) {
+                resolutions[0] = true;
+            } else {
+                LOGGER.warn("[" + this.getName() + "] Unknown resolution " + resolution);
+            } // if else
+        } // for
+        
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (resolutions=" + resolutionsStr + ")");
+        super.configure(context);
+    } // configure
     
     @Override
     public void persistBatch(NGSIBatch batch) throws Exception {
@@ -156,7 +185,7 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
                     + entityId + "," + entityType + "," + attrName + "," + attrType + "," + attrValue + ","
                     + attrMetadata);
             backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs,
-                    entityId, entityType, attrName, attrType, attrValue, attrMetadata);
+                    entityId, entityType, attrName, attrType, attrValue, attrMetadata, resolutions);
         } // for
     } // persistOne
     

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
@@ -23,7 +23,6 @@ import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import static com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink.LOGGER;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import java.util.ArrayList;
-import java.util.Arrays;
 import org.apache.flume.Context;
 
 /**
@@ -32,7 +31,7 @@ import org.apache.flume.Context;
  */
 public class NGSISTHSink extends NGSIMongoBaseSink {
     
-    private final boolean[] resolutions = {false, false, false, false, false};
+    protected final boolean[] resolutions = {false, false, false, false, false};
 
     /**
      * Constructor.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
@@ -56,7 +56,7 @@ public class NGSIMongoBaseSinkTest {
      */
     @Test
     public void testConfigureCollectionPrefixIsNotSystem() {
-        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+        System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                 + "-------- Configured 'collection_prefix' cannot be 'system.'");
         String collectionPrefix = "system.";
         String dbPrefix = "sth_";
@@ -66,10 +66,10 @@ public class NGSIMongoBaseSinkTest {
         
         try {
             assertTrue(sink.invalidConfiguration);
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "-  OK  - 'system.' value detected for 'collection_prefix'");
         } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "- FAIL - 'system.' value not detected for 'collection_prefix'");
             throw e;
         } // try catch
@@ -80,7 +80,7 @@ public class NGSIMongoBaseSinkTest {
      */
     @Test
     public void testConfigureCollectionPrefixIsEncoded() {
-        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+        System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                 + "-------- Configured 'collection_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "this\\is/a$prefix.with-forbiden,chars:-.";
         String dbPrefix = "sth_";
@@ -91,11 +91,11 @@ public class NGSIMongoBaseSinkTest {
         
         try {
             assertTrue(sink.collectionPrefix.equals(encodedCollectionPrefix));
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "-  OK  - 'collection_prefix=" + collectionPrefix
                     + "' correctly encoded as '" + encodedCollectionPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "- FAIL - 'collection_prefix=" + collectionPrefix
                     + "' wrongly encoded as '" + encodedCollectionPrefix + "'");
             throw e;
@@ -107,7 +107,7 @@ public class NGSIMongoBaseSinkTest {
      */
     @Test
     public void testConfigureDBPrefixIsEncoded() {
-        System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+        System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                 + "-------- Configured 'db_prefix' is encoded when having forbiden characters");
         String collectionPrefix = "sth_";
         String dbPrefix = "this\\is/a$prefix.with forbiden\"chars:-,";
@@ -118,10 +118,10 @@ public class NGSIMongoBaseSinkTest {
         
         try {
             assertTrue(sink.dbPrefix.equals(encodedDbPrefix));
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "-  OK  - 'db_prefix=" + dbPrefix + "' correctly encoded as '" + encodedDbPrefix + "'");
         } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[OrionMongoSink.configure]")
+            System.out.println(getTestTraceHead("[OrionMongoBaseSink.configure]")
                     + "- FAIL - 'db_prefix=" + dbPrefix + "' wrongly encoded as '" + encodedDbPrefix + "'");
             throw e;
         } // try catch

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISTHSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISTHSinkTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.telefonica.iot.cygnus.utils.CommonUtilsForTests;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import java.util.Arrays;
+import org.apache.flume.Context;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSISTHSinkTest {
+    
+    /**
+     * Constructor.
+     */
+    public NGSISTHSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSISTHSinkTest
+    
+    /**
+     * [NGSIMongoSink.configure] -------- Non mandatory parameters get the default value when not configured.
+     */
+    @Test
+    public void testConfigureDefaultValues() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                + "-------- Non mandatory parameters get the default value when not configured");
+        String collectionPrefix = null; // default value
+        String dbPrefix = null; // default value
+        String dataModel = null; // default value
+        String resolutions = null; // default value
+        NGSISTHSink sink = new NGSISTHSink();
+        sink.configure(createContext(collectionPrefix, dbPrefix, dataModel, resolutions));
+        
+        try {
+            boolean[] expected = {true, true, true, true, true};
+            assertTrue(Arrays.equals(expected, sink.resolutions));
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - 'resolutions' gets the default value when not configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - 'resolutions' doesn't get the default value when not configured");
+            throw e;
+        } // try catch
+    } // testConfigureCollectionPrefixIsNotSystem
+    
+    /**
+     * [NGSIMongoSink.configure] -------- Non valid resolutions are detected.
+     */
+    @Test
+    public void testConfigureInvalidResolutions() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                + "-------- Non valid resolutions are detected");
+        String collectionPrefix = null; // default value
+        String dbPrefix = null; // default value
+        String dataModel = null; // default value
+        String resolutions = "month,week,second";
+        NGSISTHSink sink = new NGSISTHSink();
+        sink.configure(createContext(collectionPrefix, dbPrefix, dataModel, resolutions));
+        
+        try {
+            boolean[] expected = {true, false, false, false, true};
+            assertTrue(Arrays.equals(expected, sink.resolutions));
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - Invalid resolution 'week' has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - Invalid resolution 'week' has not been detected");
+            throw e;
+        } // try catch
+    } // testConfigureInvalidResolutions
+    
+    /**
+     * [NGSIMongoSink.configure] -------- Empty 'resolutions' means no persistence for any resolution.
+     */
+    @Test
+    public void testConfigureEmptyResolutions() {
+        System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                + "-------- Empty 'resolutions' means no persistence for any resolution");
+        String collectionPrefix = null; // default value
+        String dbPrefix = null; // default value
+        String dataModel = null; // default value
+        String resolutions = "";
+        NGSISTHSink sink = new NGSISTHSink();
+        sink.configure(createContext(collectionPrefix, dbPrefix, dataModel, resolutions));
+        
+        try {
+            boolean[] expected = {false, false, false, false, false};
+            assertTrue(Arrays.equals(expected, sink.resolutions));
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "-  OK  - Empty 'resolutions' detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[OrionSTHSink.configure]")
+                    + "- FAIL - Empty 'resolutions' not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEmptyResolutions
+    
+    private Context createContext(String collectionPrefix, String dbPrefix, String dataModel, String resolutions) {
+        Context context = CommonUtilsForTests.createContextForMongoSTH(collectionPrefix, dbPrefix, dataModel);
+        context.put("resolutions", resolutions);
+        return context;
+    } // createContext
+    
+} // NGSISTHSinkTest

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
@@ -153,7 +153,7 @@ Regarding the collection names, the MongoDB collection names will be, depending 
 [Top](#top)
 
 ####<a name="section1.3.3"></a>Storing
-Assuming `data_model=dm-by-entity` as configuration parameter, then `NGSISTHSink` will persist the data within the body as:
+Assuming `data_model=dm-by-entity` and all the possible resolutions as configuration parameters (see section [Configuration](#section2.1) for more details), then `NGSISTHSink` will persist the data within the body as:
 
     $ mongo -u myuser -p
     MongoDB shell version: 2.6.9
@@ -289,6 +289,7 @@ Assuming `data_model=dm-by-entity` as configuration parameter, then `NGSISTHSink
 | should_hash | no | false | <i>true</i> for collection names based on a hash, <i>false</i> for human redable collections. |
 | db_prefix | no | sth_ ||
 | collection_prefix | no | sth_ | `system.` is not accepted. |
+| resolutions | no | month,day,hour,minute,second | Resolutions for which it is desired to aggregate data. Accepted values are <i>month</i>, <i>day</i>, <i>hour</i>, <i>minute</i> and <i>second</i> separated  by comma. |
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
@@ -311,6 +312,7 @@ A configuration example could be:
     cygnusagent.sinks.sth-sink.db_prefix = cygnus_
     cygnusagent.sinks.sth-sink.collection_prefix = cygnus_
     cygnusagent.sinks.sth-sink.should_hash = false
+    cygnusagent.sinks.sth-sink.resolutions = month,day
     cygnusagent.sinks.sth-sink.batch_size = 100
     cygnusagent.sinks.sth-sink.batch_timeout = 30
     cygnusagent.sinks.sth-sink.batch_ttl = 10


### PR DESCRIPTION
* Implements issue #940 
* 100% unit tests passed:
```
Tests run: 66, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-common
Tests run: 106, Failures: 0, Errors: 0, Skipped: 0 --> cygnus-ngsi
```

Relevant tests for this PR:
```
Running com.telefonica.iot.cygnus.sinks.NGSISTHSinkTest
[OrionSTHSink.configure] ------------------------ Non mandatory parameters get the default value when not configured
[OrionSTHSink.configure] -----------------  OK  - 'resolutions' gets the default value when not configured
[OrionSTHSink.configure] ------------------------ Non valid resolutions are detected
[OrionSTHSink.configure] -----------------  OK  - Invalid resolution 'week' has been detected
[OrionSTHSink.configure] ------------------------ Empty 'resolutions' means no persistence for any resolution
[OrionSTHSink.configure] -----------------  OK  - Empty 'resolutions' detected
```

* (unofficial) e2e tests passed:
```
time=2016-06-01T15:42:49.043CEST | lvl=DEBUG | corr= | trans= | svc= | subsvc= | function=configure | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink[65] : [sth-sink] Reading configuration (resolutions=month,hour)
...
...
time=2016-06-01T15:43:06.292CEST | lvl=INFO | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=getEvents | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[264] : Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
...
...
time=2016-06-01T15:43:07.054CEST | lvl=INFO | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=persistOne | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink[183] : [sth-sink] Persisting data at OrionSTHSink. Database: sth_frb, Collection: sth_/resolutiontest_Room1_Room.aggr, Data: 1464788586314,Room1,Room,temperature,centigrade,26.5,[]
time=2016-06-01T15:43:07.177CEST | lvl=DEBUG | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=insertContextDataAggregatedForResoultion | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[271] : Prepopulating data, database=sth_frb, collection=sth_/resolutiontest_Room1_Room.aggr, query={ "_id" : { "attrName" : "temperature" , "origin" : { "$date" : "2016-06-01T00:00:00.000Z"} , "resolution" : "hour" , "range" : "day"} , "points.offset" : 13}, insert={ "$setOnInsert" : { "attrType" : "centigrade" , "points" : [ { "offset" : 0 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 1 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 2 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 3 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 4 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 5 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 6 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 7 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 8 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 9 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 10 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 11 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 12 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 13 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 14 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 15 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 16 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 17 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 18 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 19 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 20 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 21 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 22 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 23 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity}]}}
time=2016-06-01T15:43:07.179CEST | lvl=DEBUG | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=insertContextDataAggregatedForResoultion | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[277] : Updating data, database=sth_frb, collection=sth_/resolutiontest_Room1_Room.aggr, query={ "_id" : { "attrName" : "temperature" , "origin" : { "$date" : "2016-06-01T00:00:00.000Z"} , "resolution" : "hour" , "range" : "day"} , "points.offset" : 13}, update={ "$set" : { "attrType" : "centigrade"} , "$inc" : { "points.$.samples" : 1 , "points.$.sum" : 26.5 , "points.$.sum2" : 702.25} , "$min" : { "points.$.min" : 26.5} , "$max" : { "points.$.max" : 26.5}}
time=2016-06-01T15:43:07.293CEST | lvl=DEBUG | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=insertContextDataAggregatedForResoultion | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[271] : Prepopulating data, database=sth_frb, collection=sth_/resolutiontest_Room1_Room.aggr, query={ "_id" : { "attrName" : "temperature" , "origin" : { "$date" : "2016-01-01T00:00:00.000Z"} , "resolution" : "month" , "range" : "year"} , "points.offset" : 6}, insert={ "$setOnInsert" : { "attrType" : "centigrade" , "points" : [ { "offset" : 1 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 2 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 3 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 4 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 5 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 6 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 7 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 8 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 9 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 10 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 11 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity} , { "offset" : 12 , "samples" : 0 , "sum" : 0 , "sum2" : 0 , "min" : Infinity , "max" : -Infinity}]}}
time=2016-06-01T15:43:07.293CEST | lvl=DEBUG | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=insertContextDataAggregatedForResoultion | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[277] : Updating data, database=sth_frb, collection=sth_/resolutiontest_Room1_Room.aggr, query={ "_id" : { "attrName" : "temperature" , "origin" : { "$date" : "2016-01-01T00:00:00.000Z"} , "resolution" : "month" , "range" : "year"} , "points.offset" : 6}, update={ "$set" : { "attrType" : "centigrade"} , "$inc" : { "points.$.samples" : 1 , "points.$.sum" : 26.5 , "points.$.sum2" : 702.25} , "$min" : { "points.$.min" : 26.5} , "$max" : { "points.$.max" : 26.5}}
time=2016-06-01T15:43:07.352CEST | lvl=INFO | corr=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | trans=3901bd84-b9ce-4cb8-b595-60dfbae1c20c | svc=frb | subsvc=/resolutiontest | function=processNewBatches | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.sinks.NGSISink[400] : Finishing internal transaction (3901bd84-b9ce-4cb8-b595-60dfbae1c20c)
```