### PR TITLE
hardening/807_add_admin_log_route

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - [cygnus-ngsi][bug] Change mysql and mongo hosts to "iot-mysql" and "iot-mongo" (#1105)
+- [cygnus-common][hardening] Add implementation for /admin/log route (#807)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -147,7 +147,7 @@ public class ManagementInterface extends AbstractHandler {
                 } else if (uri.equals("/v1/groupingrules")) {
                     handleGetGroupingRules(response);
                 } else if (uri.equals("/admin/log")) {
-                    handleGetAdminLog(response);
+                    handleGetAdminLog(request, response);
                 } else if (uri.equals("/v1/subscriptions")) {
                     handleGetSubscriptions(request, response);
                 } else if (uri.startsWith("/admin/configuration/agent")) {
@@ -405,38 +405,53 @@ public class ManagementInterface extends AbstractHandler {
         response.getWriter().println("{\"success\":\"true\"," + rulesStr + "}");
     } // handleGetGroupingRules
     
-    private void handleGetAdminLog(HttpServletResponse response) throws IOException {
+    private void handleGetAdminLog(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json; charset=utf-8");
         
         try {
             Level level = LogManager.getRootLogger().getLevel();
-            Enumeration appenders = LogManager.getRootLogger().getAllAppenders();
-            String appendersJson = "";
+            String verbose = request.getParameter("verbose");
+            
+            if (verbose == null) {
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.getWriter().println("{\"level\": \"" + level + "\"}");
+                LOGGER.info("Log level succesfully sent");
+            } else if (verbose.equals("true")) {
+                Enumeration appenders = LogManager.getRootLogger().getAllAppenders();
+                String appendersJson = "";
 
-            while (appenders.hasMoreElements()) {
-                Appender appender = (Appender) appenders.nextElement();
-                String name = appender.getName();
-                PatternLayout layout = (PatternLayout) appender.getLayout();
+                while (appenders.hasMoreElements()) {
+                    Appender appender = (Appender) appenders.nextElement();
+                    String name = appender.getName();
+                    PatternLayout layout = (PatternLayout) appender.getLayout();
+
+                    if (appendersJson.isEmpty()) { 
+                        appendersJson = "[{\"name\":\"" + name + "\",\"layout\":\"" 
+                                + layout.getConversionPattern() + "\"}";
+                    } else {
+                        appendersJson += ",{\"name\":\"" + name + "\",\"layout\":\""
+                                + layout.getConversionPattern() + "\"}";
+                    } // else
+                    
+                } // while
 
                 if (appendersJson.isEmpty()) {
-                    appendersJson = "[{\"name\":\"" + name + "\",\"layout\":\""
-                            + layout.getConversionPattern() + "\"}";
+                    appendersJson = "[]";
                 } else {
-                    appendersJson += ",{\"name\":\"" + name + "\",\"layout\":\""
-                            + layout.getConversionPattern() + "\"}";
+                    appendersJson += "]";
                 } // else
-            } // while
 
-            if (appendersJson.isEmpty()) {
-                appendersJson = "[]";
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.getWriter().println("{\"success\":\"true\",\"log4j\":{\"level\":\"" + level
+                        + "\",\"appenders\":" + appendersJson + "}}");
+                LOGGER.info("Log4j configuration successfully sent");
             } else {
-                appendersJson += "]";
-            } // else
-
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.getWriter().println("{\"success\":\"true\",\"log4j\":{\"level\":\"" + level
-                    + "\",\"appenders\":" + appendersJson + "}}");
-            LOGGER.info("Log4j configuration successfully sent");
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.getWriter().println("{\"success\":\"false\",\"Verbose parameter only accepts "
+                        + "'true' as value\"}");
+                LOGGER.info("Verbose parameter only accepts 'true' as value");
+            } // if else if
+            
         } catch (Exception e) {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             response.getWriter().println("{\"success\":\"false\",\"error\":\"" + e.getMessage() + "\"}");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -412,7 +412,7 @@ public class ManagementInterface extends AbstractHandler {
             Level level = LogManager.getRootLogger().getLevel();
             String verbose = request.getParameter("verbose");
             
-            if (verbose == null) {
+            if ((verbose == null) || (verbose.equals("false"))) {
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.getWriter().println("{\"level\": \"" + level + "\"}");
                 LOGGER.info("Log level succesfully sent");
@@ -445,11 +445,6 @@ public class ManagementInterface extends AbstractHandler {
                 response.getWriter().println("{\"success\":\"true\",\"log4j\":{\"level\":\"" + level
                         + "\",\"appenders\":" + appendersJson + "}}");
                 LOGGER.info("Log4j configuration successfully sent");
-            } else {
-                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                response.getWriter().println("{\"success\":\"false\",\"Verbose parameter only accepts "
-                        + "'true' as value\"}");
-                LOGGER.info("Verbose parameter only accepts 'true' as value");
             } // if else if
             
         } catch (Exception e) {

--- a/doc/apiary/apiary.apib
+++ b/doc/apiary/apiary.apib
@@ -601,6 +601,39 @@ Error list (HTTP response code in parenthesis):
 
 ## Group Admin API
 
+### Gets the log4j logging level [GET /admin/log]
+
++ Parameters
+
+       + ngsi_version: true or false (this case is equals to avoid the parameter)
+
++ Request
+
+       GET http://<cygnus_host>:<management_port>/admin/log?verbose=<verbose_value>
+
++ Response 200 (application/json)
+
+       {
+               "log4j": {
+                       "appenders": [
+                               {
+                                       "layout": "...",
+                                       "name": "..."
+                               }
+                       ],
+                       "level": "..."
+               },
+                       "success": "true"
+       }
+
++ Response 500 (application/json)
+
+       {
+               "error": "..."
+       }
+
+
+
 ### Gets the log4j configuration [GET /admin/log]
 
 + Request
@@ -610,16 +643,7 @@ Error list (HTTP response code in parenthesis):
 + Response 200 (application/json)
 
        {
-           "log4j": {
-           "appenders": [
-               {
-                   "layout": "...",
-                   "name": "..."
-               }
-            ],
-            "level": "..."
-           },
-           "success": "true"
+           "level": "..."
        }
 
 + Response 500 (application/json)

--- a/doc/apiary/apiary.apib
+++ b/doc/apiary/apiary.apib
@@ -605,7 +605,7 @@ Error list (HTTP response code in parenthesis):
 
 + Parameters
 
-       + ngsi_version: true or false (this case is equals to avoid the parameter)
+       + ngsi_version: true or false (this case is the same than avoiding the verbose parameter, see next section)
 
 + Request
 

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -242,7 +242,7 @@ Response:
 [Top](#top)
 
 ##<a name="section9"></a>`GET /admin/log`
-If parameterized with `verbose=true` (or directly, the `verbose` parameter is avoided), it simply gets the logging level.
+If parameterized with `verbose=false` (or directly, the `verbose` parameter is avoided), it simply gets the logging level.
 ```
 GET http://<cygnus_host>:<management_port>/admin/log
 ```

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -227,7 +227,7 @@ Response:
 [Top](#top)
 
 ##<a name="section8"></a>`DELETE /v1/groupingrules`
-Deletes a [grouping rules](../flume_extensions_catalogue/grouping_interceptor.md), given its ID a a query parameter.
+Deletes a [grouping rules](../flume_extensions_catalogue/grouping_interceptor.md), given its ID as a query parameter.
 
 ```
 DELETE http://<cygnus_host>:<management_port>/v1/groupingrules?id=2
@@ -242,28 +242,41 @@ Response:
 [Top](#top)
 
 ##<a name="section9"></a>`GET /admin/log`
-Gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts).
-
+Gets the logging level.
 ```
-GET http://<cygnus_host>:<management_port>/admin/log
+GET http://<cygnus_host>:<management_port>/admin/log4j
 ```
 
 Responses:
 
 ```
 200 OK
+{"level": "...."}
+```
+
+```
+500 Internal Server Error
 {
-    "log4j": {
-        "appenders": [
-            {
-                "layout": "...",
-                "name": "..."
-            }
-        ],
-        "level": "..."
-    },
-    "success": "true"
+    "error": "..."
 }
+```
+
+Gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts) given a parameter `verbose` with a true value. `false` value is invalid.
+
+```
+GET http://<cygnus_host>:<management_port>/admin/log?verbose=true
+```
+
+Responses:
+
+```
+200 OK
+{"success":"true","....":{"level":".....","appenders":[{"name":"......","layout":"...."}]}}
+```
+
+```
+400 Bad Request
+{"success":"false","Verbose parameter only accepts 'true' as value"}
 ```
 
 ```

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -242,9 +242,9 @@ Response:
 [Top](#top)
 
 ##<a name="section9"></a>`GET /admin/log`
-Gets the logging level.
+If parameterized with `verbose=true` (or directly, the `verbose` parameter is avoided), it simply gets the logging level.
 ```
-GET http://<cygnus_host>:<management_port>/admin/log4j
+GET http://<cygnus_host>:<management_port>/admin/log
 ```
 
 Responses:
@@ -261,7 +261,7 @@ Responses:
 }
 ```
 
-Gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts) given a parameter `verbose` with a true value. `false` value is invalid.
+Instead, if parameterized with `verbose=true` gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts.
 
 ```
 GET http://<cygnus_host>:<management_port>/admin/log?verbose=true


### PR DESCRIPTION
* Partially fix issue #807 
  * Update CHANGES_NEXT_RELEASE is neccesary (first time).
* 100% unit tests passed:
```
Results : Tests run: 66, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
$ curl -X GET "http://localhost:8081/admin/log"
{"level": "DEBUG"}

$ curl -X GET "http://localhost:8081/admin/log?verbose=false"
{"level": "DEBUG"}

$ curl -X GET "http://localhost:8081/admin/log?verbose=true"
{"success":"true","log4j":{"level":"DEBUG","appenders":[{"name":"console","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

[USING JSON TOOL]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   278  100   278    0     0  46888      0 --:--:-- --:--:-- --:--:-- 55600
{
    "log4j": {
        "appenders": [
            {
                "layout": "time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n",
                "name": "console"
            }
        ],
        "level": "DEBUG"
    },
    "success": "true"
}
```
* Assignee: @frbattid