### PR TITLE
hardening/1171_postgresql_add_cache_for_created_elements

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - [cygnus-ngsi][hardening] Configurable Http parameters at backend (#1152)
 - [cygnus-twitter][bug] Fixed misspelled underscores in doc examples (#1161)
 - [cygnus-ngsi][bug] Add certain Http responses as condition for changing host (#1176)
+- [cygnus-ngis][hardening] Add a cache for already created elements in PostgreSQLSink (#1171)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -59,6 +59,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
             cache = new PostgreSQLCache();
             LOGGER.info("PostgreSQL cache created succesfully");
         } // if
+        
         driver = new PostgreSQLDriver(postgresqlHost, postgresqlPort, postgresqlDatabase, postgresqlUsername,
                 postgresqlPassword);
     } // PostgreSQLBackendImpl
@@ -218,7 +219,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
          * @param postgresqlUsername
          * @param postgresqlPassword
          */
-        public PostgreSQLDriver(String postgresqlHost, String postgresqlPort,String postgresqlDatabase, 
+        public PostgreSQLDriver(String postgresqlHost, String postgresqlPort, String postgresqlDatabase, 
                 String postgresqlUsername, String postgresqlPassword) {
             connections = new HashMap<String, Connection>();
             this.postgresqlHost = postgresqlHost;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -281,4 +281,3 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
         } // createConnection
     } // PostgreSQLDriver
 } // PostgreSQLBackendImpl
-

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -42,6 +42,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
     private static final String DRIVER_NAME = "org.postgresql.Driver";
     private PostgreSQLDriver driver;
     private static final CygnusLogger LOGGER = new CygnusLogger(PostgreSQLBackendImpl.class);
+    private PostgreSQLCache cache = null;
 
     /**
      * Constructor.
@@ -50,9 +51,14 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
      * @param postgresqlDatabase
      * @param postgresqlUsername
      * @param postgresqlPassword
+     * @param enableCache
      */
     public PostgreSQLBackendImpl(String postgresqlHost, String postgresqlPort, String postgresqlDatabase,
-            String postgresqlUsername, String postgresqlPassword) {
+            String postgresqlUsername, String postgresqlPassword, boolean enableCache) {
+        if (enableCache) {
+            cache = new PostgreSQLCache();
+            LOGGER.info("PostgreSQL cache created succesfully");
+        } // if
         driver = new PostgreSQLDriver(postgresqlHost, postgresqlPort, postgresqlDatabase, postgresqlUsername,
                 postgresqlPassword);
     } // PostgreSQLBackendImpl
@@ -76,26 +82,32 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
      */
     @Override
     public void createSchema(String schemaName) throws Exception {
-        Statement stmt = null;
+        boolean schemaCached = cache.isSchemaInCache(schemaName);     
+        
+        if (!schemaCached) {
+            Statement stmt = null;
 
-        // get a connection to an empty database
-        Connection con = driver.getConnection("");
+            // get a connection to an empty database
+            Connection con = driver.getConnection("");
 
-        try {
-            stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
-        } // try catch
+            try {
+                stmt = con.createStatement();
+            } catch (Exception e) {
+                throw new CygnusRuntimeError(e.getMessage());
+            } // try catch
 
-        try {
-            String query = "CREATE SCHEMA IF NOT EXISTS " + schemaName;
-            LOGGER.debug("Executing SQL query '" + query + "'");
-            stmt.executeUpdate(query);
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
-        } // try catch
+            try {
+                String query = "CREATE SCHEMA IF NOT EXISTS " + schemaName;
+                LOGGER.debug("Executing SQL query '" + query + "'");
+                stmt.executeUpdate(query);
+            } catch (Exception e) {
+                throw new CygnusRuntimeError(e.getMessage());
+            } // try catch
 
-        closePostgreSQLObjects(con, stmt);
+            closePostgreSQLObjects(con, stmt);
+            cache.persistSchemaInCache(schemaName);
+        } // if
+        
     } // createSchema
 
     /**
@@ -107,26 +119,32 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
      */
     @Override
     public void createTable(String schemaName, String tableName, String typedFieldNames) throws Exception {
-        Statement stmt = null;
+        boolean tableInSchema = cache.isTableInCachedSchema(schemaName, tableName);
+        
+        if (!tableInSchema) {
+            Statement stmt = null;
 
-        // get a connection to the given schema
-        Connection con = driver.getConnection(schemaName);
+            // get a connection to the given schema
+            Connection con = driver.getConnection(schemaName);
 
-        try {
-            stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
-        } // try catch
+            try {
+                stmt = con.createStatement();
+            } catch (Exception e) {
+                throw new CygnusRuntimeError(e.getMessage());
+            } // try catch
 
-        try {
-            String query = "CREATE TABLE IF NOT EXISTS " + schemaName + "." + tableName + " " + typedFieldNames;
-            LOGGER.debug("Executing SQL query '" + query + "'");
-            stmt.executeUpdate(query);
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
-        } // try catch
+            try {
+                String query = "CREATE TABLE IF NOT EXISTS " + schemaName + "." + tableName + " " + typedFieldNames;
+                LOGGER.debug("Executing SQL query '" + query + "'");
+                stmt.executeUpdate(query);
+            } catch (Exception e) {
+                throw new CygnusRuntimeError(e.getMessage());
+            } // try catch
 
-        closePostgreSQLObjects(con, stmt);
+            closePostgreSQLObjects(con, stmt);
+            cache.persistTableInCache(schemaName, tableName);
+        } // if
+        
     } // createTable
 
     @Override
@@ -200,8 +218,8 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
          * @param postgresqlUsername
          * @param postgresqlPassword
          */
-        public PostgreSQLDriver(String postgresqlHost, String postgresqlPort,
-                String postgresqlDatabase, String postgresqlUsername, String postgresqlPassword) {
+        public PostgreSQLDriver(String postgresqlHost, String postgresqlPort,String postgresqlDatabase, 
+                String postgresqlUsername, String postgresqlPassword) {
             connections = new HashMap<String, Connection>();
             this.postgresqlHost = postgresqlHost;
             this.postgresqlPort = postgresqlPort;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+
+package com.telefonica.iot.cygnus.backends.postgresql;
+
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ *
+ * @author pcoello25
+ */
+public class PostgreSQLCache {
+    
+    private static final CygnusLogger LOGGER = new CygnusLogger(PostgreSQLCache.class);
+    private static final HashMap<String, ArrayList<String>> cache = new HashMap<String, ArrayList<String>>();
+    
+    public static int isSchemaTableInCache(String schemaName, String tableName) {
+        boolean isSchemaInCache = false;
+        boolean isTableInSchema = false;
+        
+        if (!cache.isEmpty()) {
+            
+            for (HashMap.Entry<String,ArrayList<String>> entry : cache.entrySet()) {
+                
+                String schema = entry.getKey();
+                ArrayList<String> tables = entry.getValue();
+                
+                LOGGER.info("Checking if the schema (" + schemaName + ") is equals to (" + schema + ")");
+                if (schema.equals(schemaName)) {
+                    isSchemaInCache = true;
+                } // if
+                
+                LOGGER.info("Checking if the table (" + tables + ") contains (" + tableName + ")");
+                if (tables.contains(tableName)) {
+                    isTableInSchema = true;
+                } // if
+                
+            } // for
+            
+        } else {
+            LOGGER.info("Empty Cache. Returning 2");
+            return 2;
+        } // if else
+        
+        if (isSchemaInCache && isTableInSchema) {
+            LOGGER.info("Schema & table in Cache: Returning 0");
+            return 0;
+        } else if (isSchemaInCache && !isTableInSchema) {
+            LOGGER.info("Schema in Cache but not the tableName: Returning 1");
+            return 1;
+        } else {
+            LOGGER.info("Schema & table not in Cache: Returning 2");
+            return 2;
+        } // if else if
+        
+    } // isSchemaTableInCache
+    
+    public static void persistInCache(String schemaName, String tableName, int code) {    
+        ArrayList<String> tableNames;
+        if (code == 1) {
+            tableNames = cache.get(schemaName);
+        } else {
+            tableNames = new ArrayList<String>();
+        } // if else
+        
+        tableNames.add(tableName);
+        cache.put(schemaName, tableNames);
+    } // persistInCache
+    
+} // PostgreSQLCache

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -39,57 +39,63 @@ public class PostgreSQLCache {
         this.cache = PSQLcache;
     } // setCache
     
-    public int isSchemaTableInCache(String schemaName, String tableName) {
-        boolean isSchemaInCache = false;
-        boolean isTableInSchema = false;
-        
+    public boolean isSchemaInCache (String schemaName) {    
+        LOGGER.debug("Checking if the schema (" + schemaName + ") exists");
         if (!cache.isEmpty()) {
             
             for (HashMap.Entry<String,ArrayList<String>> entry : cache.entrySet()) {
-                
                 String schema = entry.getKey();
-                ArrayList<String> tables = entry.getValue();
                 
-                LOGGER.info("Checking if the schema (" + schemaName + ") is equals to (" + schema + ")");
                 if (schema.equals(schemaName)) {
-                    isSchemaInCache = true;
-                } // if
-                
-                LOGGER.info("Checking if the table (" + tables + ") contains (" + tableName + ")");
-                if (tables.contains(tableName)) {
-                    isTableInSchema = true;
+                    LOGGER.debug("Schema (" + schemaName + ") exists in Cache");
+                    return true;
                 } // if
                 
             } // for
             
+            LOGGER.debug("Schema (" + schemaName + ") doesnt' exist in Cache");
+            return false;
         } else {
-            LOGGER.info("Empty Cache. Returning 2");
-            return 2;
+            LOGGER.debug("Cache is empty");
+            return false;
         } // if else
-        
-        if (isSchemaInCache && isTableInSchema) {
-            LOGGER.info("Schema & table in Cache: Returning 0");
-            return 0;
-        } else if (isSchemaInCache && !isTableInSchema) {
-            LOGGER.info("Schema in Cache but not the tableName: Returning 1");
-            return 1;
-        } else {
-            LOGGER.info("Schema & table not in Cache: Returning 2");
-            return 2;
-        } // if else if
-        
-    } // isSchemaTableInCache
+
+    } // isSchemaInCache
     
-    public void persistInCache(String schemaName, String tableName, int code) {    
-        ArrayList<String> tableNames;
-        if (code == 1) {
-            tableNames = cache.get(schemaName);
+    public boolean isTableInCachedSchema (String schemaName, String tableName) {
+        if (!cache.isEmpty()) {
+            
+            if (isSchemaInCache(schemaName)) {
+                ArrayList<String> tables = cache.get(schemaName);
+                
+                LOGGER.info("Checking if the table (" + tableName + ") belongs to (" + schemaName + ")");
+                
+                if (tables.contains(tableName)) {
+                    LOGGER.debug("Table (" + tableName + ") was found in the specified schema (" + schemaName + ")");
+                    return true;
+                } else {
+                    LOGGER.debug("Table (" + tableName + ") wasn't found in the specified schema (" + schemaName + ")");
+                    return false;
+                } // if else
+                
+            } // if             
+            
+            LOGGER.debug("Schema (" + schemaName + ") wasn't found in Cache");
+            return false;            
         } else {
-            tableNames = new ArrayList<String>();
-        } // if else
-        
+            LOGGER.debug("Cache is empty");
+            return false;
+        }
+    } // isTableInCachedSchema
+    
+    public void persistSchemaInCache(String schemaName) {
+        cache.put(schemaName, new ArrayList<String>());
+    } // persistSchemaInCache
+    
+    public void persistTableInCache(String schemaName, String tableName) {
+        ArrayList<String> tableNames = cache.get(schemaName);
         tableNames.add(tableName);
         cache.put(schemaName, tableNames);
-    } // persistInCache
+    } // persistTableInCache
     
 } // PostgreSQLCache

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -93,9 +93,15 @@ public class PostgreSQLCache {
     } // persistSchemaInCache
     
     public void persistTableInCache(String schemaName, String tableName) {
-        ArrayList<String> tableNames = cache.get(schemaName);
-        tableNames.add(tableName);
-        cache.put(schemaName, tableNames);
+        
+        if (isSchemaInCache(schemaName)) {
+            ArrayList<String> tableNames = cache.get(schemaName);
+            tableNames.add(tableName);
+            cache.put(schemaName, tableNames);
+        } else {
+            LOGGER.debug("Schema doesn't exist. Table couldn't be created");
+        } // if else
+        
     } // persistTableInCache
     
 } // PostgreSQLCache

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -90,17 +90,22 @@ public class PostgreSQLCache {
     
     public void persistSchemaInCache(String schemaName) {
         cache.put(schemaName, new ArrayList<String>());
+        LOGGER.debug("Schema (" + schemaName + ") added to cache");
     } // persistSchemaInCache
     
     public void persistTableInCache(String schemaName, String tableName) {
         
-        if (isSchemaInCache(schemaName)) {
-            ArrayList<String> tableNames = cache.get(schemaName);
-            tableNames.add(tableName);
-            cache.put(schemaName, tableNames);
-        } else {
-            LOGGER.debug("Schema doesn't exist. Table couldn't be created");
-        } // if else
+        for (HashMap.Entry<String,ArrayList<String>> entry : cache.entrySet()) {
+                String schema = entry.getKey();
+                
+                if (schema.equals(schemaName)) {
+                    ArrayList<String> tableNames = cache.get(schemaName);
+                    tableNames.add(tableName);
+                    cache.put(schemaName, tableNames);
+                    LOGGER.debug("Table (" + tableName + ") added to schema (" + schemaName + ") in cache");
+                } // if 
+                
+            } // for
         
     } // persistTableInCache
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -28,10 +28,18 @@ import java.util.HashMap;
  */
 public class PostgreSQLCache {
     
-    private static final CygnusLogger LOGGER = new CygnusLogger(PostgreSQLCache.class);
-    private static final HashMap<String, ArrayList<String>> cache = new HashMap<String, ArrayList<String>>();
+    private final CygnusLogger LOGGER = new CygnusLogger(PostgreSQLCache.class);
+    private HashMap<String, ArrayList<String>> cache = new HashMap<String, ArrayList<String>>();
     
-    public static int isSchemaTableInCache(String schemaName, String tableName) {
+    public HashMap<String, ArrayList<String>> getCache() {
+        return cache;
+    } // getCache
+    
+    public void setCache(HashMap<String, ArrayList<String>> PSQLcache) {
+        this.cache = PSQLcache;
+    } // setCache
+    
+    public int isSchemaTableInCache(String schemaName, String tableName) {
         boolean isSchemaInCache = false;
         boolean isTableInSchema = false;
         
@@ -72,7 +80,7 @@ public class PostgreSQLCache {
         
     } // isSchemaTableInCache
     
-    public static void persistInCache(String schemaName, String tableName, int code) {    
+    public void persistInCache(String schemaName, String tableName, int code) {    
         ArrayList<String> tableNames;
         if (code == 1) {
             tableNames = cache.get(schemaName);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCache.java
@@ -65,20 +65,24 @@ public class PostgreSQLCache {
     public boolean isTableInCachedSchema (String schemaName, String tableName) {
         if (!cache.isEmpty()) {
             
-            if (isSchemaInCache(schemaName)) {
-                ArrayList<String> tables = cache.get(schemaName);
+            for (HashMap.Entry<String,ArrayList<String>> entry : cache.entrySet()) {
+                String schema = entry.getKey();
                 
-                LOGGER.info("Checking if the table (" + tableName + ") belongs to (" + schemaName + ")");
+                if (schema.equals(schemaName)) {
+                    ArrayList<String> tables = cache.get(schemaName);
+
+                    LOGGER.info("Checking if the table (" + tableName + ") belongs to (" + schemaName + ")");
+
+                    if (tables.contains(tableName)) {
+                        LOGGER.debug("Table (" + tableName + ") was found in the specified schema (" + schemaName + ")");
+                        return true;
+                    } else {
+                        LOGGER.debug("Table (" + tableName + ") wasn't found in the specified schema (" + schemaName + ")");
+                        return false;
+                    } // if else
                 
-                if (tables.contains(tableName)) {
-                    LOGGER.debug("Table (" + tableName + ") was found in the specified schema (" + schemaName + ")");
-                    return true;
-                } else {
-                    LOGGER.debug("Table (" + tableName + ") wasn't found in the specified schema (" + schemaName + ")");
-                    return false;
-                } // if else
-                
-            } // if             
+                } // if     
+            } // for
             
             LOGGER.debug("Schema (" + schemaName + ") wasn't found in Cache");
             return false;            

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImplTest.java
@@ -73,7 +73,7 @@ public class PostgreSQLBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new PostgreSQLBackendImpl(host, port, database, user, password);
+        backend = new PostgreSQLBackendImpl(host, port, database, user, password, true);
 
         // set up the behaviour of the mocked classes
         when(mockDriverSchemaCreate.getConnection(Mockito.anyString())).thenReturn(mockConnection);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+
+package com.telefonica.iot.cygnus.backends.postgresql;
+
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ *
+ * @author pcoello25
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PostgreSQLCacheTest {
+
+} // PostgreSQLCacheTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
@@ -18,6 +18,12 @@
 
 package com.telefonica.iot.cygnus.backends.postgresql;
 
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import java.util.ArrayList;
+import java.util.HashMap;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -26,6 +32,141 @@ import org.mockito.runners.MockitoJUnitRunner;
  * @author pcoello25
  */
 @RunWith(MockitoJUnitRunner.class)
-public class PostgreSQLCacheTest {
+public class PostgreSQLCacheTest {   
+    
+    private final PostgreSQLCache PSQLcache = new PostgreSQLCache();
+    private final String schemaName = "aSchemaName";
+    private final String tableName = "aTableName";
+    
+    private final ArrayList<String> emptyList = new ArrayList<String>();
+    private final ArrayList<String> tableList = new ArrayList<String>();
+     
+    private final HashMap<String, ArrayList<String>> emptyCache = new HashMap<String, ArrayList<String>>();
+    private final HashMap<String, ArrayList<String>> cacheWithSchemaAndTableName = 
+            new HashMap<String, ArrayList<String>>();
+    private final HashMap<String, ArrayList<String>> cacheOnlyWithSchema = new HashMap<String, ArrayList<String>>();
+    
+    
+    /**
+     * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
+     * classes.
+     *  
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+                
+        // Used in test 'testSchemaAndTableInEmptyCache'
+        cacheOnlyWithSchema.put(schemaName, emptyList);
+        
+        // Used in test 'testSchemaAndTableInEmptyCache'
+        tableList.add(tableName);
+        cacheWithSchemaAndTableName.put(schemaName, tableList);
+    }
+    
+    @Test
+    public void testSchemaAndTableInEmptyCache() {
+        PSQLcache.setCache(emptyCache);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
+                + "-------- Adding a new tableName and new schemaName in an empty cache");
+        
+        try {
+            assertEquals(2, PSQLcache.isSchemaTableInCache(schemaName, tableName));
+            System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
+                    + "-  OK  - TableName and SchemaName weren't found in the empty Cache.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
+                    + "- FAIL - TableName and SchemaName were found in the empty Cache.");
+        } // try catch
+        
+    } // testSchemaAndTableInEmptyCache
+    
+    @Test
+    public void testSchemaAndTableWithBothValuesCached() {
+        PSQLcache.setCache(cacheWithSchemaAndTableName);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
+                + "-------- Adding a new tableName and new schemaName in a cache with both values cached");
+        
+        try {
+            assertEquals(0, PSQLcache.isSchemaTableInCache(schemaName, tableName));
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
+                    + "-  OK  - TableName and SchemaName were found in the Cache.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
+                    + "- FAIL - TableName and SchemaName weren't found in the empty Cache.");
+        } // try catch
+        
+    } // testSchemaAndTableWithBothValuesCached
+    
+    @Test
+    public void testSchemaAndTableWithSchemaCached() {
+        PSQLcache.setCache(cacheOnlyWithSchema);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
+                + "-------- Adding a new tableName and new schemaName in a cache with the schemaName");
+        
+        try {
+            assertEquals(1, PSQLcache.isSchemaTableInCache(schemaName, tableName));
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
+                    + "-  OK  - SchemaName was found in the cache but not TableName.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
+                    + "- FAIL - SchemaName and tableName weren't found in the cache.");
+        } // try catch
+        
+    } // testSchemaAndTableWithSchemaCached
+    
+    @Test
+    public void testPersistSchemaAndTableInCache() {
+        PSQLcache.setCache(emptyCache);
+        PSQLcache.persistInCache(schemaName, tableName, 2);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistSchemaAndTableInCache]")
+                + "-------- Adding a new tableName and new schemaName in a cache with the schemaName");
+        
+        try {
+            assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistSchemaAndTableInCache]")
+                    + "-  OK  - Schema and Table were persisted in Cache.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistSchemaAndTableInCache]")
+                    + "- FAIL - Schema and Table weren't persisted in Cache.");
+        } // try catch
+        
+    } // testPersistSchemaAndTableInCache
+    
+    @Test
+    public void testPersistOnlyTableInCache() {
+        PSQLcache.setCache(cacheOnlyWithSchema);
+        PSQLcache.persistInCache(schemaName, tableName, 1);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistOnlyTableInCache]")
+                + "-------- Adding a new tableName to a schema already created in cache");
+        
+        try {
+            assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistOnlyTableInCache]")
+                    + "-  OK  - Table was persisted in the cached schema.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistOnlyTableInCache]")
+                    + "- FAIL - Table wasn't persisted in the cached schema.");
+        } // try catch
+        
+    } // testPersistOnlyTableInCache
+    
+    @Test
+    public void testIfPersistDuplicateTableNames() {
+        PSQLcache.setCache(cacheWithSchemaAndTableName);
+        PSQLcache.persistInCache(schemaName, tableName, 2);
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testIfPersistDuplicateTableNames]")
+                + "-------- Adding a tableName and schema to a cache with both values already cached.");
+        
+        try {
+            assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testIfPersistDuplicateTableNames]")
+                    + "-  OK  - Values weren't duplicated.");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testIfPersistDuplicateTableNames]")
+                    + "- FAIL - TableName was duplicated in the cache.");
+        } // try catch
+        
+    } // testIfPersistDuplicateTableNames
 
 } // PostgreSQLCacheTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -22,7 +22,6 @@ import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHe
 import java.util.ArrayList;
 import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -45,23 +44,7 @@ public class PostgreSQLCacheTest {
     private final HashMap<String, ArrayList<String>> cacheWithSchemaAndTableName = 
             new HashMap<String, ArrayList<String>>();
     private final HashMap<String, ArrayList<String>> cacheOnlyWithSchema = new HashMap<String, ArrayList<String>>(); 
-    
-    /**
-     * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
-     * classes.
-     *  
-     * @throws Exception
-     */
-    @Before
-    public void setUp() throws Exception {
-                
-        // Used in test 'testSchemaAndTableInEmptyCache'
-        cacheOnlyWithSchema.put(schemaName, emptyList);
-        
-        // Used in test 'testSchemaAndTableInEmptyCache'
-        tableList.add(tableName);
-        cacheWithSchemaAndTableName.put(schemaName, tableList);
-    }
+
     
     @Test
     public void testSchemaAndTableInEmptyCache() {
@@ -83,6 +66,8 @@ public class PostgreSQLCacheTest {
     
     @Test
     public void testSchemaAndTableWithBothValuesCached() {
+        tableList.add(tableName);
+        cacheWithSchemaAndTableName.put(schemaName, tableList);
         PSQLcache.setCache(cacheWithSchemaAndTableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
                 + "-------- Testing if a tableName and a schemaName are in a cache with both values cached");
@@ -101,6 +86,7 @@ public class PostgreSQLCacheTest {
     
     @Test
     public void testSchemaAndTableWithSchemaCached() {
+        cacheOnlyWithSchema.put(schemaName, emptyList);
         PSQLcache.setCache(cacheOnlyWithSchema);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
                 + "-------- Testing if a new tableName and a schemaName are in a cache with cached schemaName");
@@ -138,6 +124,7 @@ public class PostgreSQLCacheTest {
     
     @Test
     public void testPersistOnlyTableInCache() {
+        cacheOnlyWithSchema.put(schemaName, emptyList);
         PSQLcache.setCache(cacheOnlyWithSchema);
         PSQLcache.persistTableInCache(schemaName, tableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistOnlyTableInCache]")
@@ -156,6 +143,8 @@ public class PostgreSQLCacheTest {
     
     @Test
     public void testIfPersistDuplicateTableNames() {
+        tableList.add(tableName);
+        cacheWithSchemaAndTableName.put(schemaName, tableList);
         PSQLcache.setCache(cacheWithSchemaAndTableName);
         PSQLcache.persistSchemaInCache(schemaName);
         PSQLcache.persistTableInCache(schemaName, tableName);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLCacheTest.java
@@ -44,8 +44,7 @@ public class PostgreSQLCacheTest {
     private final HashMap<String, ArrayList<String>> emptyCache = new HashMap<String, ArrayList<String>>();
     private final HashMap<String, ArrayList<String>> cacheWithSchemaAndTableName = 
             new HashMap<String, ArrayList<String>>();
-    private final HashMap<String, ArrayList<String>> cacheOnlyWithSchema = new HashMap<String, ArrayList<String>>();
-    
+    private final HashMap<String, ArrayList<String>> cacheOnlyWithSchema = new HashMap<String, ArrayList<String>>(); 
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -67,15 +66,16 @@ public class PostgreSQLCacheTest {
     @Test
     public void testSchemaAndTableInEmptyCache() {
         PSQLcache.setCache(emptyCache);
-        System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
-                + "-------- Adding a new tableName and new schemaName in an empty cache");
+        System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableInEmptyCache]")
+                + "-------- Testing if a new tableName and new schemaName are in an empty cache");
         
         try {
-            assertEquals(2, PSQLcache.isSchemaTableInCache(schemaName, tableName));
-            System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
+            assertEquals(true, ((!PSQLcache.isSchemaInCache(schemaName)) 
+                    && (!PSQLcache.isTableInCachedSchema(schemaName, tableName))));
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableInEmptyCache]")
                     + "-  OK  - TableName and SchemaName weren't found in the empty Cache.");
         } catch (Exception e) {
-            System.out.println(getTestTraceHead("[PostgreSQLCache.isSchemaTableInCache]")
+            System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableInEmptyCache]")
                     + "- FAIL - TableName and SchemaName were found in the empty Cache.");
         } // try catch
         
@@ -85,10 +85,11 @@ public class PostgreSQLCacheTest {
     public void testSchemaAndTableWithBothValuesCached() {
         PSQLcache.setCache(cacheWithSchemaAndTableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
-                + "-------- Adding a new tableName and new schemaName in a cache with both values cached");
+                + "-------- Testing if a tableName and a schemaName are in a cache with both values cached");
         
         try {
-            assertEquals(0, PSQLcache.isSchemaTableInCache(schemaName, tableName));
+            assertEquals(true, ((PSQLcache.isSchemaInCache(schemaName)) 
+                    && (PSQLcache.isTableInCachedSchema(schemaName, tableName))));
             System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithBothValuesCached]")
                     + "-  OK  - TableName and SchemaName were found in the Cache.");
         } catch (Exception e) {
@@ -102,10 +103,11 @@ public class PostgreSQLCacheTest {
     public void testSchemaAndTableWithSchemaCached() {
         PSQLcache.setCache(cacheOnlyWithSchema);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
-                + "-------- Adding a new tableName and new schemaName in a cache with the schemaName");
+                + "-------- Testing if a new tableName and a schemaName are in a cache with cached schemaName");
         
         try {
-            assertEquals(1, PSQLcache.isSchemaTableInCache(schemaName, tableName));
+            assertEquals(true, ((PSQLcache.isSchemaInCache(schemaName)) 
+                    && (!PSQLcache.isTableInCachedSchema(schemaName, tableName))));
             System.out.println(getTestTraceHead("[PostgreSQLCache.testSchemaAndTableWithSchemaCached]")
                     + "-  OK  - SchemaName was found in the cache but not TableName.");
         } catch (Exception e) {
@@ -118,9 +120,10 @@ public class PostgreSQLCacheTest {
     @Test
     public void testPersistSchemaAndTableInCache() {
         PSQLcache.setCache(emptyCache);
-        PSQLcache.persistInCache(schemaName, tableName, 2);
+        PSQLcache.persistSchemaInCache(schemaName);
+        PSQLcache.persistTableInCache(schemaName, tableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistSchemaAndTableInCache]")
-                + "-------- Adding a new tableName and new schemaName in a cache with the schemaName");
+                + "-------- Persisting a new tableName and new schemaName into an empty cache");
         
         try {
             assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());
@@ -136,9 +139,9 @@ public class PostgreSQLCacheTest {
     @Test
     public void testPersistOnlyTableInCache() {
         PSQLcache.setCache(cacheOnlyWithSchema);
-        PSQLcache.persistInCache(schemaName, tableName, 1);
+        PSQLcache.persistTableInCache(schemaName, tableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testPersistOnlyTableInCache]")
-                + "-------- Adding a new tableName to a schema already created in cache");
+                + "-------- Persisting a new tableName into a schema already created in cache");
         
         try {
             assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());
@@ -154,9 +157,10 @@ public class PostgreSQLCacheTest {
     @Test
     public void testIfPersistDuplicateTableNames() {
         PSQLcache.setCache(cacheWithSchemaAndTableName);
-        PSQLcache.persistInCache(schemaName, tableName, 2);
+        PSQLcache.persistSchemaInCache(schemaName);
+        PSQLcache.persistTableInCache(schemaName, tableName);
         System.out.println(getTestTraceHead("[PostgreSQLCache.testIfPersistDuplicateTableNames]")
-                + "-------- Adding a tableName and schema to a cache with both values already cached.");
+                + "-------- Persisting a tableName and schema into a cache with both values already cached.");
         
         try {
             assertEquals(cacheWithSchemaAndTableName, PSQLcache.getCache());

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -215,7 +215,7 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.NGSIPos
 # number of retries upon persistence error
 # cygnusagent.sinks.postgresql-sink.batch_ttl = 10
 # true enables cache, false disables cache
-cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
+#cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
 
 # ============================================
 # NGSIMongoSink configuration

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -214,6 +214,8 @@ cygnusagent.sinks.postgresql-sink.type = com.telefonica.iot.cygnus.sinks.NGSIPos
 # cygnusagent.sinks.postgresql-sink.batch_timeout = 30
 # number of retries upon persistence error
 # cygnusagent.sinks.postgresql-sink.batch_ttl = 10
+# true enables cache, false disables cache
+cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
 
 # ============================================
 # NGSIMongoSink configuration

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -30,7 +30,6 @@ import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
 import java.util.ArrayList;
 import org.apache.flume.Context;
-import com.telefonica.iot.cygnus.backends.postgresql.PostgreSQLCache;
 
 /**
  *
@@ -51,7 +50,6 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private PostgreSQLBackendImpl persistenceBackend;
     // Parameter 'cache' and cache <schema,[table,table,table..]>
     private boolean enableCache;
-    private PostgreSQLCache postgreCache;
 
     /**
      * Constructor.
@@ -72,7 +70,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
      * Gets the PostgreSQL cache. It is protected due to it is only required for testing purposes.
      * @return The PostgreSQL cache state
      */
-    protected boolean getCache() {
+    protected boolean getEnableCache() {
         return enableCache;
     } // getPostgreSQLHost
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -485,10 +485,10 @@ public class NGSIPostgreSQLSink extends NGSISink {
         
         if (cache) {
             LOGGER.info("Checking if the schema (" + schemaName + ") and the table (" + tableName + ") are in cache.");
-            int cacheCode = PostgreSQLCache.isSchemaTableInCache(schemaName, tableName);
+            int cacheCode = postgreCache.isSchemaTableInCache(schemaName, tableName);
             
             if (cacheCode > 0) {
-                PostgreSQLCache.persistInCache(schemaName, tableName, cacheCode);
+                postgreCache.persistInCache(schemaName, tableName, cacheCode);
                 
                 if (aggregator instanceof RowAggregator) {
                     if (cacheCode == 2) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -48,7 +48,6 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private String postgresqlPassword;
     private boolean rowAttrPersistence;
     private PostgreSQLBackendImpl persistenceBackend;
-    // Parameter 'cache' and cache <schema,[table,table,table..]>
     private boolean enableCache;
 
     /**

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
@@ -61,9 +61,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -95,9 +96,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -129,9 +131,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -164,9 +167,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -198,9 +202,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -234,9 +239,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String service = "someService";
         
         try {
@@ -280,9 +286,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String service = "someService";
         
         try {
@@ -327,9 +334,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -376,9 +384,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -427,9 +436,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/somePath";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -480,9 +490,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/somePath";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -531,9 +542,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -570,9 +582,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -621,9 +634,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -672,9 +686,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -719,9 +734,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String service = "tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongService";
         
         try {
@@ -758,9 +774,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -798,9 +815,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/tooLooooooooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooooooooooongEntity";
         String attribute = null; // irrelevant for this test
@@ -839,9 +857,10 @@ public class NGSIPostgreSQLSinkTest {
         String password = null; // default
         String port = null; // default
         String username = null; // default
+        String cache = null; // default
         NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableGrouping, enableLowercase, host, password, port, username));
+                enableGrouping, enableLowercase, host, password, port, username, cache));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";
         String attribute = "tooLooooooooooooongAttribute";
@@ -858,6 +877,41 @@ public class NGSIPostgreSQLSinkTest {
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
     
+        /**
+     * [NGSIPostgreSQLSink.configure] -------- cache can only be 'true' or 'false'.
+     */
+    @Test
+    public void testConfigureCache() {
+        System.out.println(getTestTraceHead("[NGSIPostgreSQLSink.configure]")
+                + "-------- cache can only be 'true' or 'false'");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null;
+        String enableGrouping = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = "falso";
+        NGSIPostgreSQLSink sink = new NGSIPostgreSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableGrouping, enableLowercase, host, password, port, username, cache));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIPostgreSQLSink.configure]")
+                    + "-  OK  - 'cache=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIPostgreSQLSink.configure]")
+                    + "- FAIL - 'cache=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEnableEncoding
+    
     private NGSIBatch createBatch(long recvTimeTs, String service, String servicePath, String destination,
             NotifyContextRequest.ContextElement contextElement) {
         NGSIEvent groupedEvent = new NGSIEvent(recvTimeTs, service, servicePath, destination, null,
@@ -869,7 +923,7 @@ public class NGSIPostgreSQLSinkTest {
     
     private Context createContext(String attrPersistence, String batchSize, String batchTime, String batchTTL,
             String dataModel, String enableEncoding, String enableGrouping, String enableLowercase, String host,
-            String password, String port, String username) {
+            String password, String port, String username, String cache) {
         Context context = new Context();
         context.put("attr_persistence", attrPersistence);
         context.put("batch_size", batchSize);
@@ -883,6 +937,7 @@ public class NGSIPostgreSQLSinkTest {
         context.put("mysql_password", password);
         context.put("mysql_port", port);
         context.put("mysql_username", username);
+        context.put("cache", cache);
         return context;
     } // createContext
 

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
@@ -877,7 +877,7 @@ public class NGSIPostgreSQLSinkTest {
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
     
-        /**
+    /**
      * [NGSIPostgreSQLSink.configure] -------- cache can only be 'true' or 'false'.
      */
     @Test

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
@@ -239,7 +239,7 @@ Coming soon.
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
-| backend.enable_cache | yes | N/A | <i>true</i> or <i>false</i>, <i>true</i> enable the creation of a Cache, <i>false</i> disable the creation of a Cache |
+| backend.enable_cache | yes | N/A | <i>true</i> or <i>false</i>, <i>true</i> enables the creation of a Cache, <i>false</i> disables the creation of a Cache. |
 A configuration example could be:
 
     cygnusagent.sinks = postgresql-sink

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
@@ -239,7 +239,7 @@ Coming soon.
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
-
+| backend.enable_cache | yes | N/A | <i>true</i> or <i>false</i>, <i>true</i> enable the creation of a Cache, <i>false</i> disable the creation of a Cache |
 A configuration example could be:
 
     cygnusagent.sinks = postgresql-sink
@@ -260,6 +260,7 @@ A configuration example could be:
     cygnusagent.sinks.postgresql-sink.batch_size = 100
     cygnusagent.sinks.postgresql-sink.batch_timeout = 30
     cygnusagent.sinks.postgresql-sink.batch_ttl = 10
+    cygnusagent.sinks.postgresql.backend.enable_cache = true
 
 [Top](#top)
 
@@ -318,7 +319,7 @@ From version 1.3.0 (included), Cygnus applies this specific encoding tailored to
 * All other characters, including the slash in the FIWARE service paths, are encoded as a `x` character followed by the [Unicode](http://unicode-table.com) of the character.
 * User defined strings composed of a `x` character and a Unicode are encoded as `xx` followed by the Unicode.
 * `xffff` is used as concatenator character.
-    
+
 Despite the old encoding will be deprecated in the future, it is possible to switch the encoding type through the `enable_encoding` parameter as explained in the [configuration](#section2.1) section.
 
 [Top](#top)

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
@@ -239,7 +239,7 @@ Coming soon.
 | batch_size | no | 1 | Number of events accumulated before persistence. |
 | batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
-| backend.enable_cache | yes | N/A | <i>true</i> or <i>false</i>, <i>true</i> enables the creation of a Cache, <i>false</i> disables the creation of a Cache. |
+| backend.enable_cache | no | false | <i>true</i> or <i>false</i>, <i>true</i> enables the creation of a Cache, <i>false</i> disables the creation of a Cache. |
 A configuration example could be:
 
     cygnusagent.sinks = postgresql-sink
@@ -260,7 +260,7 @@ A configuration example could be:
     cygnusagent.sinks.postgresql-sink.batch_size = 100
     cygnusagent.sinks.postgresql-sink.batch_timeout = 30
     cygnusagent.sinks.postgresql-sink.batch_ttl = 10
-    cygnusagent.sinks.postgresql.backend.enable_cache = true
+    cygnusagent.sinks.postgresql.backend.enable_cache = false
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -170,7 +170,7 @@ cygnusagent.sinks.postgresql-sink.batch_timeout = 30
 # number of retries upon persistence error
 cygnusagent.sinks.postgresql-sink.batch_ttl = 10
 # true enables cache, false disables cache
-cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
+#cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
 
 # ============================================
 # NGSIMySQLSink configuration

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -169,6 +169,8 @@ cygnusagent.sinks.postgresql-sink.batch_size = 100
 cygnusagent.sinks.postgresql-sink.batch_timeout = 30
 # number of retries upon persistence error
 cygnusagent.sinks.postgresql-sink.batch_ttl = 10
+# true enables cache, false disables cache
+cygnusagent.sinks.postgresql-sink.backend.enable_cache = false
 
 # ============================================
 # NGSIMySQLSink configuration


### PR DESCRIPTION
* Fix issue #1171 
* 100% unit tests passed:
```
[cygnus-common]: Results : Tests run: 75,    Failures: 0, Errors: 0, Skipped: 0
[cygnus-ngsi]:   Results : Tests run: 224,   Failures: 0, Errors: 0, Skipped: 0
```
* e2e (unofficial) test passed:
```
[Cygnus logs]
NGSIPostgreSQLSink[180] : [postgresql-sink] Reading configuration (cache=true)
NGSIPostgreSQLSink[194] : [postgresql-sink] PostgreSQL cache created

[First insert in PostgreSQL -> Empty Cache]
NGSIPostgreSQLSink[476] : [postgresql-sink] Persisting data at OrionPostgreSQLSink. Schema (schema1), Table (table1_car1_car), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1475221540001','2016-09-30T07:45:40.1Z','/table1','Car1','Car','mean_speed','integer','40','[]'))
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[59] : Cache is empty
PostgreSQLBackendImpl[101] : Executing SQL query 'CREATE SCHEMA IF NOT EXISTS schema1'
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[50] : Schema (schema1) exists in Cache
PostgreSQLCache[71] : Checking if the table (table1_car1_car) belongs to (schema1)
PostgreSQLCache[77] : Table (table1_car1_car) wasn't found in the specified schema (schema1)
PostgreSQLBackendImpl[138] : Executing SQL query 'CREATE TABLE IF NOT EXISTS schema1.table1_car1_car (recvTimeTs bigint,recvTime text,fiwareServicePath text,entityId text,entityType text,attrName text,attrType text,attrValue text,attrMd text)'
PostgreSQLBackendImpl[166] : Executing SQL query 'INSERT INTO schema1.table1_car1_car (recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd) VALUES ('1475221540001','2016-09-30T07:45:40.1Z','/table1','Car1','Car','mean_speed','integer','40','[]')'
NGSISink[429] : Finishing internal transaction (f79b369a-f1ea-4daa-811b-8d767786550f)

[Second insert with same fiware-service and fiware-servicepath]
NGSIPostgreSQLSink[476] : [postgresql-sink] Persisting data at OrionPostgreSQLSink. Schema (schema1), Table (table1_car1_car), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1475221811067','2016-09-30T07:50:11.67Z','/table1','Car1','Car','mean_speed','integer','68','[]'))
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[50] : Schema (schema1) exists in Cache
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[50] : Schema (schema1) exists in Cache
PostgreSQLCache[71] : Checking if the table (table1_car1_car) belongs to (schema1)
PostgreSQLCache[74] : Table (table1_car1_car) was found in Cache
PostgreSQLBackendImpl[166] : Executing SQL query 'INSERT INTO schema1.table1_car1_car (recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd) VALUES ('1475221811067','2016-09-30T07:50:11.67Z','/table1','Car1','Car','mean_speed','integer','68','[]')'
NGSISink[429] : Finishing internal transaction (89bff1b4-5638-4c85-86ba-1ab8f868fe9d)

[Third insert. Same schema but different tableName]
NGSIPostgreSQLSink[476] : [postgresql-sink] Persisting data at OrionPostgreSQLSink. Schema (schema1), Table (table2_car1_car), Fields ((recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd)), Values (('1475221953744','2016-09-30T07:52:33.744Z','/table2','Car1','Car','mean_speed','integer','68','[]'))
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[50] : Schema (schema1) exists in Cache
PostgreSQLCache[43] : Checking if the schema (schema1) exists
PostgreSQLCache[50] : Schema (schema1) exists in Cache
PostgreSQLCache[71] : Checking if the table (table2_car1_car) belongs to (schema1)
PostgreSQLCache[77] : Table (table2_car1_car) wasn't found in Cache
PostgreSQLBackendImpl[138] : Executing SQL query 'CREATE TABLE IF NOT EXISTS schema1.table2_car1_car (recvTimeTs bigint,recvTime text,fiwareServicePath text,entityId text,entityType text,attrName text,attrType text,attrValue text,attrMd text)'
PostgreSQLBackendImpl[166] : Executing SQL query 'INSERT INTO schema1.table2_car1_car (recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd) VALUES ('1475221953744','2016-09-30T07:52:33.744Z','/table2','Car1','Car','mean_speed','integer','68','[]')'
NGSISink[429] : Finishing internal transaction (6388d08b-c8f9-4623-80dd-13872a440ea6)

[IMPLEMENTED TEST]
Running com.telefonica.iot.cygnus.backends.postgresql.PostgreSQLCacheTest
[PostgreSQLCache.testSchemaAndTableWithSchemaCached] ---------------- Testing if a new tableName and a schemaName are in a cache with cached schemaName
[PostgreSQLCache.testSchemaAndTableWithSchemaCached] ---------  OK  - SchemaName was found in the cache but not TableName.
[PostgreSQLCache.testPersistSchemaAndTableInCache] ------------------ Persisting a new tableName and new schemaName into an empty cache
[PostgreSQLCache.testPersistSchemaAndTableInCache] -----------  OK  - Schema and Table were persisted in Cache.
[PostgreSQLCache.testSchemaAndTableInEmptyCache] -------------------- Testing if a new tableName and new schemaName are in an empty cache
[PostgreSQLCache.testSchemaAndTableInEmptyCache] -------------  OK  - TableName and SchemaName weren't found in the empty Cache.
[PostgreSQLCache.testIfPersistDuplicateTableNames] ------------------ Persisting a tableName and schema into a cache with both values already cached.
[PostgreSQLCache.testIfPersistDuplicateTableNames] -----------  OK  - Values weren't duplicated.
[PostgreSQLCache.testSchemaAndTableWithBothValuesCached] ------------ Testing if a tableName and a schemaName are in a cache with both values cached
[PostgreSQLCache.testSchemaAndTableWithBothValuesCached] -----  OK  - TableName and SchemaName were found in the Cache.
[PostgreSQLCache.testPersistOnlyTableInCache] ----------------------- Persisting a new tableName into a schema already created in cache
[PostgreSQLCache.testPersistOnlyTableInCache] ----------------  OK  - Table was persisted in the cached schema.
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec
```