### PR TITLE
hardening/893_add_test_for_agent_file_name

### DIFF
--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -124,6 +124,7 @@ public class ManagementInterfaceTest {
     private final HttpServletRequest mockPostOneAgentParameter = mock(HttpServletRequest.class);
     private final HttpServletRequest mockPutOneAgentParameter = mock(HttpServletRequest.class);
     private final HttpServletRequest mockDeleteOneAgentParameter = mock(HttpServletRequest.class);
+    private final HttpServletRequest mockRequestBadFileName = mock(HttpServletRequest.class);
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -263,6 +264,14 @@ public class ManagementInterfaceTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
+        File fileBadFileName;
+        
+        try {
+            fileBadFileName = folder.newFile("cygnus_agent.conf");
+        } catch (IOException e) {
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
         when(mockGetAllAgentParameters.getMethod()).thenReturn("GET");
         when(mockGetAllAgentParameters.getRequestURI()).thenReturn("/admin/configuration/agent/" 
                     + fileGetAll.getAbsolutePath());
@@ -289,6 +298,10 @@ public class ManagementInterfaceTest {
         when(mockDeleteOneAgentParameter.getRequestURI()).thenReturn("/admin/configuration/agent/" 
                     + fileGetOnePutPostDelete.getAbsolutePath());
         
+        when(mockRequestBadFileName.getMethod()).thenReturn("GET");
+        when(mockRequestBadFileName.getRequestURI()).thenReturn("/admin/configuration/agent/"
+                    + fileBadFileName.getAbsolutePath());
+        
     } // setUp
     
     /**
@@ -296,7 +309,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testHandle() {
-        System.out.println(getTestTraceHead("[ManagementInterface.handle]") + " - Testing ManagementInterface.handle");        
+        System.out.println(getTestTraceHead("[ManagementInterface.handle]") + " -  Testing ManagementInterface.handle");        
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         
         try {
@@ -317,8 +330,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostAValidSubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method posts a "
-                + "valid subscription (ngsi_version = 1)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method posts a "
+                + "valid subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
@@ -348,8 +361,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostAValidSubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method posts a "
-                + "valid subscription (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method posts a "
+                + "valid subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
@@ -380,8 +393,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasNotSubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method doesn't "
-                + "find a subscription (ngsi_version = 1)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method doesn't "
+                + "find a subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -411,8 +424,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasNotSubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method doesn't "
-                + "find a subscription (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method doesn't "
+                + "find a subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -442,8 +455,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasEmptyFieldsV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method post a "
-                + "subscription with empty fields (ngsi_version = 1)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+                + "subscription with empty fields (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -473,8 +486,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasEmptyFieldsV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method post a "
-                + "subscription with empty fields (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+                + "subscription with empty fields (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -504,8 +517,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasMissingFieldsV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method post a "
-                + "subscription with missing fields (ngsi_version = 1)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+                + "subscription with missing fields (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -535,7 +548,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasMissingFieldsV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - 'POST method post a subscription with missing fields (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+                + "subscription with missing fields (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -565,8 +579,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodsDeletesASubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - 'DELETE method "
-                + "deletes a subscription (ngsi_version = 1)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  DELETE method "
+                + "deletes a subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -596,8 +610,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodsDeletesASubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - 'DELETE method "
-                + "deletes a subscription (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  DELETE method "
+                + "deletes a subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -627,8 +641,8 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodsGetsASubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - 'GET method gets a "
-                + "subscription (ngsi_version = 2)'.");
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  GET method gets a "
+                + "subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -658,8 +672,8 @@ public class ManagementInterfaceTest {
       */		
      @Test		
      public void testGetMethodsGetsAllSubscriptionsV2() throws Exception {		
-         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - 'GET method gets "
-                 + "all subscriptions (ngsi_version = 2)'.");	         
+         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  GET method gets "
+                 + "all subscriptions (ngsi_version = 2).");	         
          StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);		
          ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);		
          managementInterface.setOrionBackend(orionBackend);        		
@@ -689,7 +703,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodGetsAllAgentConfigurationParameters() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - GET "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " -  GET "
                 + "method gets all agent configuration parameters.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -699,7 +713,7 @@ public class ManagementInterfaceTest {
          try {		
              managementInterface.handleGetAdminConfigurationAgent(mockGetAllAgentParameters, responseWrapper, false);
          } catch (Exception x) {		
-             System.out.println("There was some problem when handling the GET subscription");		
+             System.out.println("There was some problem when handling the GET request");		
              throw x;		
          } // try catch
          
