### PR TITLE
hardening/893_add_check_for_agent_file_name

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -624,6 +624,16 @@ public class ManagementInterface extends AbstractHandler {
         boolean allParameters = false;
         
         String param = request.getParameter("param");
+        String url = request.getRequestURI();
+     
+        String fileName = getFileName(url);
+        if (!(fileName.startsWith("agent_"))) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("{\"success\":\"false\","
+                + "\"error\":\"Agent file name must start with 'agent_'.\"}");
+            LOGGER.error("Agent file name must start with 'agent_'.");
+            return;
+        } // if
         
         if (param == null) {
             allParameters = true;
@@ -638,9 +648,9 @@ public class ManagementInterface extends AbstractHandler {
         String pathToFile;
         
         if (v1) {
-            pathToFile = request.getRequestURI().substring(29);
+            pathToFile = url.substring(29);
         } else {
-            pathToFile = request.getRequestURI().substring(26);
+            pathToFile = url.substring(26);
         } // if else 
         
         File file = new File(pathToFile);
@@ -961,6 +971,16 @@ public class ManagementInterface extends AbstractHandler {
         
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
+        String url = request.getRequestURI();
+     
+        String fileName = getFileName(url);
+        if (!(fileName.startsWith("agent_"))) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("{\"success\":\"false\","
+                + "\"error\":\"Agent file name must start with 'agent_'.\"}");
+            LOGGER.error("Agent file name must start with 'agent_'.");
+            return;
+        } // if
                 
         if (param == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -987,9 +1007,9 @@ public class ManagementInterface extends AbstractHandler {
         String pathToFile;
         
         if (v1) {
-            pathToFile = request.getRequestURI().substring(29);
+            pathToFile = url.substring(29);
         } else {
-            pathToFile = request.getRequestURI().substring(26);
+            pathToFile = url.substring(26);
         } // if
                 
         File file = new File(pathToFile);
@@ -1400,6 +1420,16 @@ public class ManagementInterface extends AbstractHandler {
         
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
+        String url = request.getRequestURI();
+     
+        String fileName = getFileName(url);
+        if (!(fileName.startsWith("agent_"))) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("{\"success\":\"false\","
+                + "\"error\":\"Agent file name must start with 'agent_'.\"}");
+            LOGGER.error("Agent file name must start with 'agent_'.");
+            return;
+        } // if
                 
         if (param == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -1426,9 +1456,9 @@ public class ManagementInterface extends AbstractHandler {
         String pathToFile;
         
         if (v1) {
-            pathToFile = request.getRequestURI().substring(29);
+            pathToFile = url.substring(29);
         } else {
-            pathToFile = request.getRequestURI().substring(26);
+            pathToFile = url.substring(26);
         } // if
                 
         File file = new File(pathToFile);
@@ -1938,5 +1968,15 @@ public class ManagementInterface extends AbstractHandler {
         printWriter.close();
         
     } // orderedPrinting
+    
+    /** 
+    * getFileName: Gets the name of the agent from the given path.
+    * 
+    * @param url 
+    */
+    private String getFileName (String url) {
+        String[] pathElements = url.split("/");
+        return pathElements[pathElements.length - 1];
+    } // getFileName
 
 } // ManagementInterface

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -626,9 +626,9 @@ public class ManagementInterface extends AbstractHandler {
         boolean allParameters = false;
         
         String param = request.getParameter("param");
-        String url = request.getRequestURI();
-     
+        String url = request.getRequestURI();     
         String fileName = getFileName(url);
+        
         if (!(fileName.startsWith("agent_"))) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().println("{\"success\":\"false\","
@@ -974,8 +974,8 @@ public class ManagementInterface extends AbstractHandler {
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
         String url = request.getRequestURI();
-     
         String fileName = getFileName(url);
+        
         if (!(fileName.startsWith("agent_"))) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().println("{\"success\":\"false\","
@@ -1198,8 +1198,8 @@ public class ManagementInterface extends AbstractHandler {
         
         String param = request.getParameter("param");
         String url = request.getRequestURI();
-     
         String fileName = getFileName(url);
+        
         if (!(fileName.startsWith("agent_"))) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().println("{\"success\":\"false\","
@@ -1503,8 +1503,8 @@ public class ManagementInterface extends AbstractHandler {
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
         String url = request.getRequestURI();
-     
         String fileName = getFileName(url);
+        
         if (!(fileName.startsWith("agent_"))) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().println("{\"success\":\"false\","

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -1197,6 +1197,16 @@ public class ManagementInterface extends AbstractHandler {
         response.setContentType("json;charset=utf-8");
         
         String param = request.getParameter("param");
+        String url = request.getRequestURI();
+     
+        String fileName = getFileName(url);
+        if (!(fileName.startsWith("agent_"))) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().println("{\"success\":\"false\","
+                + "\"error\":\"Agent file name must start with 'agent_'.\"}");
+            LOGGER.error("Agent file name must start with 'agent_'.");
+            return;
+        } // if
                 
         if (param == null) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -1215,9 +1225,9 @@ public class ManagementInterface extends AbstractHandler {
         String pathToFile;
         
         if (v1) {
-            pathToFile = request.getRequestURI().substring(29);
+            pathToFile = url.substring(29);
         } else {
-            pathToFile = request.getRequestURI().substring(26);
+            pathToFile = url.substring(26);
         } // if
                 
         File file = new File(pathToFile);


### PR DESCRIPTION
* Partially fix issue #893 
  * Update CHANGES_NEXT_RELASE is not neccesary.
* 100% Unit tests passed:
```
Results : Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
[VALID AGENT FILE NAME: Example with GET method] 
{"success":"true","result" : {"cygnusagent.sinks.mysql-sink.data_model":"dm-by-attribute"}

[INVALID AGENT FILE NAME: ` agente_cygnus.conf`]
{"success":"false","error":"Agent file name must start with 'agent_'."}
```