### PR TITLE
bug/1176_http_responses_as_condition_for_changing_host

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - [cygnus-ngsi][hardening] Remove unused hashing feature in NGSIMongoSink and NGSISTHSink (#1113)
 - [cygnus-ngsi][hardening] Configurable Http parameters at backend (#1152)
 - [cygnus-twitter][bug] Fixed misspelled underscores in doc examples (#1161)
+- [cygnus-ngsi][bug] Add certain Http responses as condition for changing host (#1176)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
@@ -44,7 +44,7 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
      */
     public CartoDBBackendImpl(String host, String port, boolean ssl, String apiKey, int maxConns,
             int maxConnsPerRoute) {
-        super(new String[]{host}, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
+        super(host, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         this.apiKey = apiKey;
     } // CartoDBBackendImpl
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -56,14 +56,14 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
      */
     public CKANBackendImpl(String apiKey, String ckanHost, String ckanPort, String orionUrl,
             boolean ssl, int maxConns, int maxConnsPerRoute) {
-        super(new String[]{ckanHost}, ckanPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
+        super(ckanHost, ckanPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         
         // this class attributes
         this.apiKey = apiKey;
         this.orionUrl = orionUrl;
         
         // create the cache
-        cache = new CKANCache(new String[]{ckanHost}, ckanPort, ssl, apiKey, maxConns, maxConnsPerRoute);
+        cache = new CKANCache(ckanHost, ckanPort, ssl, apiKey, maxConns, maxConnsPerRoute);
     } // CKANBackendImpl
 
     @Override

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -53,8 +53,8 @@ public class CKANCache extends HttpBackend {
      * @param maxConns
      * @param maxConnsPerRoute
      */
-    public CKANCache(String[] hosts, String port, boolean ssl, String apiKey, int maxConns, int maxConnsPerRoute) {
-        super(hosts, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
+    public CKANCache(String host, String port, boolean ssl, String apiKey, int maxConns, int maxConnsPerRoute) {
+        super(host, port, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         this.apiKey = apiKey;
         tree = new HashMap<String, HashMap<String, ArrayList<String>>>();
         orgMap = new HashMap<String, String>();

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackend.java
@@ -67,4 +67,11 @@ public interface HDFSBackend {
      */
     boolean exists(String filePath) throws Exception;
     
+    /**
+     * Serializes the backend for pretty printing.
+     * @return The backend serialized for pretty printing.
+     */
+    @Override
+    String toString();
+    
 } // HDFSBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -18,10 +18,8 @@
 
 package com.telefonica.iot.cygnus.backends.hdfs;
 
-import com.telefonica.iot.cygnus.backends.hive.HiveBackendImpl;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import com.telefonica.iot.cygnus.utils.CommonUtils;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -50,7 +48,7 @@ public class HDFSBackendImplBinary implements HDFSBackend {
     
     /**
      * 
-     * @param hdfsHosts
+     * @param hdfsHost
      * @param hdfsPort
      * @param hdfsUser
      * @param hdfsPassword
@@ -65,7 +63,7 @@ public class HDFSBackendImplBinary implements HDFSBackend {
      * @param krb5ConfFile
      * @param serviceAsNamespace
      */
-    public HDFSBackendImplBinary(String[] hdfsHosts, String hdfsPort, String hdfsUser, String hdfsPassword,
+    public HDFSBackendImplBinary(String hdfsHost, String hdfsPort, String hdfsUser, String hdfsPassword,
             String oauth2Token, String hiveServerVersion, String hiveHost, String hivePort, boolean krb5,
             String krb5User, String krb5Password, String krb5LoginConfFile, String krb5ConfFile,
             boolean serviceAsNamespace) {
@@ -76,7 +74,7 @@ public class HDFSBackendImplBinary implements HDFSBackend {
         this.hiveHost = hiveHost;
         this.hivePort = hivePort;
         this.serviceAsNamespace = serviceAsNamespace;
-        this.fsGetter = new FSGetter(hdfsHosts, hdfsPort);
+        this.fsGetter = new FSGetter(hdfsHost, hdfsPort);
     } // HDFSBackendImplBinary
     
     protected void setFSGetter(FSGetter fsGetter) {
@@ -244,16 +242,16 @@ public class HDFSBackendImplBinary implements HDFSBackend {
      */
     protected class FSGetter {
         
-        private final String[] hdfsHosts;
+        private final String hdfsHost;
         private final String hdfsPort;
         
         /**
          * Constructor.
-         * @param hdfsHosts
+         * @param hdfsHost
          * @param hdfsPort
          */
-        public FSGetter(String[] hdfsHosts, String hdfsPort) {
-            this.hdfsHosts = hdfsHosts;
+        public FSGetter(String hdfsHost, String hdfsPort) {
+            this.hdfsHost = hdfsHost;
             this.hdfsPort = hdfsPort;
         } // FSGetter
         
@@ -263,16 +261,11 @@ public class HDFSBackendImplBinary implements HDFSBackend {
          * @throws java.io.IOException
          */
         public FileSystem get() throws IOException {
-            for (String hdfsHost: hdfsHosts) {
-                Configuration conf = new Configuration();
-                //conf.addResource(new Path("/Users/frb/devel/fiware/fiware-cygnus/conf/core-site.xml"));
-                //conf.addResource(new Path("/Users/frb/devel/fiware/fiware-cygnus/conf/hdfs-site.xml"));
-                conf.set("fs.default.name", "hdfs://" + hdfsHost + ":" + hdfsPort);
-                return FileSystem.get(conf);
-            } // for
-            
-            LOGGER.error("No HDFS file system could be got, the sink will not work!");
-            return null;
+            Configuration conf = new Configuration();
+            //conf.addResource(new Path("/Users/frb/devel/fiware/fiware-cygnus/conf/core-site.xml"));
+            //conf.addResource(new Path("/Users/frb/devel/fiware/fiware-cygnus/conf/hdfs-site.xml"));
+            conf.set("fs.default.name", "hdfs://" + hdfsHost + ":" + hdfsPort);
+            return FileSystem.get(conf);
         } // get
         
     } // FSGetter

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -36,11 +36,9 @@ import org.apache.http.message.BasicHeader;
  */
 public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     
+    private final String hdfsHost;
+    private final String hdfsPort;
     private final String hdfsUser;
-    private final String hdfsPassword;
-    private final String hiveServerVersion;
-    private final String hiveHost;
-    private final String hivePort;
     private final boolean serviceAsNamespace;
     private static final CygnusLogger LOGGER = new CygnusLogger(HDFSBackendImplREST.class);
     private static final String BASE_URL = "/webhdfs/v1/user/";
@@ -48,7 +46,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     
     /**
      * 
-     * @param hdfsHosts
+     * @param hdfsHost
      * @param hdfsPort
      * @param hdfsUser
      * @param hdfsPassword
@@ -65,17 +63,15 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
      * @param maxConns
      * @param maxConnsPerRoute
      */
-    public HDFSBackendImplREST(String[] hdfsHosts, String hdfsPort, String hdfsUser, String hdfsPassword,
+    public HDFSBackendImplREST(String hdfsHost, String hdfsPort, String hdfsUser, String hdfsPassword,
             String oauth2Token, String hiveServerVersion, String hiveHost, String hivePort, boolean krb5,
             String krb5User, String krb5Password, String krb5LoginConfFile, String krb5ConfFile,
             boolean serviceAsNamespace, int maxConns, int maxConnsPerRoute) {
-        super(hdfsHosts, hdfsPort, false, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
+        super(hdfsHost, hdfsPort, false, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
                 maxConnsPerRoute);
+        this.hdfsHost = hdfsHost;
+        this.hdfsPort = hdfsPort;
         this.hdfsUser = hdfsUser;
-        this.hdfsPassword = hdfsPassword;
-        this.hiveServerVersion = hiveServerVersion;
-        this.hiveHost = hiveHost;
-        this.hivePort = hivePort;
         this.serviceAsNamespace = serviceAsNamespace;
         
         // add the OAuth2 token as a the unique header that will be sent
@@ -178,5 +174,10 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
         // check the status
         return (response.getStatusCode() == 200);
     } // exists
+    
+    @Override
+    public String toString() {
+        return this.hdfsHost + ":" + this.hdfsPort;
+    } // toString
 
 } // HDFSBackendImplREST

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -27,8 +27,6 @@ import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.Set;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
@@ -54,7 +52,7 @@ import org.json.simple.parser.JSONParser;
  */
 public abstract class HttpBackend {
     
-    private final LinkedList<String> hosts;
+    private final String host;
     private final String port;
     private final boolean ssl;
     private final boolean krb5;
@@ -66,7 +64,7 @@ public abstract class HttpBackend {
     
     /**
      * Constructor.
-     * @param hosts
+     * @param host
      * @param port
      * @param ssl
      * @param krb5
@@ -77,9 +75,9 @@ public abstract class HttpBackend {
      * @param maxConns
      * @param maxConnsPerRoute
      */
-    public HttpBackend(String[] hosts, String port, boolean ssl, boolean krb5, String krb5User, String krb5Password,
+    public HttpBackend(String host, String port, boolean ssl, boolean krb5, String krb5User, String krb5Password,
             String krb5LoginConfFile, String krb5ConfFile, int maxConns, int maxConnsPerRoute) {
-        this.hosts = new LinkedList(Arrays.asList(hosts));
+        this.host = host;
         this.port = port;
         this.ssl = ssl;
         this.krb5 = krb5;
@@ -115,34 +113,21 @@ public abstract class HttpBackend {
         JsonResponse response;
         
         if (relative) {
-            // iterate on the hosts
-            for (String host : hosts) {
-                // create the HttpFS URL
-                String effectiveURL = (ssl ? "https://" : "http://") + host + ":" + port + url;
-                
-                try {
-                    if (krb5) {
-                        response = doPrivilegedRequest(method, effectiveURL, headers, entity);
-                    } else {
-                        response = doRequest(method, effectiveURL, headers, entity);
-                    } // if else
-                } catch (Exception e) {
-                    LOGGER.debug("There was a problem when performing the request (details=" + e.getMessage() + "). "
-                            + "Most probably the used http endpoint (" + host + ") is not active, trying another one");
-                    continue;
-                } // try catch
-                
-                // place the current host in the first place (if not yet placed), since it is currently working
-                if (!hosts.getFirst().equals(host)) {
-                    hosts.remove(host);
-                    hosts.add(0, host);
-                    LOGGER.debug("Placing the host in the first place of the list (host=" + host + ")");
-                } // if
-                
-                return response;
-            } // for
-            
-            throw new CygnusPersistenceError("No http endpoint was reachable");
+            // create the HttpFS URL
+            String effectiveURL = (ssl ? "https://" : "http://") + host + ":" + port + url;
+
+            try {
+                if (krb5) {
+                    response = doPrivilegedRequest(method, effectiveURL, headers, entity);
+                } else {
+                    response = doRequest(method, effectiveURL, headers, entity);
+                } // if else
+            } catch (Exception e) {
+                LOGGER.debug("There was a problem when performing the request. Details: " + e.getMessage());
+                throw e;
+            } // try catch
+
+            return response;
         } else {
             if (krb5) {
                 return doPrivilegedRequest(method, url, headers, entity);
@@ -155,12 +140,11 @@ public abstract class HttpBackend {
     /**
      * Does a Http request given a method, a relative URL, a list of headers and the payload
      * Protected method due to it's used by the tests.
-     * 
      * @param method
      * @param url
      * @param headers
      * @param entity
-     * @return 
+     * @return The result of the request
      * @throws java.lang.Exception
      */
         

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/orion/OrionBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/orion/OrionBackendImpl.java
@@ -43,7 +43,7 @@ public class OrionBackendImpl extends HttpBackend implements OrionBackend {
      * @param maxConnsPerRoute
      */
     public OrionBackendImpl(String orionHost, String orionPort, boolean ssl, int maxConns, int maxConnsPerRoute) {
-        super(new String[]{orionHost}, orionPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
+        super(orionHost, orionPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
     } // StatsBackendImpl
 
     @Override

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANCacheTest.java
@@ -51,7 +51,7 @@ public class CKANCacheTest {
     private HashMap<String, String> resMap;
     
     // constants
-    private final String[] hosts = new String[]{"localhost"};
+    private final String host = "localhost";
     private final String port = "80";
     private final boolean ssl = false;
     private final String apiKey = "xxxxxxxxxxxxx";
@@ -73,7 +73,7 @@ public class CKANCacheTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        cache = new CKANCache(hosts, port, ssl, apiKey, maxConns, maxConnsPerRoute);
+        cache = new CKANCache(host, port, ssl, apiKey, maxConns, maxConnsPerRoute);
 
         // set up the behaviour of the mocked classes
         when(orgMap.get(orgName)).thenReturn(orgId);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinaryTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinaryTest.java
@@ -50,7 +50,7 @@ public class HDFSBackendImplBinaryTest {
     private FSDataOutputStream fsDataOutputStreamMock;
     
     // constants
-    private final String[] hdfsHosts = {"1.2.3.4", "5.6.7.8."};
+    private final String hdfsHost = "1.2.3.4";
     private final String hdfsPort = "50070";
     private final String user = "hdfs-user";
     private final String password = "12345abcde";
@@ -70,7 +70,7 @@ public class HDFSBackendImplBinaryTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new HDFSBackendImplBinary(hdfsHosts, hdfsPort, user, password, token, hiveServerVersion, hiveHost,
+        backend = new HDFSBackendImplBinary(hdfsHost, hdfsPort, user, password, token, hiveServerVersion, hiveHost,
                 hivePort, false, null, null, null, null, false);
         
         // set up the behaviour of the mocked classes

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplRESTTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplRESTTest.java
@@ -53,7 +53,7 @@ public class HDFSBackendImplRESTTest {
     private HttpClient mockHttpClientExistsCreateDir;
     
     // constants
-    private final String[] hdfsHosts = {"1.2.3.4", "5.6.7.8."};
+    private final String hdfsHost = "1.2.3.4";
     private final String hdfsPort = "50070";
     private final String user = "hdfs-user";
     private final String password = "12345abcde";
@@ -75,7 +75,7 @@ public class HDFSBackendImplRESTTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new HDFSBackendImplREST(hdfsHosts, hdfsPort, user, password, token, hiveServerVersion, hiveHost,
+        backend = new HDFSBackendImplREST(hdfsHost, hdfsPort, user, password, token, hiveServerVersion, hiveHost,
                 hivePort, false, null, null, null, null, false, maxConns, maxConnsPerRoute);
         
         // set up other instances

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/http/HttpBackendTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/http/HttpBackendTest.java
@@ -46,10 +46,10 @@ public class HttpBackendTest {
      */
     private class HttpBackendImpl extends HttpBackend {
 
-        public HttpBackendImpl(String[] hosts, String port, boolean ssl, boolean krb5, String krb5User,
+        public HttpBackendImpl(String host, String port, boolean ssl, boolean krb5, String krb5User,
                 String krb5Password, String krb5LoginConfFile, String krb5ConfFile, int maxConns,
                 int maxConnsPerRoute) {
-            super(hosts, port, ssl, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
+            super(host, port, ssl, krb5, krb5User, krb5Password, krb5LoginConfFile, krb5ConfFile, maxConns,
                     maxConnsPerRoute);
         } // HttpBackendImpl
    
@@ -70,7 +70,7 @@ public class HttpBackendTest {
     private StringEntity arrayEntity;
     private String normalURL;
     private String arrayURL;
-    private String[] host;
+    private String host;
     private final int maxConns = 50;
     private final int maxConnsPerRoute = 10;
     
@@ -92,7 +92,7 @@ public class HttpBackendTest {
         arrayURL = "http://someurl:1234";
         normalEntity = new StringEntity(normalResponse);
         arrayEntity = new StringEntity(arrayResponse);
-        host = new String[] {"someurl.org"};
+        host = "someurl.org";
         headers.add(new BasicHeader("Content-type", "application/json"));
         headers.add(new BasicHeader("Accept", "application/json"));
         headers.add(new BasicHeader("X-Auth-token", "12345"));


### PR DESCRIPTION
* Fixes issue #1176 
* 100% tests passed
* (unofficial) e2e tests passed:

Using `cygnus-ngsi.sinks.hdfs-sink.hdfs_host = fake,storage.cosmos.lab.fiware.org`

First notification fails using `fake` host, then `storage.cosmos.lab.fiware.org` is used and priorized in the list:
```
time=2016-09-22T15:44:52.772UTC | lvl=DEBUG | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://fake:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-09-22T15:44:52.829UTC | lvl=DEBUG | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[126] : There was a problem when performing the request. Details: Persistence error (fake: unknown error)
time=2016-09-22T15:44:52.829UTC | lvl=INFO | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[1007] : [hdfs-sink] There was some problem with the current endpoint, trying other one. Details: Persistence error (fake: unknown error)
time=2016-09-22T15:44:52.830UTC | lvl=DEBUG | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-09-22T15:44:53.371UTC | lvl=DEBUG | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[1001] : Placing the persistence backend (storage.cosmos.lab.fiware.org:14000) in the first place of the list
time=2016-09-22T15:44:53.371UTC | lvl=INFO | corr=f41fa6b2-26f4-4da5-a1b3-39359b66236f | trans=f41fa6b2-26f4-4da5-a1b3-39359b66236f | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[429] : Finishing internal transaction (f41fa6b2-26f4-4da5-a1b3-39359b66236f)
```

Second notification directly uses `storage.cosmos.lab.fiware.org`:
```
time=2016-09-22T15:45:21.265UTC | lvl=DEBUG | corr=69466121-5ca2-4b73-b055-e252c6958807 | trans=69466121-5ca2-4b73-b055-e252c6958807 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-09-22T15:45:21.762UTC | lvl=INFO | corr=69466121-5ca2-4b73-b055-e252c6958807 | trans=69466121-5ca2-4b73-b055-e252c6958807 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[429] : Finishing internal transaction (69466121-5ca2-4b73-b055-e252c6958807)
```