@@ -721,7 +735,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodGetsOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - GET "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " -  GET "
                 + "method gets one agent configuration parameter.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -731,7 +745,7 @@ public class ManagementInterfaceTest {
          try {		
              managementInterface.handleGetAdminConfigurationAgent(mockGetAllAgentParameters, responseWrapper, false);
          } catch (Exception x) {		
-             System.out.println("There was some problem when handling the GET subscription");		
+             System.out.println("There was some problem when handling the GET request");		
              throw x;		
          } // try catch
          
@@ -753,7 +767,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - POST "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " -  POST "
                 + "method post a single parameter in an agent configuration file'.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -763,7 +777,7 @@ public class ManagementInterfaceTest {
          try {		
              managementInterface.handlePostAdminConfigurationAgent(mockPostOneAgentParameter, responseWrapper, false);
          } catch (Exception x) {		
-             System.out.println("There was some problem when handling the POST subscription");		
+             System.out.println("There was some problem when handling the POST request");		
              throw x;		
          } // try catch
          
@@ -785,7 +799,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPutMethodPutOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - PUT "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " -  PUT "
                 + "method puts a single parameter in an agent configuration file.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -795,7 +809,7 @@ public class ManagementInterfaceTest {
          try {		
              managementInterface.handlePutAdminConfigurationAgent(mockPutOneAgentParameter, responseWrapper, false);
          } catch (Exception x) {		
-             System.out.println("There was some problem when handling the POST subscription");		
+             System.out.println("There was some problem when handling the PUT request");		
              throw x;		
          } // try catch
          
@@ -817,7 +831,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodDeleteOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - DELETE "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " -  DELETE "
                 + "method deletes a single parameter in an agent configuration file'.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -828,7 +842,7 @@ public class ManagementInterfaceTest {
              managementInterface.handleDeleteAdminConfigurationAgent(mockDeleteOneAgentParameter, 
                      responseWrapper, false);
          } catch (Exception x) {		
-             System.out.println("There was some problem when handling the DELETE subscription");		
+             System.out.println("There was some problem when handling the DELETE request");		
              throw x;		
          } // try catch
          
@@ -843,5 +857,37 @@ public class ManagementInterfaceTest {
          } // try catch	
     
     } // testDeleteMethodDeleteOneAgentConfigurationParameter
+    
+    /**
+     * [ManagementInterface] -------- 'Agent configuration file name starts with "agent_"'.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testAgentBadConfigurationFileName() throws Exception {
+        System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") +
+                  " -  Agent configuration doesn't start with 'agent_'.");
+        
+        StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
+        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        
+        
+         try {		
+             managementInterface.handleDeleteAdminConfigurationAgent(mockRequestBadFileName, responseWrapper, false);
+         } catch (Exception x) {		
+             System.out.println("There was some problem when handling the request");		
+             throw x;		
+         } // try catch
+         
+         try {		
+             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());		
+             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " -  "
+                     + "OK  - An agent configuration file not starting with 'agent_' has been detected");		
+         } catch (AssertionError e) {		
+             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "
+                     + "FAIL - There are some problems with your request");		
+             throw e;		
+         } // try catch	
+    
+    } // testAgentBadConfigurationFileName
     
 } // ManagementInterfaceTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -309,7 +309,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testHandle() {
-        System.out.println(getTestTraceHead("[ManagementInterface.handle]") + " -  Testing ManagementInterface.handle");        
+        System.out.println(getTestTraceHead("[ManagementInterface.handle]") + " - Testing ManagementInterface.handle");        
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         
         try {
@@ -330,7 +330,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostAValidSubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method posts a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
                 + "valid subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -345,7 +345,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
                     + "subscription");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - Invalid "
@@ -361,7 +361,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostAValidSubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method posts a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
                 + "valid subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -370,14 +370,14 @@ public class ManagementInterfaceTest {
         try {
             managementInterface.handlePostSubscription(mockRequestV2, responseWrapper);
         } catch (Exception e) {
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
                     + "subscription");
             throw e;
         } // try catch
         
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
                     + "subscription");        
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - Invalid "
@@ -393,7 +393,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasNotSubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method doesn't "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
                 + "find a subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -408,7 +408,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription not found");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -424,7 +424,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasNotSubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method doesn't "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
                 + "find a subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -439,7 +439,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription not found");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -455,7 +455,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasEmptyFieldsV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with empty fields (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -470,7 +470,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription has empty fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -486,7 +486,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasEmptyFieldsV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with empty fields (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -501,7 +501,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription has empty fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -517,7 +517,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasMissingFieldsV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with missing fields (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -532,7 +532,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription has missing fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -548,7 +548,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostHasMissingFieldsV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  POST method post a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with missing fields (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -563,7 +563,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
                     + "Subscription has missing fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -579,7 +579,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodsDeletesASubscriptionV1() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  DELETE method "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
                 + "deletes a subscription (ngsi_version = 1).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -594,7 +594,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - OK  - "
                     + "Subscription deleted");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - FAIL - "
@@ -610,7 +610,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodsDeletesASubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  DELETE method "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
                 + "deletes a subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -625,7 +625,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - OK  - "
                     + "Subscription deleted");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - FAIL - "
@@ -641,7 +641,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodsGetsASubscriptionV2() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  GET method gets a "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets a "
                 + "subscription (ngsi_version = 2).");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -656,7 +656,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - OK  - "
                     + "Subscription obtained");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - FAIL - There are "
@@ -672,7 +672,7 @@ public class ManagementInterfaceTest {
       */		
      @Test		
      public void testGetMethodsGetsAllSubscriptionsV2() throws Exception {		
-         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  GET method gets "
+         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets "
                  + "all subscriptions (ngsi_version = 2).");	         
          StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);		
          ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);		
