### PR TITLE
hardening/807_add_PUT_method_to_admin_log

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -1832,6 +1832,7 @@ public class ManagementInterface extends AbstractHandler {
                 console.setLayout(PATTERN); 
                 
                 try {
+                    
                     if (logLevel == null) {
                         Level level = LogManager.getRootLogger().getLevel();
                         console.setThreshold(level);
@@ -1855,6 +1856,7 @@ public class ManagementInterface extends AbstractHandler {
                         LOGGER.info("log4j appender and logging level updated to " + logLevel.toUpperCase() + "," 
                                 + appender + "'");
                     } // if else 
+                    
                 } catch (Exception e) {
                     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                     response.getWriter().println("{\"error\":\"Invalid log level\"}");
@@ -2669,7 +2671,6 @@ public class ManagementInterface extends AbstractHandler {
             String name = (String) description;
             String desc = (String) descriptions.get(name);
             printWriter.print(desc);
-            System.out.println("NAME: " + name + " and description: " + desc);
             
             for (Object property: properties.keySet()) {
                 String prop = (String) property;
@@ -2677,7 +2678,6 @@ public class ManagementInterface extends AbstractHandler {
                 
                 if ((prop.startsWith(name)) || (prop.equals(name))) {
                     printWriter.println(prop + "=" + value);
-                    System.out.println("INSERT: " + prop + " : " + value);
                 } // if
                 
             } // for
@@ -2685,18 +2685,9 @@ public class ManagementInterface extends AbstractHandler {
             printWriter.println();
  
         } // for
+        
         printWriter.close();
         
     } // orderedLogPrinting
-    
-    /**
-     * CheckLoggingLevel: Check if a received given is valid.
-     * 
-     * @param: loggingLevel
-     */
-    private boolean checkLoggingLevel (Level level) {
-        
-        return true;
-    } // checkLoggingLevel
     
 } // ManagementInterface

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -72,6 +72,9 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Layout;
 import org.slf4j.MDC;
 /**
  *
@@ -1787,43 +1790,127 @@ public class ManagementInterface extends AbstractHandler {
         
         // get the parameters to be updated
         String logLevel = request.getParameter("level");
+        String appender = request.getParameter("appender");
+        String transient_ = request.getParameter("transient");
         
-        if (logLevel != null) {
-            if (logLevel.equals("DEBUG")) {
-                LogManager.getRootLogger().setLevel(Level.DEBUG);
-                response.setStatus(HttpServletResponse.SC_OK);
-                //response.getWriter().println("{\"success\":\"true\"}");
-                LOGGER.info("log4j logging level updated to " + logLevel);
-            } else if (logLevel.equals("INFO")) {
-                LogManager.getRootLogger().setLevel(Level.INFO);
-                response.setStatus(HttpServletResponse.SC_OK);
-                //response.getWriter().println("{\"success\":\"true\"}");
-                LOGGER.info("log4j logging level updated to " + logLevel);
-            } else if (logLevel.equals("WARNING") || logLevel.equals("WARN")) {
-                LogManager.getRootLogger().setLevel(Level.WARN);
-                response.setStatus(HttpServletResponse.SC_OK);
-                //response.getWriter().println("{\"success\":\"true\"}");
-                LOGGER.info("log4j logging level updated to " + logLevel);
-            } else if (logLevel.equals("ERROR")) {
-                LogManager.getRootLogger().setLevel(Level.ERROR);
-                response.setStatus(HttpServletResponse.SC_OK);
-                //response.getWriter().println("{\"success\":\"true\"}");
-                LOGGER.info("log4j logging level updated to " + logLevel);
-            } else if (logLevel.equals("FATAL")) {
-                LogManager.getRootLogger().setLevel(Level.FATAL);
-                response.setStatus(HttpServletResponse.SC_OK);
-                //response.getWriter().println("{\"success\":\"true\"}");
-                LOGGER.info("log4j logging level updated to " + logLevel);
-            } else {
+        if ((transient_ == null) || (transient_.equals("true"))) {
+            
+            if ((logLevel == null) && (appender == null)) {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                response.getWriter().println("{\"error\":\"Invalid log level\"}");
-                LOGGER.error("Invalid log level '" + logLevel + "'");
-            } // if else
+                response.getWriter().println("{\"error\":\"'level' or 'appender' parameter required\"}");
+                LOGGER.error("Parameter missing in the request");
+            } else if ((logLevel != null) && (appender == null)) {
+            
+                if (logLevel.equals("DEBUG")) {
+                    LogManager.getRootLogger().setLevel(Level.DEBUG);
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println("{\"success\":\"true\","
+                    + "\"result\" : { \"log4j logging level updated to " + logLevel + "\" }");
+                    LOGGER.info("log4j logging level updated to " + logLevel);
+                } else if (logLevel.equals("INFO")) {
+                    LogManager.getRootLogger().setLevel(Level.INFO);
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println("{\"success\":\"true\","
+                    + "\"result\" : { \"log4j logging level updated to " + logLevel + "\" }");
+                    LOGGER.info("log4j logging level updated to " + logLevel);
+                } else if (logLevel.equals("WARNING") || logLevel.equals("WARN")) {
+                    LogManager.getRootLogger().setLevel(Level.WARN);
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println("{\"success\":\"true\","
+                    + "\"result\" : { \"log4j logging level updated to " + logLevel + "\" }");
+                    LOGGER.info("log4j logging level updated to " + logLevel);
+                } else if (logLevel.equals("ERROR")) {
+                    LogManager.getRootLogger().setLevel(Level.ERROR);
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println("{\"success\":\"true\","
+                    + "\"result\" : { \"log4j logging level updated to " + logLevel + "\" }");
+                    LOGGER.info("log4j logging level updated to " + logLevel);
+                } else if (logLevel.equals("FATAL")) {
+                    LogManager.getRootLogger().setLevel(Level.FATAL);
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getWriter().println("{\"success\":\"true\","
+                    + "\"result\" : { \"log4j logging level updated to " + logLevel + "\" }");
+                    LOGGER.info("log4j logging level updated to " + logLevel);
+                } else {
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    response.getWriter().println("{\"error\":\"Invalid log level\"}");
+                    LOGGER.error("Invalid log level '" + logLevel + "'");
+                } // if else
+                
+            } else {
+                
+                // the only solution is to remove the appender and then add the new one
+                // See: http://stackoverflow.com/questions/8965946/configuring-log4j-loggers-programmatically
+                ConsoleAppender console = new ConsoleAppender();
+                String appenderName = "";
+                for (Enumeration appenders = LogManager.getRootLogger().getAllAppenders(); appenders.hasMoreElements(); ) {
+                    Appender app = (Appender) appenders.nextElement();
+                    appenderName = app.getName();
+                }
+                Layout PATTERN = LogManager.getRootLogger().getAppender(appenderName).getLayout();
+                console.setName(appender);
+                console.setLayout(PATTERN); 
+                if (logLevel == null) {
+                    Level level = LogManager.getRootLogger().getLevel();
+                    console.setThreshold(level);
+                } else {
+                    LogManager.getRootLogger().setLevel(Level.toLevel(logLevel));
+                }
+                console.activateOptions();
+                LogManager.getRootLogger().addAppender(console);
+                LogManager.getRootLogger().removeAppender(appenderName);
+                
+                response.setStatus(HttpServletResponse.SC_OK);
+                if (logLevel == null) {
+                    response.getWriter().println("{\"success\":\"log4j appender updated to " + appender + "\"}");
+                    LOGGER.info("log4j appender updated to " + appender + "'");
+                } else {
+                    response.getWriter().println("{\"success\":\"log4j appender and logging level updated to " + logLevel 
+                        + "," + appender + "\"}");
+                LOGGER.info("log4j appender and logging level updated to " + logLevel + "," + appender + "'");
+                }
+            } // if else if
+            
         } else {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            response.getWriter().println("{\"error\":\"Log level missing\"}");
-            LOGGER.error("Log level missing in the request");
-        } // if else
+            String pathToFile = configurationPath + "/log4j.properties";
+            System.out.println("filePath: " + configurationPath + "/log4j.properties");
+            File file = new File(pathToFile);
+
+            try {
+                Properties properties = new Properties();   
+                properties.load(new FileInputStream(file));
+                Map<String, String> descriptions = readLogDescriptions(file); 
+                
+                String[] flumeLogger = properties.getProperty("flume.root.logger").split(",");
+                
+                if (logLevel == null) {
+                    logLevel = flumeLogger[0];
+                } // if
+                
+                if (appender == null) {
+                    logLevel = flumeLogger[1];
+                } // if
+                                
+                properties.put("flume.root.logger", logLevel + "," + appender);
+                JSONObject jsonObject = new JSONObject();
+                jsonObject.put("log4j", properties);
+
+                orderedLogPrinting(properties, descriptions, file);
+                
+                response.getWriter().println("{\"success\":\"true\","
+                        + "\"result\" : " + jsonObject + "}");
+                LOGGER.debug(jsonObject);
+                response.setStatus(HttpServletResponse.SC_OK);
+
+            } catch (Exception e) {
+                response.getWriter().println("{\"success\":\"false\","
+                        + "\"result\" : { \"File not found in the path received\" }");
+                LOGGER.debug("File not found in the path received. Details: " +  e.getMessage());
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            } // if else 
+        }
+        
+        
     } // handlePutAdminLog
     
     protected void handlePutAdminConfigurationAgent(HttpServletRequest request, HttpServletResponse response,
@@ -2492,7 +2579,6 @@ public class ManagementInterface extends AbstractHandler {
                 
         // read the comments and the properties
         BufferedReader reader = new BufferedReader(new FileReader(file));
-        String header = "";
         String description = "";
         String line;
         Map<String,String> descriptions = new LinkedHashMap<String,String>();
@@ -2508,7 +2594,6 @@ public class ManagementInterface extends AbstractHandler {
             } else if ((!(line.startsWith("#")) && (!(line.isEmpty())))) {
                 String[] nameValue = line.split("=");
                 String name = nameValue[0];
-                descriptions.put(name, description);
                 description = "";
             } // if
             
@@ -2516,6 +2601,89 @@ public class ManagementInterface extends AbstractHandler {
         
         reader.close();
         return descriptions;
-    }
+    } // readDescriptions
+    
+    /** 
+     * readLogDescriptions: Read the descriptions from a log4j file.
+     * 
+     * @param file
+     */
+    private Map<String,String> readLogDescriptions(File file) throws IOException {
+                
+        // read the comments and the properties
+        BufferedReader reader = new BufferedReader(new FileReader(file));
+        String description = "";
+        String line;
+        Map<String,String> descriptions = new LinkedHashMap<String,String>();
+        boolean flag = true;
+
+        while ((line = reader.readLine()) != null) {
+                        
+            if (line.startsWith("#")) {
+                description += line + "\n";
+                flag = true;
+            } // if
+            
+            if (line.isEmpty()) {
+                description = "";
+                flag = true;
+            } else if ((!(line.startsWith("#")) && (!(line.isEmpty())))) {
+                
+                if (flag == true) {
+                    String[] appenderFields = line.split("(\\.)|(=)");
+                    String name = appenderFields[0] + "." + appenderFields[1];
+                
+                    if (appenderFields[1].equals("appender")) {
+                        name += "." + appenderFields[2];
+                    } // if
+                    
+                    descriptions.put(name, description);
+                    description = "";
+                    flag = false;
+                } // if
+
+            } // if else if
+            
+        } // while
+        
+        reader.close();
+        return descriptions;
+    } // readLogDescriptions
+    
+    /** 
+     * OrderedPrintWriter: Creates a writer with the original order's agent file.
+     * 
+     * @param printWriter
+     * @param properties 
+     */
+    private void orderedLogPrinting (Properties properties, Map<String,String> descriptions, File file) 
+            throws FileNotFoundException {
+        PrintWriter printWriter = new PrintWriter(file);
+        printWriter.println(CommonConstants.CYGNUS_IPR_HEADER + "\n");      
+        printWriter.println("# To be put in APACHE_FLUME_HOME/conf/log4j.properties \n");
+        
+        for (Object description : descriptions.keySet()) {
+            String name = (String) description;
+            String desc = (String) descriptions.get(name);
+            printWriter.print(desc);
+            System.out.println("NAME: " + name + " and description: " + desc);
+            
+            for (Object property: properties.keySet()) {
+                String prop = (String) property;
+                String value = (String) properties.getProperty(prop);
+                
+                if ((prop.startsWith(name)) || (prop.equals(name))) {
+                    printWriter.println(prop + "=" + value);
+                    System.out.println("INSERT: " + prop + " : " + value);
+                } // if
+                
+            } // for
+            
+            printWriter.println();
+ 
+        } // for
+        printWriter.close();
+        
+    } // orderedLogPrinting
     
 } // ManagementInterface

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -71,7 +71,7 @@ public final class CommonConstants {
     public static final String INTERNAL_CONCATENATOR = "=";
     public static final String CONCATENATOR = "x0000";
     
-    // Header for API uses
+    // Used by ManagementInterface for API 
     public static final String CYGNUS_IPR_HEADER = "#####\n"  
                                     + "# Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U\n" 
                                     + "# \n" 
@@ -94,5 +94,6 @@ public final class CommonConstants {
                                     + "# \n" 
                                     + "# For those usages not covered by the GNU Affero General Public License please "
                                     + "contact with iot_support at tid dot es";
+    public enum LoggingLevels { FATAL, ERROR, WARN, INFO, DEBUG, ALL, NONE, OFF }
     
 } // CommonConstants

--- a/doc/apiary/apiary.apib
+++ b/doc/apiary/apiary.apib
@@ -659,28 +659,66 @@ Error list (HTTP response code in parenthesis):
                "error": "..."
        }
 
-### Update the logging level of Cygnus [PUT /admin/log]
+### Update the logging level and/or the appender of Cygnus [PUT /admin/log]
 
 + Parameters
 
-        + loglevel: Must be DEBUG, INFO, WARN, ERROR o FATAL (String) - A valid log level.
+        + level: Must be DEBUG, INFO, WARN, ERROR o FATAL (String) - A valid log level.
+        + appender: A valid appender name.
+        + transient: Must be true (or diretly, the transient parameter is avoided, see next section) or false (PUT in log4j properties file).
 
 + Request
 
-       PUT http://<cygnus_host>:<management_port>/admin/log?level=<log_level>
+       PUT http://<cygnus_host>:<management_port>/admin/log?level=<log_level>&appender=<appender_value>&transient=false
 
 + Response 200 (text/plain)
 
-       OK
-
-+ Response 400 (application/json)
-
        {
-           "error":"Invalid log level"
+               "success":"true","result" : {
+                       "log4j":{
+                               "........."
+                       }
+               }
        }
 
 + Response 400 (application/json)
 
        {
-           "error":""
+           "error":"......"
+       }
+
+### Update the loggin level and/or the appender of Cygnys [PUT /admin/log]
+
++ Request
+
+       PUT http://<cygnus_host>:<management_port>/admin/loggin
+
++ Response 200 (application/json)
+
+       {
+               "success":"log4j logging level updated to ...."
+       }
+
++ Response 200 (application/json)
+
+       {
+               "success":"log4j appender updated to ....."
+       }
+
++ Response 200 (application/json)
+
+       {
+               "success":"log4j appender and logging level updated to ..... , ....."
+       }
+
++ Response 400 (application/json)
+
+       {
+               "error":"Invalid log level"
+       }
+
++ Response 400 (application/json)
+
+       {
+               "error":"......."
        }

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -285,21 +285,31 @@ Responses:
 [Top](#top)
 
 ##<a name="section10"></a>`PUT /admin/log`
-Updates the logging level of Cygnus, given the logging level as a query parameter.
+Updates the logging level of Cygnus and the name of the appender, given the logging level and the appender name as a query parameters. If parameterized with `transient=true` (or directly, the `transient` parameter is avoided) the information is retrieved from memory. If `transient=false` the information is retrieved from `log4j.properties` file.
 
 Valid logging levels are `DEBUG`, `INFO`, `WARNING` (`WARN` also works), `ERROR` and `FATAL`.
 
 ```
-PUT http://<cygnus_host>:<management_port>/admin/log?level=<log_level>
+PUT http://<cygnus_host>:<management_port>/admin/log
 ```
 
 Responses:
 
 ```
 200 OK
+{"success":"true","result" : { "log4j logging level updated to ...." }
 ```
 
 ```
+200 OK
+{"success":"log4j appender updated to ....."}
+```
+
+```
+200 OK
+{"success":"log4j appender and logging level updated to ..... , ....."}
+```
+
 400 Bad Request
 {"error":"Invalid log level"}
 ```
@@ -307,6 +317,24 @@ Responses:
 ```
 400 Bad Request
 {"error":"}
+```
+
+Instead, if parameterized with `transient=false` puts the information into `log4j.properties` file, not in memory.
+
+```
+PUT http://<cygnus_host>:<management_port>/admin/log?transient=false
+```
+
+Responses:
+
+```
+200 OK
+{"success":"true","result" : {"log4j":{"........."}}}
+```
+
+```
+400 Bad Request
+{"error":""}
 ```
 
 [Top](#top)


### PR DESCRIPTION
* Partially fix issue #807 
  * Update CHANGES_NEXT_RELEASE is not neccesary
* 100% unit tests passed:
```
Results : Tests run: 66, Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) tests passed:
```
[ **** transient=true : Changes in memory **** ]

[GETTING INFORMATION ABOUT LOG LEVEL AND APPENDER]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=true"
{"success":"true","log4j":{"level":"DEBUG","appenders":[{"name":"console","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

[PUTTING NEW INFORMATION: `level=INFO` and `appender=LOGFILE`
$ curl -X PUT "http://localhost:8081/admin/log?level=INFO&appender=LOGFILE"
{"success":"log4j appender and logging level updated to INFO,LOGFILE"}

[GETTING INFORMATION AGAIN]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=true"
{"success":"true","log4j":{"level":"INFO","appenders":[{"name":"LOGFILE","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

[PUTTING AN INVALID LOGGING LEVEL]
$ curl -X PUT "http://localhost:8081/admin/log?level=DEBUR"
{"error":"Invalid log level"}

[ **** transient=false : Changes in log4j.properties file **** ]

[GETTING INFORMATION ABOUT LOGGING LEVEL AND APPENDER]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=false"
{"success":"true","log4j":{"level":"DEBUG","appenders":[{"name":"console","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

[PUTTING NEW INFORMATION: `level=INFO` and `appender=LOGFILE`]
$ curl -X PUT "http://localhost:8081/admin/log?transient=false&level=INFO&appender=LOGFILE"
{"success":"true","result" : {"log4j":{"log4j.appender.DAILY.rollingPolicy.ActiveFileName":"${flume.log.dir}\/${flume.log.file}","log4j.appender.LOGFILE":"org.apache.log4j.RollingFileAppender","log4j.appender.DAILY.rollingPolicy.FileNamePattern":"${flume.log.dir}\/${flume.log.file}.%d{yyyy-MM-dd}","log4j.appender.DAILY":"org.apache.log4j.rolling.RollingFileAppender","log4j.appender.LOGFILE.layout":"org.apache.log4j.PatternLayout","flume.root.logger":"INFO,LOGFILE","log4j.appender.LOGFILE.MaxBackupIndex":"10","log4j.logger.org.apache.zookeeper":"WARN","flume.log.dir":"\/var\/log\/cygnus\/","log4j.appender.console.layout.ConversionPattern":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n","log4j.appender.LOGFILE.File":"${flume.log.dir}\/${flume.log.file}","log4j.appender.console.layout":"org.apache.log4j.PatternLayout","log4j.appender.DAILY.layout.ConversionPattern":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n","log4j.logger.org.apache.kafka":"WARN","log4j.logger.org.mortbay":"WARN","log4j.logger.org.apache.hadoop":"WARN","log4j.appender.console.target":"System.err","log4j.appender.console":"org.apache.log4j.ConsoleAppender","log4j.logger.org.apache.http":"WARN","log4j.appender.LOGFILE.MaxFileSize":"100MB","log4j.appender.DAILY.layout":"org.apache.log4j.PatternLayout","log4j.logger.org.apache.avro.ipc.NettyTransceiver":"WARN","log4j.logger.org.apache.flume.lifecycle":"WARN","log4j.logger.org.mongodb":"WARN","log4j.appender.DAILY.rollingPolicy":"org.apache.log4j.rolling.TimeBasedRollingPolicy","flume.log.file":"cygnus.log","log4j.logger.org.I0Itec":"WARN","log4j.logger.com.amazonaws":"WARN","log4j.rootLogger":"${flume.root.logger}","log4j.appender.LOGFILE.layout.ConversionPattern":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n","log4j.logger.org.jboss":"WARN"}}}

[GETTING INFORMATION AGAIN]
$ curl -X GET "http://localhost:8081/admin/log?verbose=true&transient=false"
{"success":"true","log4j":{"level":"INFO","appenders":[{"name":"LOGFILE","layout":"time=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSSzzz} | lvl=%p | corr=%X{correlatorId} | trans=%X{transactionId} | srv=%X{service} | subsrv=%X{subservice} | function=%M | comp=Cygnus | msg=%C[%L] : %m%n"}]}}

[VIEW MODIFIED PART OF `log4j.properties` FILE]
# Define some default values.
# These can be overridden by system properties, e.g. the following logs in the standard output, which is very useful
# for testing purposes (-Dflume.root.logger=DEBUG,console)
flume.root.logger=INFO,LOGFILE
#flume.root.logger=DEBUG,console
flume.log.dir=/var/log/cygnus/
flume.log.file=cygnus.log

[PUTTING AN INVALID LOGGING LEVEL]
$ curl -X PUT "http://localhost:8081/admin/log?transient=false&level=INFORRRR"
{"error":"Invalid log level"}
```
* Assignee: @frbattid