### PR TITLE
hardening/807_add_transient_option_to_GET_method

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -72,7 +72,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
-import org.json.simple.JSONArray;
 import org.slf4j.MDC;
 /**
  *

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -420,7 +420,7 @@ public class ManagementInterface extends AbstractHandler {
             String param = "flume.root.logger";
             
             if ((verbose == null) || (verbose.equals("false"))) {
-                if (transient_.equals("true")) {
+                if ((transient_ == null) || (transient_.equals("true"))) {
                     response.setStatus(HttpServletResponse.SC_OK);
                     response.getWriter().println("{\"level\": \"" + level + "\"}");
                     LOGGER.info("Log level succesfully sent");
@@ -454,7 +454,7 @@ public class ManagementInterface extends AbstractHandler {
                     } // if else
                 }
             } else if (verbose.equals("true")) {
-                if (transient_.equals("true")) {
+                if ((transient_ == null) || (transient_.equals("true"))) {
                     Enumeration appenders = LogManager.getRootLogger().getAllAppenders();
                     String appendersJson = "";
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -412,7 +412,6 @@ public class ManagementInterface extends AbstractHandler {
         response.setContentType("application/json; charset=utf-8");
         
         try {
-            Level level = LogManager.getRootLogger().getLevel();
             String verbose = request.getParameter("verbose");
             String transient_ = request.getParameter("transient");
             String pathToFile = configurationPath + "/log4j.properties";
@@ -420,10 +419,12 @@ public class ManagementInterface extends AbstractHandler {
             String param = "flume.root.logger";
             
             if ((verbose == null) || (verbose.equals("false"))) {
+                
                 if ((transient_ == null) || (transient_.equals("true"))) {
+                    Level level = LogManager.getRootLogger().getLevel();
                     response.setStatus(HttpServletResponse.SC_OK);
                     response.getWriter().println("{\"level\": \"" + level + "\"}");
-                    LOGGER.info("Log level succesfully sent");
+                    LOGGER.info("Log level succesfully sent");     
                 } else {
                 
                     if (file.exists()) {
@@ -452,9 +453,11 @@ public class ManagementInterface extends AbstractHandler {
                         LOGGER.debug("File not found in the path received");
                         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                     } // if else
-                }
+                }            
             } else if (verbose.equals("true")) {
+                
                 if ((transient_ == null) || (transient_.equals("true"))) {
+                    Level level = LogManager.getRootLogger().getLevel();
                     Enumeration appenders = LogManager.getRootLogger().getAllAppenders();
                     String appendersJson = "";
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -199,10 +199,11 @@ public class CygnusApplication extends Application {
             CommandLineParser parser = new GnuParser();
             CommandLine commandLine = parser.parse(options, args);
 
-            File configurationFile = new File(commandLine.getOptionValue('f'));
+                        File configurationFile = new File(commandLine.getOptionValue('f'));
             String agentName = commandLine.getOptionValue('n');
             boolean reload = !commandLine.hasOption("no-reload-conf");
-
+            
+            String configurationPath = configurationFile.getParent();
             if (commandLine.hasOption('h')) {
                 new HelpFormatter().printHelp("cygnus-flume-ng agent", options, true);
                 return;
@@ -284,8 +285,8 @@ public class CygnusApplication extends Application {
             
             // start the Management Interface, passing references to Flume components
             LOGGER.info("Starting a Jetty server listening on port " + apiPort + " (Management Interface)");
-            mgmtIfServer = new JettyServer(apiPort, guiPort, new ManagementInterface(configurationFile,
-                    sourcesRef, channelsRef, sinksRef, apiPort, guiPort));
+            mgmtIfServer = new JettyServer(apiPort, guiPort, new ManagementInterface(configurationPath,
+                    configurationFile, sourcesRef, channelsRef, sinksRef, apiPort, guiPort));
             mgmtIfServer.start();
 
             // create a hook "listening" for shutdown interrupts (runtime.exit(int), crtl+c, etc)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -204,6 +204,7 @@ public class CygnusApplication extends Application {
             boolean reload = !commandLine.hasOption("no-reload-conf");
             
             String configurationPath = configurationFile.getParent();
+            
             if (commandLine.hasOption('h')) {
                 new HelpFormatter().printHelp("cygnus-flume-ng agent", options, true);
                 return;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -199,7 +199,7 @@ public class CygnusApplication extends Application {
             CommandLineParser parser = new GnuParser();
             CommandLine commandLine = parser.parse(options, args);
 
-                        File configurationFile = new File(commandLine.getOptionValue('f'));
+            File configurationFile = new File(commandLine.getOptionValue('f'));
             String agentName = commandLine.getOptionValue('n');
             boolean reload = !commandLine.hasOption("no-reload-conf");
             

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/ManagementInterfaceTest.java
@@ -367,7 +367,8 @@ public class ManagementInterfaceTest {
     @Test
     public void testHandle() {
         System.out.println(getTestTraceHead("[ManagementInterface.handle]") + " - Testing ManagementInterface.handle");        
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         
         try {
             managementInterface.handle(null, mockRequest, mockResponse, 1);
@@ -390,7 +391,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
                 + "valid subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
              
         try {
@@ -421,7 +423,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method posts a "
                 + "valid subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);
         
         try {
@@ -453,7 +456,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
                 + "find a subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -484,7 +488,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method doesn't "
                 + "find a subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -515,7 +520,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with empty fields (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -546,7 +552,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with empty fields (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -577,7 +584,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with missing fields (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -608,7 +616,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handlePostSubscription]") + " - POST method post a "
                 + "subscription with missing fields (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -639,7 +648,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
                 + "deletes a subscription (ngsi_version = 1)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -670,7 +680,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handleDeleteSubscription]") + " - DELETE method "
                 + "deletes a subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -702,7 +713,8 @@ public class ManagementInterfaceTest {
                 + "method deletes one instance configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         
         
          try {		
@@ -736,7 +748,8 @@ public class ManagementInterfaceTest {
         System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets a "
                 + "subscription (ngsi_version = 2)");
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         managementInterface.setOrionBackend(orionBackend);        
         
         try {
@@ -767,7 +780,8 @@ public class ManagementInterfaceTest {
          System.out.println(getTestTraceHead("[ManagementInterface.handleGetSubscriptions]") + " - GET method gets "
                  + "all subscriptions (ngsi_version = 2)");	         
          StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);		
-         ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);		
+         ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                 8081, 8082);		
          managementInterface.setOrionBackend(orionBackend);        		
          		
         try {		
@@ -799,7 +813,8 @@ public class ManagementInterfaceTest {
                 + "method gets all agent configuration parameters");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         
         try {		
             managementInterface.handleGetAdminConfigurationAgent(mockGetAllAgentParameters, responseWrapper, false);
@@ -830,7 +845,8 @@ public class ManagementInterfaceTest {
                 + "method gets one agent configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);    
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);    
         
         try {		
             managementInterface.handleGetAdminConfigurationAgent(mockGetAllAgentParameters, responseWrapper, false);
@@ -861,7 +877,8 @@ public class ManagementInterfaceTest {
                 + "method gets all instance configuration parameters");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);      
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);      
         
         try {		
             managementInterface.handleGetAdminConfigurationInstance(mockGetAllInstanceParameters, 
@@ -895,7 +912,8 @@ public class ManagementInterfaceTest {
                 + "method gets one instance configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);        
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);        
         
         try {		
             managementInterface.handleGetAdminConfigurationInstance(mockGetOneInstanceParameter, 
@@ -929,7 +947,8 @@ public class ManagementInterfaceTest {
                 + "method post a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);        
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);        
         
         try {		
             managementInterface.handlePostAdminConfigurationAgent(mockPostOneAgentParameter, responseWrapper, false);
@@ -960,7 +979,8 @@ public class ManagementInterfaceTest {
                 + "method posts one instance configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);        
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);        
         
         try {		
             managementInterface.handlePutAdminConfigurationInstance(mockPutOneInstanceParameter, 
@@ -994,7 +1014,8 @@ public class ManagementInterfaceTest {
                 + "method puts a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);
         
         try {		
             managementInterface.handlePutAdminConfigurationAgent(mockPutOneAgentParameter, responseWrapper, false);
@@ -1025,7 +1046,8 @@ public class ManagementInterfaceTest {
                 + "method puts one instance configuration parameter");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);     
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);     
         
         try {		
             managementInterface.handlePutAdminConfigurationInstance(mockPutOneInstanceParameter, 
@@ -1059,7 +1081,8 @@ public class ManagementInterfaceTest {
                 + "method deletes a single parameter in an agent configuration file");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082);       
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082);       
         
         try {		
             managementInterface.handleDeleteAdminConfigurationAgent(mockDeleteOneAgentParameter, 
@@ -1091,7 +1114,8 @@ public class ManagementInterfaceTest {
                   " - Agent configuration doesn't start with 'agent_'");
         
         StatusExposingServletResponse responseWrapper = new StatusExposingServletResponse(response);
-        ManagementInterface managementInterface = new ManagementInterface(new File(""), null, null, null, 8081, 8082); 
+        ManagementInterface managementInterface = new ManagementInterface(null, new File(""), null, null, null, 
+                8081, 8082); 
         
         try {		
             managementInterface.handleDeleteAdminConfigurationAgent(mockRequestBadFileName, responseWrapper, false);

--- a/doc/apiary/apiary.apib
+++ b/doc/apiary/apiary.apib
@@ -606,7 +606,7 @@ Error list (HTTP response code in parenthesis):
 + Parameters
 
        + verbose: true or false (this case is the same than avoiding the verbose parameter, see next section)
-       + transient: true (retrieves information from memory) or false (retrieves information from `log4j.properties` file)
+       + transient: true (this case is the same than avoiding the transient parameter, see next section: retrieves information from memory) or false (retrieves information from `log4j.properties` file)
 
 + Request
 
@@ -643,13 +643,9 @@ Error list (HTTP response code in parenthesis):
 
 ### Gets the log4j configuration [GET /admin/log]
 
-+ Parameters
-
-       + transient: true (retrieves information from memory) or false (retrieves information from `log4j.properties` file)
-
 + Request
 
-       GET http://<cygnus_host>:<management_port>/admin/log&transient=<transient_value>
+       GET http://<cygnus_host>:<management_port>/admin/log
 
 + Response 200 (application/json)
 

--- a/doc/apiary/apiary.apib
+++ b/doc/apiary/apiary.apib
@@ -605,15 +605,17 @@ Error list (HTTP response code in parenthesis):
 
 + Parameters
 
-       + ngsi_version: true or false (this case is the same than avoiding the verbose parameter, see next section)
+       + verbose: true or false (this case is the same than avoiding the verbose parameter, see next section)
+       + transient: true (retrieves information from memory) or false (retrieves information from `log4j.properties` file)
 
 + Request
 
-       GET http://<cygnus_host>:<management_port>/admin/log?verbose=<verbose_value>
+       GET http://<cygnus_host>:<management_port>/admin/log?verbose=<verbose_value>&transient=<transient_value>
 
 + Response 200 (application/json)
 
        {
+               "success": "true",
                "log4j": {
                        "appenders": [
                                {
@@ -622,8 +624,13 @@ Error list (HTTP response code in parenthesis):
                                }
                        ],
                        "level": "..."
-               },
-                       "success": "true"
+               }
+       }
+
++ Response 200 (application/json)
+
+       {
+               "level": "..."
        }
 
 + Response 500 (application/json)
@@ -636,20 +643,24 @@ Error list (HTTP response code in parenthesis):
 
 ### Gets the log4j configuration [GET /admin/log]
 
++ Parameters
+
+       + transient: true (retrieves information from memory) or false (retrieves information from `log4j.properties` file)
+
 + Request
 
-       GET http://<cygnus_host>:<management_port>/admin/log
+       GET http://<cygnus_host>:<management_port>/admin/log&transient=<transient_value>
 
 + Response 200 (application/json)
 
        {
-           "level": "..."
+               "level": "..."
        }
 
 + Response 500 (application/json)
 
        {
-           "error": "..."
+               "error": "..."
        }
 
 ### Update the logging level of Cygnus [PUT /admin/log]

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -242,9 +242,9 @@ Response:
 [Top](#top)
 
 ##<a name="section9"></a>`GET /admin/log`
-If parameterized with `verbose=false` (or directly, the `verbose` parameter is avoided), it simply gets the logging level using `transient` parameter. If parameterized with `transient=true` the information is retrieved from memory. If `transient=false` the information is retrieved from `log4j.properties` file.
+If parameterized with `verbose=false` (or directly, the `verbose` parameter is avoided), it simply gets the logging level using `transient` parameter. If parameterized with `transient=true` (or directly, the `transient` parameter is avoided) the information is retrieved from memory. If `transient=false` the information is retrieved from `log4j.properties` file.
 ```
-GET http://<cygnus_host>:<management_port>/admin/log?transient=<transient_value>
+GET http://<cygnus_host>:<management_port>/admin/log
 ```
 
 Responses:
@@ -261,10 +261,11 @@ Responses:
 }
 ```
 
-Instead, if parameterized with `verbose=true` gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts.
+Instead, if parameterized with `verbose=true` gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts).
+Moreover, if parameterized with `transient=false` retrieves the information from `log4j.properties` file, not from memory.
 
 ```
-GET http://<cygnus_host>:<management_port>/admin/log?verbose=true&transient=<transient_value>
+GET http://<cygnus_host>:<management_port>/admin/log?verbose=true&transient=false
 ```
 
 Responses:

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -242,9 +242,9 @@ Response:
 [Top](#top)
 
 ##<a name="section9"></a>`GET /admin/log`
-If parameterized with `verbose=false` (or directly, the `verbose` parameter is avoided), it simply gets the logging level.
+If parameterized with `verbose=false` (or directly, the `verbose` parameter is avoided), it simply gets the logging level using `transient` parameter. If parameterized with `transient=true` the information is retrieved from memory. If `transient=false` the information is retrieved from `log4j.properties` file.
 ```
-GET http://<cygnus_host>:<management_port>/admin/log
+GET http://<cygnus_host>:<management_port>/admin/log?transient=<transient_value>
 ```
 
 Responses:
@@ -264,7 +264,7 @@ Responses:
 Instead, if parameterized with `verbose=true` gets the log4j configuration (relevant parts, as the logging level or the appender names and layouts.
 
 ```
-GET http://<cygnus_host>:<management_port>/admin/log?verbose=true
+GET http://<cygnus_host>:<management_port>/admin/log?verbose=true&transient=<transient_value>
 ```
 
 Responses:
@@ -272,11 +272,6 @@ Responses:
 ```
 200 OK
 {"success":"true","....":{"level":".....","appenders":[{"name":"......","layout":"...."}]}}
-```
-
-```
-400 Bad Request
-{"success":"false","Verbose parameter only accepts 'true' as value"}
 ```
 
 ```


### PR DESCRIPTION
* Partially fix issue #807 
  * Update CHANGES_NEXT_RELEASE is not neccesary
* 100% unit tests passed:
```
Results : Tests run: 66, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
[DEFAULT CASE: NO PARAMETERS -> RUN LIKE `verbose=false` and `transient=true`]
$ curl -X GET "http://localhost:8081/admin/log"
{"level": "DEBUG"}

[CASES WITH TRANSIENT AND NO VERBOSE]
$ curl -X GET "http://localhost:8081/admin/log?transient=false"
{"level": "INFO"}
$ curl -X GET "http://localhost:8081/admin/log?transient=true"
{"level": "DEBUG"}

[CASES WITH VERBOSE AND NO TRANSIENT]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true"
{"success":"true","log4j":{"level":"DEBUG","appenders":[{"name":"console","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}
$ curl -X GET "http://localhost:8081/admin/log?verbose=false"
{"level": "DEBUG"}

[CASES COMBINING PARAMETERS]
$ curl -X GET "http://localhost:8081/admin/log?verbose=false&transient=true"
{"level": "DEBUG"}

$ curl -X GET "http://localhost:8081/admin/log?verbose=false&transient=false"
{"level": "INFO"}

$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=false"
{"success":"true","log4j":{"level":"INFO","appenders":[{"name":"LOGFILE","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=true"
{"success":"true","log4j":{"level":"DEBUG","appenders":[{"name":"console","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}
```
* Assignee: @frbattid