@@ -687,7 +687,7 @@ public class ManagementInterfaceTest {
                  		
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  OK  - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - OK  - "
                      + "Subscription obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - FAIL - "
@@ -703,7 +703,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodGetsAllAgentConfigurationParameters() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " -  GET "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - GET "
                 + "method gets all agent configuration parameters.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -719,7 +719,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - "
                      + "OK  - All agent configuration parameters obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - "
@@ -735,7 +735,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testGetMethodGetsOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " -  GET "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - GET "
                 + "method gets one agent configuration parameter.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -751,7 +751,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - "
                      + "OK  - Agent configuration parameter obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - "
@@ -767,7 +767,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPostMethodPostOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " -  POST "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - POST "
                 + "method post a single parameter in an agent configuration file'.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -783,7 +783,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - "
                      + "OK  - Agent configuration parameter posted");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - "
@@ -799,7 +799,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testPutMethodPutOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " -  PUT "
+        System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - PUT "
                 + "method puts a single parameter in an agent configuration file.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -815,7 +815,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - "
                      + "OK  - Agent configuration parameter put");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - "
@@ -831,7 +831,7 @@ public class ManagementInterfaceTest {
      */
     @Test
     public void testDeleteMethodDeleteOneAgentConfigurationParameter() throws Exception {
-        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " -  DELETE "
+        System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - DELETE "
                 + "method deletes a single parameter in an agent configuration file'.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
@@ -848,7 +848,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - "
                      + "OK  - Agent configuration parameter deleted");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - "
@@ -865,7 +865,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testAgentBadConfigurationFileName() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") +
-                  " -  Agent configuration doesn't start with 'agent_'.");
+                  " - Agent configuration doesn't start with 'agent_'.");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -880,7 +880,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " -  "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "
                      + "OK  - An agent configuration file not starting with 'agent_' has been detected");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -331,7 +331,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostAValidSubscriptionV1() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
-                + "valid subscription (ngsi_version = 1).");
+                + "valid subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
@@ -345,7 +345,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
                     + "subscription");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - Invalid "
@@ -362,7 +362,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostAValidSubscriptionV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
-                + "valid subscription (ngsi_version = 2).");
+                + "valid subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
@@ -370,14 +370,14 @@ public class ManagementInterfaceTest {
         try {
             managementInterface.handlePostSubscription(mockRequestV2, responseWrapper);
         } catch (Exception e) {
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
                     + "subscription");
             throw e;
         } // try catch
         
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - Valid "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - Valid "
                     + "subscription");        
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - Invalid "
@@ -394,7 +394,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasNotSubscriptionV1() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
-                + "find a subscription (ngsi_version = 1).");
+                + "find a subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -408,7 +408,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription not found");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -425,7 +425,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasNotSubscriptionV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
-                + "find a subscription (ngsi_version = 2).");
+                + "find a subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -439,7 +439,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription not found");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -456,7 +456,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasEmptyFieldsV1() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
-                + "subscription with empty fields (ngsi_version = 1).");
+                + "subscription with empty fields (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -470,7 +470,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription has empty fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -487,7 +487,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasEmptyFieldsV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
-                + "subscription with empty fields (ngsi_version = 2).");
+                + "subscription with empty fields (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -501,7 +501,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription has empty fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -518,7 +518,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasMissingFieldsV1() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
-                + "subscription with missing fields (ngsi_version = 1).");
+                + "subscription with missing fields (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -532,7 +532,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription has missing fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -549,7 +549,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostHasMissingFieldsV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
-                + "subscription with missing fields (ngsi_version = 2).");
+                + "subscription with missing fields (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -563,7 +563,7 @@ public class ManagementInterfaceTest {
         
         try {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " -  OK  - "
                     + "Subscription has missing fields");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - FAIL - "
