### PR TITLE
hardening/894_create_POST_instance_conf_method

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -2225,14 +2225,8 @@ public class ManagementInterface extends AbstractHandler {
             throws FileNotFoundException {
                 
         PrintWriter printWriter = new PrintWriter(file);      
-        boolean hasHeader = Boolean.valueOf(descriptions.get("hasHeader"));
-        
-        if (!hasHeader) {
-            printWriter.println(descriptions.get("header"));
-        } else {
-            printWriter.println(CommonConstants.INSTANCE_HEADER);
-            printWriter.println();
-        } // if else
+        printWriter.println(CommonConstants.CYGNUS_IPR_HEADER);
+        printWriter.println();
         
         for (Object key : properties.keySet()) {
             String name = (String) key;
@@ -2267,31 +2261,13 @@ public class ManagementInterface extends AbstractHandler {
     private Map<String,String> readDescriptions(File file) throws IOException {
                 
         // read the comments and the properties
-        BufferedReader readerHeader = new BufferedReader(new FileReader(file));
-        BufferedReader readerbody = new BufferedReader(new FileReader(file));
+        BufferedReader reader = new BufferedReader(new FileReader(file));
         String header = "";
         String description = "";
         String line;
         Map<String,String> descriptions = new HashMap<String,String>();
-        
-        while ((line = readerHeader.readLine()) != null) {
-                        
-            if (line.startsWith("#")) {
-                header += line + "\n";
-            } // if
-            
-            if (line.isEmpty()) {
-                descriptions.put("hasHeader", "true");
-                descriptions.put("header", header);
-                break;
-            } else if ((!(line.startsWith("#")) && (!(line.isEmpty())))) {
-                descriptions.put("header", "false");
-            } // if else
-        } // while
-        
-        readerHeader.close();
 
-        while ((line = readerbody.readLine()) != null) {
+        while ((line = reader.readLine()) != null) {
             
             if (line.startsWith("#")) {
                 description += line + "\n";
@@ -2308,7 +2284,7 @@ public class ManagementInterface extends AbstractHandler {
             
         } // while
         
-        readerbody.close();
+        reader.close();
         return descriptions;
     }
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -1184,12 +1184,12 @@ public class ManagementInterface extends AbstractHandler {
         } // if
                 
         File file = new File(pathToFile);
-        Map<String, String> descriptions = readDescriptions(file);
         
         try {
             Properties properties = new Properties();           
             properties.load(new FileInputStream(file));
-            JSONObject jsonObject = new JSONObject();
+            JSONObject jsonObject = new JSONObject();          
+            Map<String, String> descriptions = readDescriptions(file);
             
             for (Object key: properties.keySet()) {
                 String name = (String) key;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -232,14 +232,14 @@ public class ManagementInterface extends AbstractHandler {
     } // handle
 
     private void handleGetVersion(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().println("{\"success\":\"true\",\"version\":\"" + CommonUtils.getCygnusVersion()
                 + "." + CommonUtils.getLastCommit() + "\"}");
     } // handleGetVersion
 
     private void handleGetStats(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         String jsonStr = "{\"success\":\"true\",\"stats\":{\"sources\":[";
         boolean first = true;
@@ -373,7 +373,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handleGetStats
 
     private void handleGetGroupingRules(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
 
         if (groupingRulesConfFile == null) {
             response.getWriter().println("{\"success\":\"false\","
@@ -397,7 +397,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handleGetGroupingRules
     
     private void handleGetAdminLog(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         try {
             Level level = LogManager.getRootLogger().getLevel();
@@ -437,7 +437,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handleGetAdminLog
     
     protected void handleGetSubscriptions(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         // flag for use get all or get one subscription
         boolean getAllSubscriptions = false;
@@ -632,7 +632,7 @@ public class ManagementInterface extends AbstractHandler {
     protected void handleGetAdminConfigurationAgent(HttpServletRequest request, HttpServletResponse response, 
             boolean v1) throws IOException {
         
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         boolean allParameters = false;
         
         String param = request.getParameter("param");
@@ -707,7 +707,7 @@ public class ManagementInterface extends AbstractHandler {
     protected void handleGetAdminConfigurationInstance (HttpServletRequest request, HttpServletResponse response, 
             boolean v1) throws IOException {
         
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         boolean allParameters = false;
         
         String param = request.getParameter("param");
@@ -778,7 +778,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handleGetAdminConfigurationInstance
 
     private void handlePostGroupingRules(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
 
         // read the new rule wanted to be added
         BufferedReader reader = request.getReader();
@@ -871,7 +871,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handlePostGroupingRules
 
     protected void handlePostSubscription(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         
         // read the new rule wanted to be added
@@ -1052,7 +1052,7 @@ public class ManagementInterface extends AbstractHandler {
     
     protected void handlePostAdminConfigurationAgent(HttpServletRequest request, HttpServletResponse response,
             boolean v1) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
@@ -1138,7 +1138,7 @@ public class ManagementInterface extends AbstractHandler {
     
     protected void handlePostAdminConfigurationInstance (HttpServletRequest request, HttpServletResponse response,
             boolean v1) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         String param = request.getParameter("param").toUpperCase();
         String newValue = request.getParameter("value");
@@ -1214,7 +1214,7 @@ public class ManagementInterface extends AbstractHandler {
             
         } catch (Exception e) {
             response.getWriter().println("{\"success\":\"false\","
-                    + "\"result\" : { \"File not found in the path received\" }");
+                    + "\"result\" : {\"File not found in the path received\"}");
             LOGGER.debug("File not found in the path received. Details: " +  e.getMessage());
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         } // if else    
@@ -1222,7 +1222,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handlePostAdminConfigurationInstance
     
     protected void handleDeleteSubscription(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         String subscriptionId = request.getParameter("subscription_id");
         String ngsiVersion = request.getParameter("ngsi_version");
@@ -1362,7 +1362,7 @@ public class ManagementInterface extends AbstractHandler {
     
     protected void handleDeleteAdminConfigurationAgent (HttpServletRequest request, HttpServletResponse response, 
             boolean v1) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         String param = request.getParameter("param");
         String url = request.getRequestURI();
@@ -1441,7 +1441,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handleDeleteAdminConfigurationAgent
     
     private void handlePutStats(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         for (String key : sources.keySet()) {
             Source source;
@@ -1522,7 +1522,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handlePutStats
 
     private void handlePutGroupingRules(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
 
         // read the new rule wanted to be added
         BufferedReader reader = request.getReader();
@@ -1621,7 +1621,7 @@ public class ManagementInterface extends AbstractHandler {
     } // handlePutGroupingRules
     
     private void handlePutAdminLog(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         // get the parameters to be updated
         String logLevel = request.getParameter("level");
@@ -1666,7 +1666,7 @@ public class ManagementInterface extends AbstractHandler {
     
     protected void handlePutAdminConfigurationAgent(HttpServletRequest request, HttpServletResponse response,
             boolean v1) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         
         String param = request.getParameter("param");
         String newValue = request.getParameter("value");
@@ -1739,7 +1739,7 @@ public class ManagementInterface extends AbstractHandler {
     
     private void handleDeleteGroupingRules(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
 
         // get the rule ID to be deleted
         long id = new Long(request.getParameter("id"));
@@ -1808,7 +1808,7 @@ public class ManagementInterface extends AbstractHandler {
     } // getGroupingRulesConfFile
 
     private void handleGetGUI(HttpServletResponse response) throws IOException {
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
 
         String indexJSP = "";
@@ -1838,7 +1838,7 @@ public class ManagementInterface extends AbstractHandler {
             if (channel instanceof CygnusChannel) {
                 CygnusChannel cygnusChannel = (CygnusChannel) channel;
                 point += "," + cygnusChannel.getNumEvents();
-            } // if
+            } // if12
         } // for
 
         point += "]";
@@ -1856,7 +1856,7 @@ public class ManagementInterface extends AbstractHandler {
         numPoints++;
 
         // return the points
-        response.setContentType("json;charset=utf-8");
+        response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().println(
                 "{\"source_points\":{\"columns\":[" + sourceColumns + "],\"rows\":[" + sourceRows + "]},"

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -71,4 +71,32 @@ public final class CommonConstants {
     public static final String INTERNAL_CONCATENATOR = "=";
     public static final String CONCATENATOR = "x0000";
     
+    // Header for API uses
+    public static final String INSTANCE_HEADER = "#####\n" 
+                                    + "#\n" 
+                                    + "# Configuration file for apache-flume\n" 
+                                    + "#\n" 
+                                    + "#####\n" 
+                                    + "# Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U\n" 
+                                    + "# \n" 
+                                    + "# This file is part of fiware-cygnus (FI-WARE project).\n" 
+                                    + "# \n" 
+                                    + "# fiware-cygnus is free software: you can redistribute it and/or modify it under "
+                                    + "the terms of the GNU Affero General\n" 
+                                    + "# Public License as published by the Free Software Foundation, either version 3 "
+                                    + "of the License, or (at your option) any\n" 
+                                    + "# later version.\n" 
+                                    + "# fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT "
+                                    + "ANY WARRANTY; without even the implied\n" 
+                                    + "# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU "
+                                    + "Affero General Public License for more\n" 
+                                    + "# details.\n" 
+                                    + "# \n" 
+                                    + "# You should have received a copy of the GNU Affero General Public License "
+                                    + "along with fiware-cygnus. If not, see\n" 
+                                    + "# http://www.gnu.org/licenses/.\n" 
+                                    + "# \n" 
+                                    + "# For those usages not covered by the GNU Affero General Public License please "
+                                    + "contact with iot_support at tid dot es";
+    
 } // CommonConstants

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -72,11 +72,7 @@ public final class CommonConstants {
     public static final String CONCATENATOR = "x0000";
     
     // Header for API uses
-    public static final String INSTANCE_HEADER = "#####\n" 
-                                    + "#\n" 
-                                    + "# Configuration file for apache-flume\n" 
-                                    + "#\n" 
-                                    + "#####\n" 
+    public static final String CYGNUS_IPR_HEADER = "#####\n"  
                                     + "# Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U\n" 
                                     + "# \n" 
                                     + "# This file is part of fiware-cygnus (FI-WARE project).\n" 

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -20,13 +20,14 @@ Content:
 * [GET `/admin/configuration/instance`](#section15)
   * [GET all parameters](#section15.1)
   * [GET a single parameter](#section15.2)
-* [POST `/v1/subscriptions`](#section16)
-  * [`NGSI Version 1`](#section16.1)
-  * [`NGSI Version 2`](#section16.2)
-* [DELETE `/v1/subscriptions`](#section17)
-* [GET `/v1/subscriptions`](#section18)
-  * [GET subscription by ID](#section18.1)
-  * [GET all subscriptions](#section18.2)
+* [POST `/admin/configuration/instance`](#section16)
+* [POST `/v1/subscriptions`](#section17)
+  * [`NGSI Version 1`](#section17.1)
+  * [`NGSI Version 2`](#section17.2)
+* [DELETE `/v1/subscriptions`](#section18)
+* [GET `/v1/subscriptions`](#section19)
+  * [GET subscription by ID](#section19.1)
+  * [GET all subscriptions](#section19.2)
 
 ##<a name="section1"></a>Apiary version of this document
 This API specification can be checked at [Apiary](http://telefonicaid.github.io/fiware-cygnus/api/) as well.
@@ -622,8 +623,50 @@ Instance configuration file not found:
 
 [Top](#top)
 
-##<a name="section16"></a>`POST /v1/subscriptions`
-###<a name="section16.1"></a> `NGSI Version 1`
+##<a name="section16"></a>`POST /admin/configuration/instance`
+
+Posts a single parameter if it doesn't exist in the instance given the path to the configuration file as the URI within the URL and the name and the value of the parameter as a query parameters. The path to the instance must be with `/usr/cygnus/conf`.
+
+```
+POST "http://<cygnus_host>:<management_port>/admin/configuration/instance/usr/cygnus/conf/cygnus_instance.conf?param=<param_name>&value=<param_value>"
+```
+
+NOTE: Using the `/v1/admin/configuration/instance` path behaves the same way.
+
+```
+POST "http://<cygnus_host>:<management_port>/v1/admin/configuration/instance/usr/cygnus/conf/cygnus_instance.conf?param=<param_name>&value=<param_value>"
+```
+
+Responses:
+
+Valid path to the instance configuration file:
+
+```
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnusagent","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT_2":"8082","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
+```
+
+Invalid path to the instance configuration file:
+
+```
+{"success":"false","result" : {"Invalid path for a instance configuration file"}
+```
+
+Existing value in the instance configuration file:
+
+```
+{"success":"false","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnusagent","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT":"8081","CYGNUS_USER":"cygnus","LOGFILE_NAME":"cygnus.log","POLLING_INTERVAL":"30"}}}
+```
+
+Instance configuration file not found:
+
+```
+{"success":"false","result" : {"File not found in the path received"}
+```
+
+[Top](#top)
+
+##<a name="section17"></a>`POST /v1/subscriptions`
+###<a name="section17.1"></a> `NGSI Version 1`
 
 Creates a new subscription to Orion given the version of NGSI (`ngsi_version=1` in this case). The Json passed in the payload contains the Json subscription itself and Orion's endpoint details.
 
@@ -684,7 +727,7 @@ Please observe Cygnus checks if the Json passed in the payload is valid (syntact
 
 [Top](#top)
 
-###<a name="section16.2"></a> `NGSI Version 2`
+###<a name="section17.2"></a> `NGSI Version 2`
 
 Creates a new subscription to Orion given the version of NGSI (`ngsi_version=2` in this case). The Json passed in the payload contains the Json subscription itself and Orion's endpoint details.
 
@@ -756,7 +799,7 @@ Please observe Cygnus checks if the Json passed in the payload is valid (syntact
 
 [Top](#top)
 
-##<a name="section17"></a>`DELETE /v1/subscriptions`
+##<a name="section18"></a>`DELETE /v1/subscriptions`
 
 Deletes a subscription made to Orion given its ID and the NGSI version. The Json passed in the payload contains the Orion's endpoint details.
 
@@ -811,8 +854,8 @@ Missing fields (empty or not given):
 
 [Top](#top)
 
-##<a name="section18"></a>`GET /v1/subscriptions`
-###<a name="section18.1"></a> GET subscription by ID
+##<a name="section19"></a>`GET /v1/subscriptions`
+###<a name="section19.1"></a> GET subscription by ID
 
 Gets an existent subscription from Orion, given the NGSI version and the subscription id as a query parameter.
 
@@ -857,7 +900,7 @@ Missing or empty parameters:
 
 [Top](#top)
 
-###<a name="section18.2"></a> GET all subscriptions
+###<a name="section19.2"></a> GET all subscriptions
 
 Gets all existent subscriptions from Orion, given the NGSI version as a query parameter.
 


### PR DESCRIPTION
* Partially fix issue #894 
  * Update CHANGES_NEXT_RELEASE is not neccesary
* 100% unit tests passed:
```
Results : Tests run: 73, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
[POSTING A NEW PARAMETER `ADMIN_PORT_2`]
$ curl -X POST "http://localhost:8081/admin/configuration/instance/usr/cygnus/conf/cygnus_instance_test.conf?param=ADMIN_PORT_2&value=8082"
{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnusagent","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT_2":"8082","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}

[POSTING AN EXISTENT PARAMETER `ADMIN_PORT_2`]
$ curl -X POST "http://localhost:8081/admin/configuration/instance/usr/cygnus/conf/cygnus_instance.conf?param=ADMIN_PORT_2&value=8082"
{"success":"false","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnusagent","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT":"8081","ADMIN_PORT_2":"8082","CYGNUS_USER":"cygnus","LOGFILE_NAME":"cygnus.log","POLLING_INTERVAL":"30"}}}

[INVALID PATH: Must be `/usr/cygnus/conf` ]
$ curl -X POST "http://localhost:8081/admin/configuration/instance/usr/cygnus/configuration/cygnus_instance_test.conf?param=ADMIN_PORT_3&value=8083"
{"success":"false","result" : {"Invalid path for a instance configuration file"}

[INEXISTENT FILE NAME]
$ curl -X POST "http://localhost:8081/admin/configuration/instance/usr/cygnus/conf/cygnus_inexistent.conf?param=ADMIN_PORT_2&value=8082"
{"success":"false","result" : {"File not found in the path received"}
```
* Instance conf file before POST [Without copyright header] : 
```
# Who to run cygnus as. Note that you may need to use root if you want
# to run cygnus in a privileged port (<1024)
CYGNUS_USER=cygnus

# Where is the config folder
CONFIG_FOLDER=/usr/cygnus/conf

# Which is the config file
CONFIG_FILE=/usr/cygnus/conf/agent.conf

# Administration port. Must be unique per instance
ADMIN_PORT=8081

# Name of the agent. The name of the agent is not trivial, since it is the base for the Flume parameters 
# naming conventions, e.g. it appears in .sources.http-source.channels=...
AGENT_NAME=cygnusagent

# Polling interval (seconds) for the configuration reloading
POLLING_INTERVAL=30

# Name of the logfile located at /var/log/cygnus. It is important to put the extension '.log' in order to the log rotation works properly
LOGFILE_NAME=cygnus.log
```
* Instance configuration file after POST: 
```
#####
#
# Configuration file for apache-flume
#
#####
# Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
# 
# This file is part of fiware-cygnus (FI-WARE project).
# 
# fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
# later version.
# fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
# details.
# 
# You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
# http://www.gnu.org/licenses/.
# 
# For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es

# Which is the config file
CONFIG_FILE=/usr/cygnus/conf/agent.conf

# Name of the agent. The name of the agent is not trivial, since it is the base for the Flume parameters 
# naming conventions, e.g. it appears in .sources.http-source.channels=...
AGENT_NAME=cygnusagent

# Administration port. Must be unique per instance
ADMIN_PORT=8081

# Where is the config folder
CONFIG_FOLDER=/usr/cygnus/conf

ADMIN_PORT_2=8082

# Name of the logfile located at /var/log/cygnus. It is important to put the extension '.log' in order to the log rotation works properly
LOGFILE_NAME=cygnus.log

# Who to run cygnus as. Note that you may need to use root if you want
# to run cygnus in a privileged port (<1024)
CYGNUS_USER=cygnus

# Polling interval (seconds) for the configuration reloading
POLLING_INTERVAL=30
```

* Assignee: @frbattid 