### PR TITLE
hardening/1152_configurable_http_parameters

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [cygnus][bug] Fix documentation about DELETE subscriptions (#1147)
 - [cygnus-ngsi][hardening] Remove unused hashing feature in NGSIMongoSink and NGSISTHSink (#1113)
+- [cygnus-ngsi][hardening] Configurable Http parameters at backend (#1152)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
@@ -39,9 +39,12 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
      * @param port
      * @param ssl
      * @param apiKey
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
-    public CartoDBBackendImpl(String host, String port, boolean ssl, String apiKey) {
-        super(new String[]{host}, port, ssl, false, null, null, null, null);
+    public CartoDBBackendImpl(String host, String port, boolean ssl, String apiKey, int maxConns,
+            int maxConnsPerRoute) {
+        super(new String[]{host}, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         this.apiKey = apiKey;
     } // CartoDBBackendImpl
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -51,17 +51,19 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
      * @param ckanPort
      * @param orionUrl
      * @param ssl
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
     public CKANBackendImpl(String apiKey, String ckanHost, String ckanPort, String orionUrl,
-            boolean ssl) {
-        super(new String[]{ckanHost}, ckanPort, ssl, false, null, null, null, null);
+            boolean ssl, int maxConns, int maxConnsPerRoute) {
+        super(new String[]{ckanHost}, ckanPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         
         // this class attributes
         this.apiKey = apiKey;
         this.orionUrl = orionUrl;
         
         // create the cache
-        cache = new CKANCache(new String[]{ckanHost}, ckanPort, ssl, apiKey);
+        cache = new CKANCache(new String[]{ckanHost}, ckanPort, ssl, apiKey, maxConns, maxConnsPerRoute);
     } // CKANBackendImpl
 
     @Override

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -50,9 +50,11 @@ public class CKANCache extends HttpBackend {
      * @param port
      * @param ssl
      * @param apiKey
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
-    public CKANCache(String[] hosts, String port, boolean ssl, String apiKey) {
-        super(hosts, port, ssl, false, null, null, null, null);
+    public CKANCache(String[] hosts, String port, boolean ssl, String apiKey, int maxConns, int maxConnsPerRoute) {
+        super(hosts, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         this.apiKey = apiKey;
         tree = new HashMap<String, HashMap<String, ArrayList<String>>>();
         orgMap = new HashMap<String, String>();

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
@@ -62,12 +62,15 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
      * @param krb5LoginConfFile
      * @param krb5ConfFile
      * @param serviceAsNamespace
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
     public HDFSBackendImplREST(String[] hdfsHosts, String hdfsPort, String hdfsUser, String hdfsPassword,
             String oauth2Token, String hiveServerVersion, String hiveHost, String hivePort, boolean krb5,
             String krb5User, String krb5Password, String krb5LoginConfFile, String krb5ConfFile,
-            boolean serviceAsNamespace) {
-        super(hdfsHosts, hdfsPort, false, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile);
+            boolean serviceAsNamespace, int maxConns, int maxConnsPerRoute) {
+        super(hdfsHosts, hdfsPort, false, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
+                maxConnsPerRoute);
         this.hdfsUser = hdfsUser;
         this.hdfsPassword = hdfsPassword;
         this.hiveServerVersion = hiveServerVersion;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -74,9 +74,11 @@ public abstract class HttpBackend {
      * @param krb5Password
      * @param krb5LoginConfFile
      * @param krb5ConfFile
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
     public HttpBackend(String[] hosts, String port, boolean ssl, boolean krb5, String krb5User, String krb5Password,
-            String krb5LoginConfFile, String krb5ConfFile) {
+            String krb5LoginConfFile, String krb5ConfFile, int maxConns, int maxConnsPerRoute) {
         this.hosts = new LinkedList(Arrays.asList(hosts));
         this.port = port;
         this.ssl = ssl;
@@ -85,7 +87,7 @@ public abstract class HttpBackend {
         this.krb5Password = krb5Password;
         
         // create a Http clients factory and an initial connection
-        httpClientFactory = new HttpClientFactory(ssl, krb5LoginConfFile, krb5ConfFile);
+        httpClientFactory = new HttpClientFactory(ssl, krb5LoginConfFile, krb5ConfFile, maxConns, maxConnsPerRoute);
         httpClient = httpClientFactory.getHttpClient(ssl, krb5);
     } // HttpBackend
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpClientFactory.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -19,7 +19,6 @@
 package com.telefonica.iot.cygnus.backends.http;
 
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import com.telefonica.iot.cygnus.utils.CommonConstants;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
@@ -59,8 +58,11 @@ public class HttpClientFactory {
      * @param ssl True if SSL connections are desired. False otherwise.
      * @param loginConfFile
      * @param krb5ConfFile
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
-    public HttpClientFactory(boolean ssl, String loginConfFile, String krb5ConfFile) {
+    public HttpClientFactory(boolean ssl, String loginConfFile, String krb5ConfFile, int maxConns,
+            int maxConnsPerRoute) {
         // set the Kerberos parameters
         this.loginConfFile = loginConfFile;
         this.krb5ConfFile = krb5ConfFile;
@@ -68,16 +70,16 @@ public class HttpClientFactory {
         // create the appropriate connections manager
         if (ssl) {
             sslConnectionsManager = new PoolingClientConnectionManager(getSSLSchemeRegistry());
-            sslConnectionsManager.setMaxTotal(CommonConstants.MAX_CONNS);
-            sslConnectionsManager.setDefaultMaxPerRoute(CommonConstants.MAX_CONNS_PER_ROUTE);
+            sslConnectionsManager.setMaxTotal(maxConns);
+            sslConnectionsManager.setDefaultMaxPerRoute(maxConnsPerRoute);
         } else {
             connectionsManager = new PoolingClientConnectionManager();
-            connectionsManager.setMaxTotal(CommonConstants.MAX_CONNS);
-            connectionsManager.setDefaultMaxPerRoute(CommonConstants.MAX_CONNS_PER_ROUTE);
+            connectionsManager.setMaxTotal(maxConns);
+            connectionsManager.setDefaultMaxPerRoute(maxConnsPerRoute);
         } // if else
         
-        LOGGER.info("Setting max total connections (" + CommonConstants.MAX_CONNS + ")");
-        LOGGER.info("Setting default max connections per route (" + CommonConstants.MAX_CONNS_PER_ROUTE + ")");
+        LOGGER.info("Setting max total connections (" + maxConns + ")");
+        LOGGER.info("Setting default max connections per route (" + maxConnsPerRoute + ")");
     } // HttpClientFactory
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/orion/OrionBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/orion/OrionBackendImpl.java
@@ -39,9 +39,11 @@ public class OrionBackendImpl extends HttpBackend implements OrionBackend {
      * @param orionHost
      * @param orionPort
      * @param ssl
+     * @param maxConns
+     * @param maxConnsPerRoute
      */
-    public OrionBackendImpl(String orionHost, String orionPort, boolean ssl) {
-        super(new String[]{orionHost}, orionPort, ssl, false, null, null, null, null);
+    public OrionBackendImpl(String orionHost, String orionPort, boolean ssl, int maxConns, int maxConnsPerRoute) {
+        super(new String[]{orionHost}, orionPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
     } // StatsBackendImpl
 
     @Override

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -49,10 +49,6 @@ public final class CommonConstants {
     public static final String ATTR_VALUE          = "attrValue";
     public static final String ATTR_MD             = "attrMd";
     public static final String ATTR_MD_FILE        = "attrMdFile";
-
-    // Maximum values
-    public static final int MAX_CONNS           = 500;
-    public static final int MAX_CONNS_PER_ROUTE = 100;
     
     // Others
     public static final String EMPTY_MD = "[]";

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
@@ -65,6 +65,8 @@ public class CKANBackendImplTest {
     private final String data = "this is a lot of data";
     private final HashMap<String, String> attrList = new HashMap<String, String>();
     private final HashMap<String, String> attrMdList = new HashMap<String, String>();
+    private final int maxConns = 50;
+    private final int maxConnsPerRoute = 10;
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -75,7 +77,7 @@ public class CKANBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new CKANBackendImpl(apiKey, host, port, orionURL, ssl);
+        backend = new CKANBackendImpl(apiKey, host, port, orionURL, ssl, maxConns, maxConnsPerRoute);
 
         // set up the behaviour of the mocked classes
         when(mockCache.isCachedOrg(orgName)).thenReturn(true);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
@@ -61,6 +61,8 @@ public class CKANCacheTest {
     private final String orgId = "org_id";
     private final String pkgId = "pkg_id";
     private final String resId = "res_id";
+    private final int maxConns = 50;
+    private final int maxConnsPerRoute = 10;
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -71,7 +73,7 @@ public class CKANCacheTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        cache = new CKANCache(hosts, port, ssl, apiKey);
+        cache = new CKANCache(hosts, port, ssl, apiKey, maxConns, maxConnsPerRoute);
 
         // set up the behaviour of the mocked classes
         when(orgMap.get(orgName)).thenReturn(orgId);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplRESTTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplRESTTest.java
@@ -63,6 +63,8 @@ public class HDFSBackendImplRESTTest {
     private final String hivePort = "10000";
     private final String dirPath = "path/to/my/data";
     private final String data = "this is a lot of data";
+    private final int maxConns = 50;
+    private final int maxConnsPerRoute = 10;
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -74,7 +76,7 @@ public class HDFSBackendImplRESTTest {
     public void setUp() throws Exception {
         // set up the instance of the tested class
         backend = new HDFSBackendImplREST(hdfsHosts, hdfsPort, user, password, token, hiveServerVersion, hiveHost,
-                hivePort, false, null, null, null, null, false);
+                hivePort, false, null, null, null, null, false, maxConns, maxConnsPerRoute);
         
         // set up other instances
         BasicHttpResponse resp200 = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "OK");

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/http/HttpBackendTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/http/HttpBackendTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -46,14 +46,17 @@ public class HttpBackendTest {
      */
     private class HttpBackendImpl extends HttpBackend {
 
-        public HttpBackendImpl(String[] hosts, String port, boolean ssl, boolean krb5, String krb5User, String krb5Password, String krb5LoginConfFile, String krb5ConfFile) {
-            super(hosts, port, ssl, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile);
+        public HttpBackendImpl(String[] hosts, String port, boolean ssl, boolean krb5, String krb5User,
+                String krb5Password, String krb5LoginConfFile, String krb5ConfFile, int maxConns,
+                int maxConnsPerRoute) {
+            super(hosts, port, ssl, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
+                    maxConnsPerRoute);
         } // HttpBackendImpl
    
     } // HttpBackendImpl
     
     @Mock
-    HttpClient httpclient; 
+    private HttpClient httpclient;
     
     // instance to be tested
     private HttpBackend httpBackend;
@@ -67,7 +70,9 @@ public class HttpBackendTest {
     private StringEntity arrayEntity;
     private String normalURL;
     private String arrayURL;
-    private String[] host;    
+    private String[] host;
+    private final int maxConns = 50;
+    private final int maxConnsPerRoute = 10;
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -77,24 +82,21 @@ public class HttpBackendTest {
      */
     @Before
     public void setUp() throws Exception {
-        
-        String normalResponse = "{\"somefield\":\"somevalue\",\"somefield2\":\"somevalue2\",\"somefield2\":\"somevalue2\"}";
-        String arrayResponse = "[{\"somefield\":{\"somesubfield1\":\"somevalue1\",\"sumesuffield1\":\"somevalue2\",\"http\":{\"field1\":\"value1\"},}},{\"somefield\":{\"somesubfield1\":\"somevalue1\",\"sumesuffield1\":\"somevalue2\",\"http\":{\"field1\":\"value1\"},}}]";
-        
+        String normalResponse =
+                "{\"somefield\":\"somevalue\",\"somefield2\":\"somevalue2\",\"somefield2\":\"somevalue2\"}";
+        String arrayResponse =
+                "[{\"somefield\":{\"somesubfield1\":\"somevalue1\",\"sumesuffield1\":\"somevalue2\","
+                + "\"http\":{\"field1\":\"value1\"},}},{\"somefield\":{\"somesubfield1\":\"somevalue1\","
+                + "\"sumesuffield1\":\"somevalue2\",\"http\":{\"field1\":\"value1\"},}}]";
         normalURL = "http://someurl:1234";
         arrayURL = "http://someurl:1234";
-        
         normalEntity = new StringEntity(normalResponse);
         arrayEntity = new StringEntity(arrayResponse);
-        
         host = new String[] {"someurl.org"};
-        
         headers.add(new BasicHeader("Content-type", "application/json"));
         headers.add(new BasicHeader("Accept", "application/json"));
         headers.add(new BasicHeader("X-Auth-token", "12345"));
-        
         when(mockResponse.getEntity()).thenReturn(normalEntity);
-        
         when(mockArrayResponse.getEntity()).thenReturn(arrayEntity);
         when(httpclient.execute(mockRequest)).thenReturn(mockResponse);
         when(httpclient.execute(mockArrayRequest)).thenReturn(mockArrayResponse);
@@ -102,34 +104,38 @@ public class HttpBackendTest {
     
     @Test
     public void testDoRequestWithNormalResponse() throws Exception {
-        System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " - Gets a valid Json object based JSONResponse");
-        httpBackend = new HttpBackendImpl(host, normalURL, false, false, null, null, null, null);
+        System.out.println(getTestTraceHead("[HttpBackend.doRequest]")
+                + " - Gets a valid Json object based JSONResponse");
+        httpBackend = new HttpBackendImpl(host, normalURL, false, false, null, null, null, null, maxConns,
+                maxConnsPerRoute);
         httpBackend.setHttpClient(httpclient);
         
         try {
             httpBackend.doRequest("GET", normalURL, headers, normalEntity);
             System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " -  OK  - Succesfully got");
         } catch (Exception e) {
-            System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " - FAIL - There was some problem when handling the request.");
+            System.out.println(getTestTraceHead("[HttpBackend.doRequest]")
+                    + " - FAIL - There was some problem when handling the request.");
             throw e;
         } // try catch
-        
     } // testDoRequestWithNormalResponse
     
     @Test
-    public void testDoRequestWithArrayResponse () throws Exception {
-        System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " - Gets a valid Json array based JSONResponse");
-        httpBackend = new HttpBackendImpl(host, arrayURL, false, false, null, null, null, null);
+    public void testDoRequestWithArrayResponse() throws Exception {
+        System.out.println(getTestTraceHead("[HttpBackend.doRequest]")
+                + " - Gets a valid Json array based JSONResponse");
+        httpBackend = new HttpBackendImpl(host, arrayURL, false, false, null, null, null, null, maxConns,
+                maxConnsPerRoute);
         httpBackend.setHttpClient(httpclient);
         
         try {
             httpBackend.doRequest("GET", arrayURL, headers, arrayEntity);
             System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " -  OK  - Succesfully got");
         } catch (Exception e) {
-            System.out.println(getTestTraceHead("[HttpBackend.doRequest]") + " - FAIL - There was some problem when handling the request.");
+            System.out.println(getTestTraceHead("[HttpBackend.doRequest]")
+                    + " - FAIL - There was some problem when handling the request.");
             throw e;
         } // try catch
-        
     } // testDoRequestWithArrayResponse
 
 } // HttpBackendTest

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -69,7 +69,11 @@ cygnusagent.sinks.hdfs-sink.type = com.telefonica.iot.cygnus.sinks.NGSIHDFSSink
 # default data model, must be dm-by-entity
 # cygnusagent.sinks.hdfs-sink.data_model = dm-by-entity
 # rest if the interaction with HDFS will be WebHDFS/HttpFS-based, binary if based on the Hadoop API
-# cygnusagent.sinks.hdfs-sink.backend_impl = rest
+# cygnusagent.sinks.hdfs-sink.backend.impl = rest
+# maximum number of Http connections to HDFS backend
+# cygnusagent.sinks.hdfs-sink.backend.max_conns = 500
+# maximum number of Http connections per route to HDFS backend
+# cygnusagent.sinks.hdfs-sink.backend.max_conns_per_route = 100
 # Comma-separated list of FQDN/IP address regarding the HDFS Namenode endpoints
 # If you are using Kerberos authentication, then the usage of FQDNs instead of IP addresses is mandatory
 # cygnusagent.sinks.hdfs-sink.hdfs_host = localhost
@@ -144,6 +148,10 @@ cygnusagent.sinks.ckan-sink.api_key = ckanapikey
 # cygnusagent.sinks.ckan-sink.batch_timeout = 30
 # number of retries upon persistence error
 # cygnusagent.sinks.ckan-sink.batch_ttl = 10
+# maximum number of Http connections to CKAN backend
+# cygnusagent.sinks.ckan-sink.backend.max_conns = 500
+# maximum number of Http connections per route to CKAN backend
+# cygnusagent.sinks.ckan-sink.backend.max_conns_per_route = 100
 
 # ============================================
 # NGSIMySQLSink configuration

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -24,7 +24,6 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
-import com.telefonica.iot.cygnus.utils.CommonConstants;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import com.telefonica.iot.cygnus.utils.NGSICharsets;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
@@ -48,6 +47,8 @@ public class NGSICKANSink extends NGSISink {
     private String orionUrl;
     private boolean rowAttrPersistence;
     private boolean ssl;
+    private int backendMaxConns;
+    private int backendMaxConnsPerRoute;
     private CKANBackend persistenceBackend;
 
     /**
@@ -114,6 +115,24 @@ public class NGSICKANSink extends NGSISink {
     protected boolean getSSL() {
         return this.ssl;
     } // getSSL
+    
+    /**
+     * Gets the maximum number of Http connections allowed in the backend. It is protected due to it is only required
+     * for testing purposes.
+     * @return The maximum number of Http connections allowed in the backend
+     */
+    protected int getBackendMaxConns() {
+        return backendMaxConns;
+    } // getBackendMaxConns
+    
+    /**
+     * Gets the maximum number of Http connections per route allowed in the backend. It is protected due to it is only
+     * required for testing purposes.
+     * @return The maximum number of Http connections per route allowed in the backend
+     */
+    protected int getBackendMaxConnsPerRoute() {
+        return backendMaxConnsPerRoute;
+    } // getBackendMaxConnsPerRoute
 
     @Override
     public void configure(Context context) {
@@ -158,6 +177,12 @@ public class NGSICKANSink extends NGSISink {
                 + sslStr + ") -- Must be 'true' or 'false'");
         }  // if else
         
+        backendMaxConns = context.getInteger("backend.max_conns", 500);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (backend.max_conns=" + backendMaxConns + ")");
+        backendMaxConnsPerRoute = context.getInteger("backend.max_conns_per_route", 100);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (backend.max_conns_per_route="
+                + backendMaxConnsPerRoute + ")");
+        
         super.configure(context);
         
         // Techdebt: allow this sink to work with all the data models
@@ -170,7 +195,8 @@ public class NGSICKANSink extends NGSISink {
     @Override
     public void start() {
         try {
-            persistenceBackend = new CKANBackendImpl(apiKey, ckanHost, ckanPort, orionUrl, ssl);
+            persistenceBackend = new CKANBackendImpl(apiKey, ckanHost, ckanPort, orionUrl, ssl, backendMaxConns,
+                    backendMaxConnsPerRoute);
             LOGGER.debug("[" + this.getName() + "] CKAN persistence backend created");
         } catch (Exception e) {
             LOGGER.error("Error while creating the CKAN persistence backend. Details="

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -71,10 +71,10 @@ public class NGSICKANSinkTest {
         try {
             assertTrue(sink.getRowAttrPersistence());
             System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                    + "-  OK  - 'attr_persisnce=row' configured by default");
+                    + "-  OK  - 'attr_persistence=row' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                    + "- FAIL - 'attr_persisnce=row' not configured by default");
+                    + "- FAIL - 'attr_persistence=row' not configured by default");
             throw e;
         } // try catch
         
@@ -101,10 +101,10 @@ public class NGSICKANSinkTest {
         try {
             assertEquals(100, sink.getBackendMaxConnsPerRoute());
             System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                    + "-  OK  - 'backend.max_conns_per_rpute=100' configured by default");
+                    + "-  OK  - 'backend.max_conns_per_route=100' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                    + "- FAIL - 'backend.max_conns_per_rpute=100' not configured by default");
+                    + "- FAIL - 'backend.max_conns_per_route=100' not configured by default");
             throw e;
         } // try catch
         
@@ -174,7 +174,7 @@ public class NGSICKANSinkTest {
                     + "-  OK  - 'enable_lowercase=true' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                    + "- FAIL - 'enable_owercase=true' not configured by default");
+                    + "- FAIL - 'enable_lowercase=true' not configured by default");
             throw e;
         } // try catch
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -210,6 +210,78 @@ public class NGSICKANSinkTest {
     } // testConfigureDefaults
     
     /**
+     * [NGSICKANSink.configure] -------- backend.max_conns gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConns() {
+        System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                + "-------- backend.max_conns gets the configured value");
+        String apiKey = null; // default
+        String attrPersistence = null; // default
+        String backendMaxConns = "25";
+        String backendMaxConnsPerRoute = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "falso";
+        String enableGrouping = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String port = null; // default
+        String ssl = null; // default
+        NGSICKANSink sink = new NGSICKANSink();
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+        
+        try {
+            assertEquals(25, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'backend.max_conns=25' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'backend.max_conns=25' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConns
+    
+    /**
+     * [NGSICKANSink.configure] -------- backend.max_conns_per_route gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConnsPerRoute() {
+        System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                + "-------- backend.max_conns_per_route gets the configured value");
+        String apiKey = null; // default
+        String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = "3";
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "falso";
+        String enableGrouping = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String port = null; // default
+        String ssl = null; // default
+        NGSICKANSink sink = new NGSICKANSink();
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+        
+        try {
+            assertEquals(3, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'backend.max_conns_per_route=3' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'backend.max_conns_per_route=3' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConnsPerRoute
+    
+    /**
      * [NGSICKANSink.configure] -------- enable_encoding can only be 'true' or 'false'.
      */
     @Test
@@ -941,8 +1013,8 @@ public class NGSICKANSinkTest {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("attr_persistence", attrPersistence);
-        context.put("backend.maxConns", backendMaxConns);
-        context.put("backend.maxConnsPerRoute", backendMaxConnsPerRoute);
+        context.put("backend.max_conns", backendMaxConns);
+        context.put("backend.max_conns_per_route", backendMaxConnsPerRoute);
         context.put("batch_size", batchSize);
         context.put("batch_time", batchTime);
         context.put("batch_ttl", batchTTL);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -20,6 +20,7 @@ package com.telefonica.iot.cygnus.sinks;
 
 import static org.junit.Assert.*; // this is required by "fail" like assertions
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -43,13 +44,182 @@ public class NGSICKANSinkTest {
     } // NGSICKANSinkTest
 
     /**
+     * [NGSICKANSink.configure] -------- When not configured, not mandatory parameters get default values.
+     */
+    @Test
+    public void testConfigureDefaults() {
+        System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                + "-------- When not configured, not mandatory parameters get default values");
+        String apiKey = null; // default
+        String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableGrouping = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String port = null; // default
+        String ssl = null; // default
+        NGSICKANSink sink = new NGSICKANSink();
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+        
+        try {
+            assertTrue(sink.getRowAttrPersistence());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'attr_persisnce=row' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'attr_persisnce=row' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("nokey", sink.getAPIKey());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'api_key=nokey' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'api_key=nokey' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(500, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'backend.max_conns=500' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'backend.max_conns=500' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(100, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'backend.max_conns_per_rpute=100' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'backend.max_conns_per_rpute=100' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(1, sink.getBatchSize());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'batch_size=1' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'batch_size=1' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(30, sink.getBatchTimeout());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'batch_timeout=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'batch_timeout=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(10, sink.getBatchTTL());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'batch_ttl=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'batch_ttl=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(DataModel.DMBYENTITY, sink.getDataModel());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-entity' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-entity' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableEncoding());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'enable_encoding=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'enable_encoding=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableGrouping());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'enable_grouping=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'enable_grouping=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(sink.getEnableLowerCase());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'enable_lowercase=true' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'enable_owercase=true' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("localhost", sink.getCKANHost());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'ckan_host=localhost' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'ckan_host=localhost' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("80", sink.getCKANPort());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'ckan_port=80' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'ckan_port=80' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getSSL());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'ssl=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'ssl=false' not configured by default");
+            throw e;
+        } // try catch
+    } // testConfigureDefaults
+    
+    /**
      * [NGSICKANSink.configure] -------- enable_encoding can only be 'true' or 'false'.
      */
     @Test
     public void testConfigureEnableEncoding() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
                 + "-------- enable_encoding can only be 'true' or 'false'");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -58,12 +228,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -83,7 +252,10 @@ public class NGSICKANSinkTest {
     public void testConfigureEnableLowercase() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
                 + "-------- enable_lowercase can only be 'true' or 'false'");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -92,12 +264,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = "falso";
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -117,7 +288,10 @@ public class NGSICKANSinkTest {
     public void testConfigureEnableGrouping() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
                 + "-------- enable_grouping can only be 'true' or 'false'");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -126,12 +300,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = "falso";
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -152,21 +325,23 @@ public class NGSICKANSinkTest {
     public void testConfigureDataModel() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
                 + "-------- data_model can only be 'dm-by-entity'");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
-        String dataModel = "dm-by-service";
+        String dataModel = null; // default
         String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -186,7 +361,10 @@ public class NGSICKANSinkTest {
     public void testConfigureAttrPersistence() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
                 + "-------- attr_persistence can only be 'row' or 'column'");
+        String apiKey = null; // default
         String attrPersistence = "fila";
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -195,12 +373,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -223,21 +400,23 @@ public class NGSICKANSinkTest {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildOrgName]")
                 + "-------- When no encoding, the org name is equals to the encoding of the notified/defaulted "
                 + "service");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = "false";
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         
         try {
@@ -269,7 +448,10 @@ public class NGSICKANSinkTest {
     public void testBuildOrgNameEncoding() throws Exception {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildOrgName]")
                 + "-------- When encoding, the org name is equals to the encoding of the notified/defaulted service");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -278,12 +460,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         
         try {
@@ -318,21 +499,23 @@ public class NGSICKANSinkTest {
                 + "-------- When no encoding and when using a notified/defaulted non root service path, the pkg name "
                 + "is equals to the encoding of the concatenation of the notified/defaulted service and the "
                 + "notified/defaulted service path");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = "false";
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         String servicePath = "/someServicePath";
         
@@ -370,7 +553,10 @@ public class NGSICKANSinkTest {
                 + "-------- When encoding and when using a notified/defaulted non root service path, the pkg name is "
                 + "equals to the encoding of the concatenation of the notified/defaulted service and the "
                 + "notified/defaulted service path");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -379,12 +565,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         String servicePath = "/someServicePath";
         
@@ -422,21 +607,23 @@ public class NGSICKANSinkTest {
                 + "-------- When no encoding and when using a notified/defaulted root service path, the pkg name is "
                 + "equals to the encoding of the concatenation of the notified/defaulted service and the "
                 + "notified/defaulted service path");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = "false";
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         String servicePath = "/";
         
@@ -474,7 +661,10 @@ public class NGSICKANSinkTest {
                 + "-------- When encoding and when using a notified/defaulted root service path, the pkg name is "
                 + "equals to the encoding of the concatenation of the notified/defaulted service and the "
                 + "notified/defaulted service path");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -483,12 +673,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "someService";
         String servicePath = "/";
         
@@ -524,21 +713,23 @@ public class NGSICKANSinkTest {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildResName]")
                 + "-------- When no encoding, the CKAN resource name is the encoding of the concatenation of the "
                 + "notified <entityId> and <entityType>");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = "false";
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String entity = "someId=someType";
         
         try {
@@ -572,7 +763,10 @@ public class NGSICKANSinkTest {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildResName]")
                 + "-------- When encoding, the CKAN resource name is the encoding of the concatenation of the "
                 + "notified <entityId> and <entityType>");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -581,12 +775,11 @@ public class NGSICKANSinkTest {
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String entity = "someId=someType";
         
         try {
@@ -618,21 +811,23 @@ public class NGSICKANSinkTest {
     public void testBuildOrganizationNameLength() throws Exception {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildOrgName]")
                 + "-------- An organization name length greater than 100 characters is detected");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = null; // defalt
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogService";
         
@@ -656,21 +851,23 @@ public class NGSICKANSinkTest {
     public void testBuildPackageNameLength() throws Exception {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildPkgName]")
                 + "-------- A resource name length greater than 100 characters is detected");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = null; // defalt
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String service = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogService";
         String servicePath = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
@@ -696,21 +893,23 @@ public class NGSICKANSinkTest {
     public void testBuildResourceNameLength() throws Exception {
         System.out.println(getTestTraceHead("[NGSICKANSink.buildResName]")
                 + "-------- A resource name length greater than 100 characters is detected");
+        String apiKey = null; // default
         String attrPersistence = null; // default
+        String backendMaxConns = null; // default
+        String backendMaxConnsPerRoute = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = null; // default
-        String enableEncoding = null; // defalt
+        String enableEncoding = null; // default
         String enableGrouping = null; // default
         String enableLowercase = null; // default
         String host = null; // default
-        String password = null; // default
         String port = null; // default
-        String username = null; // default
+        String ssl = null; // default
         NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
         String entity = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogEntity";
         
@@ -735,22 +934,25 @@ public class NGSICKANSinkTest {
         return batch;
     } // createBatch
     
-    private Context createContext(String attrPersistence, String batchSize, String batchTime, String batchTTL,
-            String dataModel, String enableEncoding, String enableGrouping, String enableLowercase, String host,
-            String password, String port, String username) {
+    private Context createContext(String apiKey, String attrPersistence, String backendMaxConns,
+            String backendMaxConnsPerRoute, String batchSize, String batchTime, String batchTTL, String dataModel,
+            String enableEncoding, String enableGrouping, String enableLowercase, String host, String port,
+            String ssl) {
         Context context = new Context();
+        context.put("api_key", apiKey);
         context.put("attr_persistence", attrPersistence);
+        context.put("backend.maxConns", backendMaxConns);
+        context.put("backend.maxConnsPerRoute", backendMaxConnsPerRoute);
         context.put("batch_size", batchSize);
         context.put("batch_time", batchTime);
         context.put("batch_ttl", batchTTL);
+        context.put("ckan_host", host);
+        context.put("ckan_port", port);
         context.put("data_model", dataModel);
         context.put("enable_encoding", enableEncoding);
         context.put("enable_grouping", enableGrouping);
         context.put("enable_lowercase", enableLowercase);
-        context.put("mysql_host", host);
-        context.put("mysql_password", password);
-        context.put("mysql_port", port);
-        context.put("mysql_username", username);
+        context.put("ssl", ssl);
         return context;
     } // createContext
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -56,6 +56,132 @@ public class NGSICartoDBSinkTest {
     } // NGSICartoDBSinkTest
     
     /**
+     * [NGSICartoDBSink.configure] -------- When not configured, not mandatory parameters get default values.
+     */
+    @Test
+    public void testConfigureDefaults() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- When not configured, not mandatory parameters get default values");
+        String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
+        String dataModel = null; // default one
+        String enableDistance = null;
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null;
+        String flipCoordinates = null; // default one
+        String keysConfFile = "/keys.conf";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
+        
+        try {
+            assertEquals(500, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'backend.max_conns=500' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'backend.max_conns=500' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(100, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'backend.max_conns_per_route=100' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'backend.max_conns_per_route=100' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(1, sink.getBatchSize());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'batch_size=1' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'batch_size=1' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(30, sink.getBatchTimeout());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'batch_timeout=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'batch_timeout=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(10, sink.getBatchTTL());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'batch_ttl=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'batch_ttl=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(Enums.DataModel.DMBYENTITY, sink.getDataModel());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-entity' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-entity' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableDistance());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_distance=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_encoding=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableGrouping());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_grouping=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_grouping=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(sink.getEnableLowerCase());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_lowercase=true' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_lowercase=true' not configured by default");
+            throw e;
+        } // try catch
+
+        try {
+            assertTrue(sink.getEnableRaw());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_raw=true' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_raw=true' not configured by default");
+            throw e;
+        } // try catch
+    } // testConfigureDefaults
+    
+    /**
      * [NGSICartoDBSink.configure] -------- Independently of the configured value, enable_lowercase is always 'true'
      * by default.
      */
@@ -63,17 +189,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureEnableLowercaseAlwaysTrue() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Independently of the configured value, enable_lowercase is always 'true' by default");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = "false";
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = "false";
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -93,17 +225,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureFlipCoordinatesOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'flip_coordinates' cannot be different than 'true' or 'false'");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = "falso"; // wrong value
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = "falso"; // wrong value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -123,17 +261,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureEnableRawOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'enable_raw' cannot be different than 'true' or 'false'");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default value
-        String enableRaw = "falso"; // wrong value
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = "falso"; // wrong value
+        String flipCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -153,17 +297,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureEnableDistanceOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'enable_distance' cannot be different than 'true' or 'false'");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
-        String keysConfFile = "/keys.conf";
         String enableDistance = "falso"; // wrong value
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
+        String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -183,17 +333,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureKeysConfFileOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'keys_conf_file' cannot be empty");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default_one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = null; // empty file
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -227,17 +383,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -273,17 +435,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -320,17 +488,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -354,17 +528,23 @@ public class NGSICartoDBSinkTest {
     public void testConfigureDataModelOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured `data_model` cannot be different than `dm-by-service-path` or `dm-by-entity`");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-service";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -378,8 +558,9 @@ public class NGSICartoDBSinkTest {
         
         dataModel = "dm-by-attribute";
         sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -413,17 +594,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
         String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -460,17 +647,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -508,17 +701,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
         String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -555,17 +754,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -602,17 +807,23 @@ public class NGSICartoDBSinkTest {
             throw new AssertionError(e.getMessage());
         } // try catch
         
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -637,17 +848,23 @@ public class NGSICartoDBSinkTest {
     public void testBuildSchemaName() throws Exception {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
                 + "-------- The schema name is equals to the encoding of the notified/defaulted service");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = null; // default one
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String service = "someService";
         
         try {
@@ -680,17 +897,23 @@ public class NGSICartoDBSinkTest {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a non root service-path is notified/defaulted and data_model is "
                 + "'dm-by-service-path' the CartoDB table name is the encoding of <service-path>");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -726,17 +949,23 @@ public class NGSICartoDBSinkTest {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a non root service-path is notified/defaulted and data_model is 'dm-by-entity' "
                 + "the CartoDB table name is the lower case of x002f<servicePath>xffff<entityId>xffff<entityType>");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId=someType"; // using the internal concatenator
         String attribute = null; // irrelevant for this test
@@ -772,17 +1001,23 @@ public class NGSICartoDBSinkTest {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When a root service-path is notified/defaulted and data_model is "
                 + "'dm-by-service-path' the CartoDB table name is x002f");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -818,17 +1053,23 @@ public class NGSICartoDBSinkTest {
                 + "-------- When a non service-path is notified/defaulted and data_model is 'dm-by-entity' "
                 + "the CartoDB table name is the encoding of the concatenation of <service-path>, <entityId> and"
                 + "<entityType>");
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -866,17 +1107,23 @@ public class NGSICartoDBSinkTest {
                 + "-------- When initializing through an initial geolocated event, a table name is created");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -923,17 +1170,23 @@ public class NGSICartoDBSinkTest {
                 + "the geolocation attribute, which is added as a specific field ('the_geom')");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -999,17 +1252,23 @@ public class NGSICartoDBSinkTest {
                 + "string is lower case, starts with '(' and finishes with ')'");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1077,17 +1336,23 @@ public class NGSICartoDBSinkTest {
                 + "geolocation attribute, which is added as a specific value (a point)");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1161,17 +1426,23 @@ public class NGSICartoDBSinkTest {
                 + "with '(' and finishes with ')'");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = null; // default one
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1228,17 +1499,23 @@ public class NGSICartoDBSinkTest {
                 + "field contains a point with exchanged latitude and longitude.");
         
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default one
-        String flipCoordinates = "true";
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default one
+        String flipCoordinates = "true";
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1284,17 +1561,23 @@ public class NGSICartoDBSinkTest {
                 + "-------- When data model is by service path, a table name length greater than 63 characters is "
                 + "detected");
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableLowercase = null; // default
-        String flipCoordinates = null; // default
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1321,17 +1604,23 @@ public class NGSICartoDBSinkTest {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                 + "-------- When data model is by entity, a table name length greater than 63 characters is detected");
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableLowercase = null; // default
-        String flipCoordinates = null; // default
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/tooLoooooooooooooooooooooooooooongServicePath";
         String entity = "tooLoooooooooooooooooooooooooooongEntity";
         String attribute = null; // irrelevant for this test
@@ -1359,17 +1648,23 @@ public class NGSICartoDBSinkTest {
                 + "-------- When data model is by atribute, a table name length greater than 63 characters is "
                 + "detected");
         // Create a NGSICartoDBSink
-        String endpoint = "https://localhost";
         String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
         String dataModel = "dm-by-attribute";
-        String enableLowercase = null; // default
-        String flipCoordinates = null; // default
-        String enableRaw = null; // default one
         String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
-        sink.configure(createContext(endpoint, apiKey, dataModel, enableLowercase, flipCoordinates, enableRaw,
-                enableDistance, keysConfFile));
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";
         String attribute = "tooLooooooooooooongAttribute";
@@ -1386,19 +1681,22 @@ public class NGSICartoDBSinkTest {
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
     
-    private Context createContext(String endpoint, String apiKey, String dataModel, String enableLowercase,
-            String flipCoordinates, String enableRaw, String enableDistance, String keysConfFile) {
+    private Context createContext(String apiKey, String backendMaxConns, String backendMaxConnsPerRoute,
+            String batchSize, String batchTimeout, String batchTTL, String dataModel, String enableDistance,
+            String enableGrouping, String enableLowercase, String enableRaw, String flipCoordinates,
+            String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
-        context.put("batch_size", "100");
-        context.put("batch_timeout", "30");
-        context.put("batch_ttl", "10");
+        context.put("backend_max_conns", backendMaxConns);
+        context.put("backend_max_conns_per_route", backendMaxConnsPerRoute);
+        context.put("batch_size", batchSize);
+        context.put("batch_timeout", batchTimeout);
+        context.put("batch_ttl", batchTTL);
         context.put("data_model", dataModel);
         context.put("enable_distance", enableDistance);
-        context.put("enable_grouping", "false");
+        context.put("enable_grouping", enableGrouping);
         context.put("enable_lowercase", enableLowercase);
         context.put("enable_raw", enableRaw);
-        context.put("endpoint", endpoint);
         context.put("flip_coordinates", flipCoordinates);
         context.put("keys_conf_file", keysConfFile);
         return context;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -146,7 +146,7 @@ public class NGSICartoDBSinkTest {
                     + "-  OK  - 'enable_distance=false' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_encoding=false' not configured by default");
+                    + "- FAIL - 'enable_distance=false' not configured by default");
             throw e;
         } // try catch
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -182,6 +182,78 @@ public class NGSICartoDBSinkTest {
     } // testConfigureDefaults
     
     /**
+     * [NGSICartoDBSink.configure] -------- backend.max_conns gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConns() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- backend.max_conns gets the configured value");
+        String apiKey = "1234567890abcdef";
+        String backendMaxConns = "25";
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
+        String dataModel = null; // default one
+        String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null;
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
+        String keysConfFile = "/keys.conf";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
+        
+        try {
+            assertEquals(25, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'backend.max_conns=25' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'backend.max_conns=25' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConns
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- backend.max_conns_per_route gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConnsPerRoute() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- backend.max_conns_per_route gets the configured value");
+        String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = "3";
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
+        String dataModel = null; // default one
+        String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null;
+        String enableRaw = null; // default one
+        String flipCoordinates = null; // default one
+        String keysConfFile = "/keys.conf";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
+                keysConfFile));
+        
+        try {
+            assertEquals(3, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'backend.max_conns_per_route=3' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'backend.max_conns_per_route=3' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConnsPerRoute
+    
+    /**
      * [NGSICartoDBSink.configure] -------- Independently of the configured value, enable_lowercase is always 'true'
      * by default.
      */
@@ -1687,8 +1759,8 @@ public class NGSICartoDBSinkTest {
             String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
-        context.put("backend_max_conns", backendMaxConns);
-        context.put("backend_max_conns_per_route", backendMaxConnsPerRoute);
+        context.put("backend.max_conns", backendMaxConns);
+        context.put("backend.max_conns_per_route", backendMaxConnsPerRoute);
         context.put("batch_size", batchSize);
         context.put("batch_timeout", batchTimeout);
         context.put("batch_ttl", batchTTL);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSinkTest.java
@@ -17,8 +17,10 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
-import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import org.apache.flume.Context;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -27,28 +29,132 @@ import org.junit.Test;
  */
 public class NGSIDynamoDBSinkTest {
     
+    /**
+     * [NGSIDynamoDBSink.configure] -------- When not configured, not mandatory parameters get default values.
+     */
     @Test
-    public void dummyTest() {
-    } // dummyTest
+    public void testConfigureDefaults() {
+        System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                + "-------- When not configured, not mandatory parameters get default values");
+        String accessKeyId = "my_access_key";
+        String attrPersistence = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
+        String dataModel = null;
+        String enableGrouping = null;
+        String enableLowercase = null;
+        String region = null;
+        String secretAccessKey = "my_secret_access_key";
+        NGSIDynamoDBSink sink = new NGSIDynamoDBSink();
+        sink.configure(createContext(accessKeyId, attrPersistence, batchSize, batchTimeout, batchTTL, dataModel,
+                enableGrouping, enableLowercase, region, secretAccessKey));
+        
+        try {
+            assertTrue(sink.getRowAttrPersistence());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'attr_persisnce=row' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'attr_persisnce=row' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(1, sink.getBatchSize());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'batch_size=1' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'batch_size=1' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(30, sink.getBatchTimeout());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'batch_timeout=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'batch_timeout=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(10, sink.getBatchTTL());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'batch_ttl=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'batch_ttl=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(Enums.DataModel.DMBYENTITY, sink.getDataModel());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-entity' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-entity' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(sink.getEnableEncoding());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'enable_encoding=true' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'enable_encoding=true' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableGrouping());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'enable_grouping=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'enable_grouping=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableLowerCase());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'enable_lowercase=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'enable_lowercase=false' not configured by default");
+            throw e;
+        } // try catch
+
+        try {
+            assertEquals("eu-west-1", sink.getRegion());
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "-  OK  - 'region=eu-west-1' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
+                    + "- FAIL - 'region=eu-west-1' not configured by default");
+            throw e;
+        } // try catch
+    } // testConfigureDefaults
     
-    private NGSIBatch createBatch(long recvTimeTs, String service, String servicePath, String destination,
-            NotifyContextRequest.ContextElement contextElement) {
-        NGSIEvent groupedEvent = new NGSIEvent(recvTimeTs, service, servicePath, destination, null,
-            contextElement);
-        NGSIBatch batch = new NGSIBatch();
-        batch.addEvent(destination, groupedEvent);
-        return batch;
-    } // createBatch
-    
-    private Context createContext(String accessKeyId, String attrPersistence, String enableGrouping, String region,
-            String secretAccessKey, String tableType) {
+    private Context createContext(String accessKeyId, String attrPersistence, String batchSize, String batchTimeout,
+            String batchTTL, String dataModel, String enableGrouping, String enableLowercase, String region,
+            String secretAccessKey) {
         Context context = new Context();
         context.put("access_key_id", accessKeyId);
         context.put("attr_persistence", attrPersistence);
+        context.put("batch_size", batchSize);
+        context.put("batch_timeout", batchTimeout);
+        context.put("batch_ttl", batchTTL);
+        context.put("data_model", dataModel);
         context.put("enable_grouping", enableGrouping);
+        context.put("enable_lowercase", enableLowercase);
         context.put("region", region);
         context.put("secret_access_key", secretAccessKey);
-        context.put("table_type", tableType);
         return context;
     } // createContext
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSinkTest.java
@@ -53,10 +53,10 @@ public class NGSIDynamoDBSinkTest {
         try {
             assertTrue(sink.getRowAttrPersistence());
             System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
-                    + "-  OK  - 'attr_persisnce=row' configured by default");
+                    + "-  OK  - 'attr_persistence=row' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIDynamoDBSink.configure]")
-                    + "- FAIL - 'attr_persisnce=row' not configured by default");
+                    + "- FAIL - 'attr_persistence=row' not configured by default");
             throw e;
         } // try catch
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
@@ -247,6 +247,92 @@ public class NGSIHDFSSinkTest {
     } // testConfigureDefaults
     
     /**
+     * [NGSIHDFSSinkTest.configure] -------- backend.max_conns gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConns() {
+        System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                + "-------- backend.max_conns gets the configured value");
+        String backendImpl = null; // default value
+        String backendMaxConns = "25";
+        String backendMaxConnsPerRoute = null; // default value
+        String batchSize = null; // default value
+        String batchTime = null; // default value
+        String batchTTL = null; // default value
+        String csvSeparator = null; // default value
+        String dataModel = null; // default value
+        String enableEncoding = null;
+        String enableGrouping = null; // default value
+        String enableLowercase = null; // default value
+        String fileFormat = null; // default value
+        String host = null; // default value
+        String password = "mypassword";
+        String port = null; // default value
+        String username = "myuser";
+        String hive = null;
+        String krb5 = null;
+        String token = "mytoken";
+        String serviceAsNamespace  = null; // default value
+        NGSIHDFSSink sink = new NGSIHDFSSink();
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
+        
+        try {
+            assertEquals(25, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                    + "-  OK  - 'backend.max_conns=25' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                    + "- FAIL - 'backend.max_conns=25' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConns
+    
+    /**
+     * [NGSIHDFSSinkTest.configure] -------- backend.max_conns_per_route gets the configured value.
+     */
+    @Test
+    public void testConfigureMaxConnsPerRoute() {
+        System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                + "-------- backend.max_conns_per_route gets the configured value");
+        String backendImpl = null; // default value
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = "3";
+        String batchSize = null; // default value
+        String batchTime = null; // default value
+        String batchTTL = null; // default value
+        String csvSeparator = null; // default value
+        String dataModel = null; // default value
+        String enableEncoding = null;
+        String enableGrouping = null; // default value
+        String enableLowercase = null; // default value
+        String fileFormat = null; // default value
+        String host = null; // default value
+        String password = "mypassword";
+        String port = null; // default value
+        String username = "myuser";
+        String hive = null;
+        String krb5 = null;
+        String token = "mytoken";
+        String serviceAsNamespace  = null; // default value
+        NGSIHDFSSink sink = new NGSIHDFSSink();
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
+        
+        try {
+            assertEquals(3, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                    + "-  OK  - 'backend.max_conns_per_route=3' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
+                    + "- FAIL - 'backend.max_conns_per_route=3' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureMaxConnsPerRoute
+    
+    /**
      * [NGSIHDFSSinkTest.configure] -------- enable_encoding can only be 'true' or 'false'.
      */
     @Test

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
@@ -180,7 +180,7 @@ public class NGSIHDFSSinkTest {
                     + "-  OK  - 'enable_lowercase=false' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
-                    + "- FAIL - 'enable_owercase=false' not configured by default");
+                    + "- FAIL - 'enable_lowercase=false' not configured by default");
             throw e;
         } // try catch
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSinkTest.java
@@ -19,10 +19,12 @@
 package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.sinks.NGSIHDFSSink.BackendImpl;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import org.apache.flume.Context;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -41,6 +43,210 @@ public class NGSIHDFSSinkTest {
     } // NGSIHDFSSinkTest
 
     /**
+     * [NGSIHDFSSink.configure] -------- When not configured, not mandatory parameters get default values.
+     */
+    @Test
+    public void testConfigureDefaults() {
+        System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                + "-------- When not configured, not mandatory parameters get default values");
+        String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
+        String batchSize = null; // default value
+        String batchTime = null; // default value
+        String batchTTL = null; // default value
+        String csvSeparator = null; // default value
+        String dataModel = null; // default value
+        String enableEncoding = null; // default value
+        String enableGrouping = null; // default value
+        String enableLowercase = null; // default value
+        String fileFormat = null; // default value
+        String host = null; // default value
+        String password = "mypassword";
+        String port = null; // default value
+        String username = "myuser";
+        String hive = null; // default value
+        String krb5 = null; // default value
+        String token = "mytoken";
+        String serviceAsNamespace  = null; // default value
+        NGSIHDFSSink sink = new NGSIHDFSSink();
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
+        
+        try {
+            assertEquals(BackendImpl.REST, sink.getBackendImpl());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'backend.impl=rest' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'backend.impl=rest' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(500, sink.getBackendMaxConns());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'backend.max_conns=500' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'backend.max_conns=500' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(100, sink.getBackendMaxConnsPerRoute());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'backend.max_conns_per_route=100' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'backend.max_conns_per_route=100' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(1, sink.getBatchSize());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'batch_size=1' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'batch_size=1' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(30, sink.getBatchTimeout());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'batch_timeout=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'batch_timeout=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(10, sink.getBatchTTL());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'batch_ttl=30' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'batch_ttl=30' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(",", sink.getCSVSeparator());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'csv_separator=,' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'csv_separator=,' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(Enums.DataModel.DMBYENTITY, sink.getDataModel());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-entity' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-entity' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableEncoding());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'enable_encoding=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'enable_encoding=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableGrouping());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'enable_grouping=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'enable_grouping=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableLowerCase());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'enable_lowercase=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'enable_owercase=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("json-row", sink.getFileFormat());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'file_format=json-row' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'file_format=json-row' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            String[] expectedHost = {"localhost"};
+            Assert.assertArrayEquals(expectedHost, sink.getHDFSHosts());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'hdfs_host=localhost' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'hdfs_host=localhost' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals("14000", sink.getHDFSPort());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'hdfs_port=14000' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'hdfs_port=14000' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableHive());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'enable_hive=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'enable_hive=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableKrb5Auth());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'enable_krb5=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'enable_krb5=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getServiceAsNamespace());
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "-  OK  - 'service_as_namespace=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIHDFSSink.configure]")
+                    + "- FAIL - 'service_as_namespace=false' not configured by default");
+            throw e;
+        } // try catch
+    } // testConfigureDefaults
+    
+    /**
      * [NGSIHDFSSinkTest.configure] -------- enable_encoding can only be 'true' or 'false'.
      */
     @Test
@@ -48,6 +254,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
                 + "-------- enable_encoding can only be 'true' or 'false'");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -66,9 +274,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -89,6 +297,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
                 + "-------- enable_lowercase can only be 'true' or 'false'");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -107,9 +317,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -131,6 +341,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
                 + "-------- enable_grouping can only be 'true' or 'false'");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -149,9 +361,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -165,13 +377,15 @@ public class NGSIHDFSSinkTest {
     } // testConfigureEnableGrouping
     
     /**
-     * [NGSIHDFSSinkTest.configure] -------- backend_impl can only be 'rest' or 'binary'.
+     * [NGSIHDFSSinkTest.configure] -------- backend.impl can only be 'rest' or 'binary'.
      */
     @Test
     public void testConfigureBackendImpl() {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
-                + "-------- enable_grouping can only be 'true' or 'false'");
+                + "-------- backend.impl can only be 'rest' or 'binary'");
         String backendImpl = "api";
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -190,9 +404,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -214,6 +428,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
                 + "-------- data_model can only be 'dm-by-entity'");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -232,9 +448,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -256,6 +472,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSinkTest.configure]")
                 + "-------- file_format can only be 'json-row', 'json-column', 'csv-row' or 'csv-column'");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -274,9 +492,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -300,6 +518,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When no encoding and when a non root service-path is notified/defaulted the HDFS folder "
                 + "path is the encoding of <service>/<service-path>/<entity>");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -318,9 +538,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/somePath";
         String entity = "someId=someType";
@@ -358,6 +578,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When encoding and when a non root service-path is notified/defaulted the HDFS folder path "
                 + "is the encoding of <service>/<service-path>/<entity>");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -376,9 +598,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/somePath";
         String entity = "someId=someType";
@@ -416,6 +638,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When no encoding and when a root service-path is notified/defaulted the HDFS folder path "
                 + "is the encoding of <service>/<entity>");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -434,9 +658,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/";
         String entity = "someId=someType";
@@ -474,6 +698,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When encoding and when a root service-path is notified/defaulted the HDFS folder path is "
                 + "the encoding of <service>/<entity>");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -492,9 +718,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/";
         String entity = "someId=someType";
@@ -532,6 +758,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When no encoding and when a non root service-path is notified/defaulted the HDFS file path "
                 + "is the encoding of <service>/<service-path>/<entity>/<entity>.txt");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -550,9 +778,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/somePath";
         String entity = "someId=someType";
@@ -590,6 +818,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When encoding and when a non root service-path is notified/defaulted the HDFS file path "
                 + "is the encoding of <service>/<service-path>/<entity>/<entity>.txt");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -608,9 +838,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/somePath";
         String entity = "someId=someType";
@@ -648,6 +878,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When no encoding and when a root service-path is notified/defaulted the HDFS file path is "
                 + "the encoding of <service>/<entity>/<entity>.txt");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -666,9 +898,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/";
         String entity = "someId=someType";
@@ -706,6 +938,8 @@ public class NGSIHDFSSinkTest {
                 + "-------- When encoding and when a root service-path is notified/defaulted the HDFS file path is the "
                 + "encoding of <service>/<entity>/<entity>.txt");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -724,9 +958,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "someService";
         String servicePath = "/";
         String entity = "someId=someType";
@@ -762,6 +996,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSink.buildFolderPath]")
                 + "-------- A folder path length greater than 255 characters is detected");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -780,9 +1016,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "tooLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogService";
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String destination = "tooLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogDestination";
@@ -808,6 +1044,8 @@ public class NGSIHDFSSinkTest {
         System.out.println(getTestTraceHead("[NGSIHDFSSink.buildFilePath]")
                 + "-------- A file path length greater than 255 characters is detected");
         String backendImpl = null; // default value
+        String backendMaxConns = null; // default value
+        String backendMaxConnsPerRoute = null; // default value
         String batchSize = null; // default value
         String batchTime = null; // default value
         String batchTTL = null; // default value
@@ -826,9 +1064,9 @@ public class NGSIHDFSSinkTest {
         String token = "mytoken";
         String serviceAsNamespace  = null; // default value
         NGSIHDFSSink sink = new NGSIHDFSSink();
-        sink.configure(createContext(backendImpl, batchSize, batchTime, batchTTL, csvSeparator, dataModel,
-                enableEncoding, enableGrouping, enableLowercase, fileFormat, host, password, port, username, hive, krb5,
-                token, serviceAsNamespace));
+        sink.configure(createContext(backendImpl, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTime,
+                batchTTL, csvSeparator, dataModel, enableEncoding, enableGrouping, enableLowercase, fileFormat, host,
+                password, port, username, hive, krb5, token, serviceAsNamespace));
         String service = "tooLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogService";
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String destination = "tooLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogDestination";
@@ -854,12 +1092,15 @@ public class NGSIHDFSSinkTest {
         return batch;
     } // createBatch
     
-    private Context createContext(String backendImpl, String batchSize, String batchTime, String batchTTL,
-            String csvSeparator, String dataModel, String enableEncoding, String enableGrouping, String enableLowercase,
-            String fileFormat, String host, String password, String port, String username, String hive, String krb5,
-            String token, String serviceAsNamespace) {
+    private Context createContext(String backendImpl, String backendMaxConns, String backendMaxConnsPerRoute,
+            String batchSize, String batchTime, String batchTTL, String csvSeparator, String dataModel,
+            String enableEncoding, String enableGrouping, String enableLowercase, String fileFormat, String host,
+            String password, String port, String username, String hive, String krb5, String token,
+            String serviceAsNamespace) {
         Context context = new Context();
-        context.put("backend_impl", backendImpl);
+        context.put("backend.impl", backendImpl);
+        context.put("backend.max_conns", backendMaxConns);
+        context.put("backend.max_conns_per_route", backendMaxConnsPerRoute);
         context.put("batchSize", batchSize);
         context.put("batchTime", batchTime);
         context.put("batchTTL", batchTTL);

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -397,6 +397,8 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsx000
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| backend.max_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. |
+| backend.max_conns_per_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. |
 
 A configuration example could be:
 
@@ -416,6 +418,8 @@ cygnus-ngsi.sinks.raw-sink.data_model = dm-by-entity
 cygnus-ngsi.sinks.raw-sink.batch_size = 10
 cygnus-ngsi.sinks.raw-sink.batch_timeout = 5
 cygnus-ngsi.sinks.raw-sink.batch_ttl = 0
+cygnus-ngsi.sinks.raw-sink.backend.max_conns = 500
+cygnus-ngsi.sinks.raw-sink.backend.max_conns_per_route = 100
 ```
 
 An example of CartoDB keys configuration file could be (this can be generated from the configuration template distributed with Cygnus):

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
@@ -334,6 +334,8 @@ NOTE: `curl` is a Unix command allowing for interacting with REST APIs such as t
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| backend.max_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. |
+| backend.max_conns_per_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. |
 
 A configuration example could be:
 
@@ -354,6 +356,8 @@ A configuration example could be:
     cygnusagent.sinks.ckan-sink.batch_size = 100
     cygnusagent.sinks.ckan-sink.batch_timeout = 30
     cygnusagent.sinks.ckan-sink.batch_ttl = 10
+    cygnusagent.sinks.ckan-sink.backend.max_conns = 500
+    cygnusagent.sinks.ckan-sink.backend.max_conns_per_route = 100
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
@@ -274,7 +274,9 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
 | data_model | no | dm-by-entity |  Always <i>dm-by-entity</i>, even if not configured. |
 | file_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>. |
-| backend_impl | no | rest | <i>rest</i>, if a WebHDFS/HttpFS-based implementation is used when interacting with HDFS; or <i>binary</i>, if a Hadoop API-based implementation is used when interacting with HDFS. |
+| backend.impl | no | rest | <i>rest</i>, if a WebHDFS/HttpFS-based implementation is used when interacting with HDFS; or <i>binary</i>, if a Hadoop API-based implementation is used when interacting with HDFS. |
+| backend.max_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
+| backend.max_conns_per_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
 | hdfs_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run. |
 | hdfs_port | no | 14000 | <i>14000</i> if using HttpFS (rest), <i>50070</i> if using WebHDFS (rest), <i>8020</i> if using the Hadoop API (binary). |
 | hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser. |
@@ -309,7 +311,9 @@ A configuration example could be:
     cygnusagent.sinks.hdfs-sink.enable_lowercase = false
     cygnusagent.sinks.hdfs-sink.data_model = dm-by-entity
     cygnusagent.sinks.hdfs-sink.file_format = json-column
-    cygnusagent.sinks.hdfs-sink.backend_impl = rest
+    cygnusagent.sinks.hdfs-sink.backend.impl = rest
+    cygnusagent.sinks.hdfs-sink.backend.max_conns = 500
+    cygnusagent.sinks.hdfs-sink.backend.max_conns_per_route = 100
     cygnusagent.sinks.hdfs-sink.hdfs_host = 192.168.80.34
     cygnusagent.sinks.hdfs-sink.hdfs_port = 14000
     cygnusagent.sinks.hdfs-sink.hdfs_username = myuser

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -57,7 +57,11 @@ cygnusagent.sinks.hdfs-sink.enable_grouping = false
 # true if lower case is wanted to forced in all the element names, false otherwise
 cygnusagent.sinks.hdfs-sink.enable_lowercase = false
 # rest if the interaction with HDFS will be WebHDFS/HttpFS-based, binary if based on the Hadoop API
-cygnusagent.sinks.hdfs-sink.backend_impl = rest
+cygnusagent.sinks.hdfs-sink.backend.impl = rest
+# maximum number of Http connections to HDFS backend
+cygnusagent.sinks.hdfs-sink.backend.max_conns = 500
+# maximum number of Http connections per route to HDFS backend
+cygnusagent.sinks.hdfs-sink.backend.max_conns_per_route = 100
 # Comma-separated list of FQDN/IP address regarding the HDFS Namenode endpoints
 # If you are using Kerberos authentication, then the usage of FQDNs instead of IP addresses is mandatory
 cygnusagent.sinks.hdfs-sink.hdfs_host = x1.y1.z1.w1,x2.y2.z2.w2
@@ -130,6 +134,10 @@ cygnusagent.sinks.ckan-sink.batch_size = 100
 cygnusagent.sinks.ckan-sink.batch_timeout = 30
 # number of retries upon persistence error
 cygnusagent.sinks.ckan-sink.batch_ttl = 10
+# maximum number of Http connections to CKAN backend
+cygnusagent.sinks.ckan-sink.backend.max_conns = 500
+# maximum number of Http connections per route to CKAN backend
+cygnusagent.sinks.ckan-sink.backend.max_conns_per_route = 100
 
 # ============================================
 # NGSIPostgreSQLSink configuration


### PR DESCRIPTION
* Implements issue #1152 
* 100% unit tests passed:
* Relevant tests for this PR:

`NGSIHDFSSink` tests:
```
[NGSIHDFSSink.configure] -------------------------------------------- When not configured, not mandatory parameters get default values
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'backend.impl=rest' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'backend.max_conns=500' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'backend.max_conns_per_route=100' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'batch_size=1' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'batch_timeout=30' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'batch_ttl=30' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'csv_separator=,' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'data_model=dm-by-entity' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'enable_encoding=false' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'enable_grouping=false' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'enable_lowercase=false' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'file_format=json-row' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'hdfs_host=localhost' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'hdfs_port=14000' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'enable_hive=false' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'enable_krb5=false' configured by default
[NGSIHDFSSink.configure] -------------------------------------  OK  - 'service_as_namespace=false' configured by default
[NGSIHDFSSinkTest.configure] ---------------------------------------- backend.max_conns gets the configured value
[NGSIHDFSSinkTest.configure] ---------------------------------  OK  - 'backend.max_conns=25' was configured
NGSIHDFSSinkTest.configure] ---------------------------------------- backend.max_conns_per_route gets the configured value
[NGSIHDFSSinkTest.configure] ---------------------------------  OK  - 'backend.max_conns_per_route=3' was configured
```
`NGSICKANSink` tests:
```
[NGSICKANSink.configure] -------------------------------------------- When not configured, not mandatory parameters get default values
[NGSICKANSink.configure] -------------------------------------  OK  - 'attr_persisnce=row' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'api_key=nokey' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'backend.max_conns=500' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'backend.max_conns_per_rpute=100' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'batch_size=1' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'batch_timeout=30' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'batch_ttl=30' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'data_model=dm-by-entity' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'enable_encoding=false' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'enable_grouping=false' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'enable_lowercase=true' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'ckan_host=localhost' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'ckan_port=80' configured by default
[NGSICKANSink.configure] -------------------------------------  OK  - 'ssl=false' configured by default
NGSICKANSink.configure] -------------------------------------------- backend.max_conns gets the configured value
[NGSICKANSink.configure] -------------------------------------  OK  - 'backend.max_conns=25' was configured
[NGSICKANSink.configure] -------------------------------------------- backend.max_conns_per_route gets the configured value
[NGSICKANSink.configure] -------------------------------------  OK  - 'backend.max_conns_per_route=3'
```
`NGSICartoDBSink` tests:
```
[NGSICartoDBSink.configure] ----------------------------------------- When not configured, not mandatory parameters get default values
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'backend.max_conns=500' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'backend.max_conns_per_route=100' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'batch_size=1' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'batch_timeout=30' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'batch_ttl=30' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'data_model=dm-by-entity' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_distance=false' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_grouping=false' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_lowercase=true' configured by default
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_raw=true' configured by default
[NGSICartoDBSink.configure] ----------------------------------------- backend.max_conns gets the configured value
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'backend.max_conns=25' was configured
[NGSICartoDBSink.configure] ----------------------------------------- backend.max_conns gets the configured value
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'backend.max_conns=25' was configured
[NGSICartoDBSink.configure] ----------------------------------------- backend.max_conns_per_route gets the configured value
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'backend.max_conns_per_route=3' was configured
```