@@ -580,7 +580,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testDeleteMethodsDeletesASubscriptionV1() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
-                + "deletes a subscription (ngsi_version = 1).");
+                + "deletes a subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -594,7 +594,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  OK  - "
                     + "Subscription deleted");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - FAIL - "
@@ -611,7 +611,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testDeleteMethodsDeletesASubscriptionV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
-                + "deletes a subscription (ngsi_version = 2).");
+                + "deletes a subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -625,7 +625,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " -  OK  - "
                     + "Subscription deleted");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - FAIL - "
@@ -642,7 +642,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testGetMethodsGetsASubscriptionV2() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets a "
-                + "subscription (ngsi_version = 2).");
+                + "subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
@@ -656,7 +656,7 @@ public class ManagementInterfaceTest {
                 
         try {
             assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());
-            System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - OK  - "
+            System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  OK  - "
                     + "Subscription obtained");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - FAIL - There are "
@@ -673,7 +673,7 @@ public class ManagementInterfaceTest {
      @Test		
      public void testGetMethodsGetsAllSubscriptionsV2() throws Exception {		
          System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets "
-                 + "all subscriptions (ngsi_version = 2).");	         
+                 + "all subscriptions (ngsi_version = 2)");	         
          StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);		
          ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);		
          managementInterface.setOrionBackend(orionBackend);        		
@@ -687,7 +687,7 @@ public class ManagementInterfaceTest {
                  		
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - OK  - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " -  OK  - "
                      + "Subscription obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - FAIL - "
@@ -704,7 +704,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testGetMethodGetsAllAgentConfigurationParameters() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - GET "
-                + "method gets all agent configuration parameters.");
+                + "method gets all agent configuration parameters");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -719,7 +719,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " -  "
                      + "OK  - All agent configuration parameters obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetAgentConfParams]") + " - "
@@ -736,7 +736,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testGetMethodGetsOneAgentConfigurationParameter() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - GET "
-                + "method gets one agent configuration parameter.");
+                + "method gets one agent configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -751,7 +751,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " -  "
                      + "OK  - Agent configuration parameter obtained");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleGetOneAgentConfParam]") + " - "
@@ -768,7 +768,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPostMethodPostOneAgentConfigurationParameter() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - POST "
-                + "method post a single parameter in an agent configuration file'.");
+                + "method post a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -783,7 +783,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " -  "
                      + "OK  - Agent configuration parameter posted");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handlePostOneAgentConfParam]") + " - "
@@ -800,7 +800,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testPutMethodPutOneAgentConfigurationParameter() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - PUT "
-                + "method puts a single parameter in an agent configuration file.");
+                + "method puts a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -815,7 +815,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " -  "
                      + "OK  - Agent configuration parameter put");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handlePutOneAgentConfParam]") + " - "
@@ -832,7 +832,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testDeleteMethodDeleteOneAgentConfigurationParameter() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - DELETE "
-                + "method deletes a single parameter in an agent configuration file'.");
+                + "method deletes a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -848,7 +848,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_OK, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " -  "
                      + "OK  - Agent configuration parameter deleted");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteOneAgentConfParam]") + " - "
@@ -865,7 +865,7 @@ public class ManagementInterfaceTest {
     @Test
     public void testAgentBadConfigurationFileName() throws Exception {
         System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") +
-                  " - Agent configuration doesn't start with 'agent_'.");
+                  " - Agent configuration doesn't start with 'agent_'");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
@@ -880,7 +880,7 @@ public class ManagementInterfaceTest {
          
          try {		
              assertEquals(HttpServletResponse.SC_BAD_REQUEST, responseWrapper.getStatus());		
-             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "
+             System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " -  "
                      + "OK  - An agent configuration file not starting with 'agent_' has been detected");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -884,7 +884,7 @@ public class ManagementInterfaceTest {
                      + "OK  - An agent configuration file not starting with 'agent_' has been detected");		
          } catch (AssertionError e) {		
              System.out.println(getTestTraceHead("[ManagementInterface.handleAgentConfFileName]") + " - "
-                     + "FAIL - There are some problems with your request");		
+                     + "FAIL - An agent configuration file not starting with 'agent_' has not been detected");		
              throw e;		
          } // try catch	
     


### PR DESCRIPTION
* Partially fix issue #893 
  * Update CHANGES_NEXT_RELEASE is not neccesary.
* 100% unit tests passed:
```
Results : Tests run: 73, Failures: 0, Errors: 0, Skipped: 0
```
* Logs:
```
[ManagementInterface.handleAgentConfFileName] ------- -  Agent configuration doesn't start with 'agent_'.
[ManagementInterface.handleAgentConfFileName] ------- -  OK  - An agent configuration file not starting with 'agent_' has been detected
```
* Assignee: @frbattid 