### PR TITLE
hardening/1138_delay_retries_not_persisted_batches

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi][hardening] Delay the retries of not persisted batches (#1138)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -75,6 +75,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
     protected int batchSize;
     protected int batchTimeout;
     protected int batchTTL;
+    protected int[] batchRetryIntervals;
     protected boolean enableLowercase;
     protected boolean invalidConfiguration;
     protected boolean enableEncoding;
@@ -264,6 +265,30 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 + enableNameMappingsStr + ") -- Must be 'true' or 'false'");
         }  // if else
         
+        String batchRetryIntervalsStr = context.getString("batch_retry_intervals", "5000");
+        String[] batchRetryIntervalsSplit = batchRetryIntervalsStr.split(",");
+        batchRetryIntervals = new int[batchRetryIntervalsSplit.length];
+        boolean allOK = true;
+        
+        for (int i = 0; i < batchRetryIntervalsSplit.length; i++) {
+            String batchRetryIntervalStr = batchRetryIntervalsSplit[i];
+            int batchRetryInterval = new Integer(batchRetryIntervalStr);
+            
+            if (batchRetryInterval <= 0) {
+                invalidConfiguration = true;
+                LOGGER.debug("[" + this.getName() + "] Invalid configuration (batch_retry_intervals="
+                        + batchRetryIntervalStr + ") -- Members must be greater than 0");
+                allOK = false;
+                break;
+            } else {
+                batchRetryIntervals[i] = batchRetryInterval;
+            } // if else
+        } // for
+        
+        if (allOK) {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (batch_retry_intervals="
+                    + batchRetryIntervalsStr + ")");
+        } // if
     } // configure
 
     @Override
@@ -292,21 +317,38 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         } else if (rollbackedAccumulations.isEmpty()) {
             return processNewBatches();
         } else {
-            return processRollbackedBatches();
+            processRollbackedBatches();
+            return processNewBatches();
         } // if else
     } // process
 
     private Status processRollbackedBatches() throws EventDeliveryException {
-        Accumulator rollbackedAccumulation;
+        // Get a rollbacked accumulation
+        Accumulator rollbackedAccumulation = null;
+        
+        for (Accumulator rollbackedAcc : rollbackedAccumulations) {
+            rollbackedAccumulation = rollbackedAcc;
+            
+            // Check the last retry
+            int retryIntervalIndex = batchTTL - rollbackedAccumulation.ttl;
+            
+            if (retryIntervalIndex >= batchRetryIntervals.length) {
+                retryIntervalIndex = batchRetryIntervals.length - 1;
+            } // if
+            
+            if (rollbackedAccumulation.getLastRetry() + batchRetryIntervals[retryIntervalIndex]
+                    <= new Date().getTime()) {
+                break;
+            } // if
+            
+            rollbackedAccumulation = null;
+        } // for
 
-        // get a rollbacked accumulation
-        if (rollbackedAccumulations.isEmpty()) {
-            return Status.BACKOFF;
-        } else {
-            rollbackedAccumulation = rollbackedAccumulations.get(0);
-        } // if else
-
-        // try persisting the rollbacked accumulation
+        if (rollbackedAccumulation == null) {
+            return Status.READY; // No rollbacked batch was ready for retry, so we are ready to process new batches
+        } // if
+            
+        // Try persisting the rollbacked accumulation
         try {
             persistBatch(rollbackedAccumulation.getBatch());
             
@@ -320,27 +362,29 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         } catch (Exception e) {
             LOGGER.debug(Arrays.toString(e.getStackTrace()));
 
-            // rollback only if the exception is about a persistence error
+            // Rollback only if the exception is about a persistence error
             if (e instanceof CygnusPersistenceError) {
                 LOGGER.error(e.getMessage());
                 
                 if (rollbackedAccumulation.ttl == -1) {
+                    rollbackedAccumulation.setLastRetry(new Date().getTime());
                     LOGGER.info("Rollbacking again (" + rollbackedAccumulation.getAccTransactionIds() + "), "
                             + "infinite batch TTL");
-                } else if (rollbackedAccumulation.ttl > 0) {
+                } else if (rollbackedAccumulation.ttl > 1) {
+                    rollbackedAccumulation.setLastRetry(new Date().getTime());
                     rollbackedAccumulation.ttl--;
                     LOGGER.info("Rollbacking again (" + rollbackedAccumulation.getAccTransactionIds() + "), "
-                            + "batch TTL=" + rollbackedAccumulation.ttl);
+                            + "this was retry #" + (batchTTL - rollbackedAccumulation.ttl));
                 } else {
                     rollbackedAccumulations.remove(0);
                     
                     if (!rollbackedAccumulation.getAccTransactionIds().isEmpty()) {
-                        LOGGER.info("TTL exhausted, finishing internal transaction ("
-                                + rollbackedAccumulation.getAccTransactionIds() + ")");
+                        LOGGER.info("Finishing internal transaction ("
+                                + rollbackedAccumulation.getAccTransactionIds() + "), this was retry #" + batchTTL);
                     } // if
                 } // if else
                 
-                return Status.BACKOFF; // slow down the sink since there are problems with the persistence backend
+                return Status.BACKOFF; // Slow down the sink since there are problems with the persistence backend
             } else {
                 if (e instanceof CygnusRuntimeError) {
                     LOGGER.error(e.getMessage());
@@ -489,18 +533,19 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 LOGGER.error(e.getMessage());
                 
                 if (accumulator.ttl == -1) {
+                    accumulator.setLastRetry(new Date().getTime());
                     rollbackedAccumulations.add(accumulator.clone());
-                    LOGGER.info("Rollbacking again (" + accumulator.getAccTransactionIds() + "), "
+                    LOGGER.info("Rollbacking (" + accumulator.getAccTransactionIds() + "), "
                             + "infinite batch TTL");
                 } else if (accumulator.ttl > 0) {
-                    accumulator.ttl--;
+                    accumulator.setLastRetry(new Date().getTime());
                     rollbackedAccumulations.add(accumulator.clone());
-                    LOGGER.info("Rollbacking again (" + accumulator.getAccTransactionIds() + "), "
-                            + "batch TTL=" + accumulator.ttl);
+                    LOGGER.info("Rollbacking (" + accumulator.getAccTransactionIds() + "), "
+                            + batchTTL + " retries will be done");
                 } else {
                     if (!accumulator.getAccTransactionIds().isEmpty()) {
-                        LOGGER.info("TTL exhausted, finishing internal transaction ("
-                                + accumulator.getAccTransactionIds() + ")");
+                        LOGGER.info("Finishing internal transaction ("
+                                + accumulator.getAccTransactionIds() + "), 0 retries will be done");
                     } // if
                 } // if else
                 
@@ -561,6 +606,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         private int accIndex;
         private String accTransactionIds;
         private int ttl;
+        private long lastRetry;
 
         /**
          * Constructor.
@@ -571,6 +617,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
             accIndex = 0;
             accTransactionIds = null;
             ttl = batchTTL;
+            lastRetry = 0;
         } // Accumulator
 
         public long getAccStartDate() {
@@ -592,6 +639,14 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         public String getAccTransactionIds() {
             return accTransactionIds;
         } // getAccTransactionIds
+        
+        public long getLastRetry() {
+            return lastRetry;
+        } // getLastRetry
+        
+        public void setLastRetry(long lastRetry) {
+            this.lastRetry = lastRetry;
+        } // setLastRetry
 
         /**
          * Accumulates an event given its headers and context data.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
@@ -24,6 +24,7 @@ import com.telefonica.iot.cygnus.utils.CommonConstants;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import com.telefonica.iot.cygnus.utils.TestUtils;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -130,7 +131,7 @@ public class NGSISinkTest {
     public void testStart() {
         System.out.println(getTestTraceHead("[NGSISink.start]") + "-------- The sink starts properly");
         NGSISinkImpl sink = new NGSISinkImpl();
-        sink.configure(createContext(null, null, null, null, null, null, null)); // default configuration
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
         sink.setChannel(new MemoryChannel());
         sink.start();
         LifecycleState state = sink.getLifecycleState();
@@ -154,7 +155,18 @@ public class NGSISinkTest {
         System.out.println(getTestTraceHead("[NGSISink.configure]")
                 + "-------- When not configured, the default values are used for non mandatory parameters");
         NGSISinkImpl sink = new NGSISinkImpl();
-        sink.configure(createContext(null, null, null, null, null, null, null)); // default configuration
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
+        
+        try {
+            assertEquals("5000", sink.getBatchRetryIntervals());
+            System.out.println(getTestTraceHead("[NGSISink.configure]")
+                    + "-  OK  - The default configuration value for 'batch_retry_intervals' is '5000'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.configure]")
+                    + "- FAIL - The default configuration value for "
+                    + "'batch_retry_intervals' is '" + sink.getBatchRetryIntervals() + "'");
+            throw e;
+        } // try catch
         
         try {
             assertEquals(1, sink.getBatchSize());
@@ -254,7 +266,7 @@ public class NGSISinkTest {
                 + "having a discrete set of accepted values, or numerical values having upper or lower limits");
         NGSISinkImpl sink = new NGSISinkImpl();
         String configuredBatchSize = "0";
-        sink.configure(createContext(configuredBatchSize, null, null, null, null, null, null));
+        sink.configure(createContext(null, configuredBatchSize, null, null, null, null, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -270,7 +282,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String configuredBatchTimeout = "0";
-        sink.configure(createContext(null, configuredBatchTimeout, null, null, null, null, null));
+        sink.configure(createContext(null, null, configuredBatchTimeout, null, null, null, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -286,7 +298,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String configuredBatchTTL = "-2";
-        sink.configure(createContext(null, null, configuredBatchTTL, null, null, null, null));
+        sink.configure(createContext(null, null, null, configuredBatchTTL, null, null, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -300,7 +312,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String dataModel = "dm-by-other";
-        sink.configure(createContext(null, null, null, dataModel, null, null, null));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -314,7 +326,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String configuredEnableGrouping = "falso";
-        sink.configure(createContext(null, null, null, null, configuredEnableGrouping, null, null));
+        sink.configure(createContext(null, null, null, null, null, configuredEnableGrouping, null, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -330,7 +342,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String configuredEnableLowercase = "verdadero";
-        sink.configure(createContext(null, null, null, null, null, configuredEnableLowercase, null));
+        sink.configure(createContext(null, null, null, null, null, null, configuredEnableLowercase, null));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -346,7 +358,7 @@ public class NGSISinkTest {
         
         sink = new NGSISinkImpl();
         String configuredEnableNameMappings = "verdadero";
-        sink.configure(createContext(null, null, null, null, null, null, configuredEnableNameMappings));
+        sink.configure(createContext(null, null, null, null, null, null, null, configuredEnableNameMappings));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -372,7 +384,7 @@ public class NGSISinkTest {
                 + "-------- When data model is by service, a notification is successfully accumulated");
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-service";
-        sink.configure(createContext(null, null, null, dataModel, null, null, null));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, null));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -468,7 +480,7 @@ public class NGSISinkTest {
                 + "-------- When data model is by service path, a notification is successfully accumulated");
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-service-path";
-        sink.configure(createContext(null, null, null, dataModel, null, null, null));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, null));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -568,7 +580,7 @@ public class NGSISinkTest {
                 + "-------- When data model is by entity, a notification is successfully accumulated");
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-entity";
-        sink.configure(createContext(null, null, null, dataModel, null, null, null));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, null));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -671,7 +683,7 @@ public class NGSISinkTest {
                 + "-------- When data model is by attribute, a notification is successfully accumulated");
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-attribute";
-        sink.configure(createContext(null, null, null, dataModel, null, null, null));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, null));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -776,7 +788,7 @@ public class NGSISinkTest {
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-service";
         String enableNameMappings = "true";
-        sink.configure(createContext(null, null, null, dataModel, null, null, enableNameMappings));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, enableNameMappings));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -874,7 +886,7 @@ public class NGSISinkTest {
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-service-path";
         String enableNameMappings = "true";
-        sink.configure(createContext(null, null, null, dataModel, null, null, enableNameMappings));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, enableNameMappings));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -976,7 +988,7 @@ public class NGSISinkTest {
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-entity";
         String enableNameMappings = "true";
-        sink.configure(createContext(null, null, null, dataModel, null, null, enableNameMappings));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, enableNameMappings));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -1081,7 +1093,7 @@ public class NGSISinkTest {
         NGSISinkImpl sink = new NGSISinkImpl();
         String dataModel = "dm-by-attribute";
         String enableNameMappings = "true";
-        sink.configure(createContext(null, null, null, dataModel, null, null, enableNameMappings));
+        sink.configure(createContext(null, null, null, null, dataModel, null, null, enableNameMappings));
         Accumulator acc = sink.new Accumulator();
         acc.initialize(new Date().getTime());
         Map<String, String> headers = new HashMap<String, String>();
@@ -1173,9 +1185,155 @@ public class NGSISinkTest {
         } // try catch
     } // testAccumulateDMByAttributeNameMappings
     
-    private Context createContext(String batchSize, String batchTimeout, String batchTTL, String dataModel,
-            String enableGrouping, String enableLowercase, String enableNameMappings) {
+    /**
+     * [NGSISink.getRollbackedAccumulationForRetry] -------- When there are no candidates for retrying, null is
+     * returned.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testGetRollbackedAccumulationForRetryNoCandidates() throws Exception {
+        System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                + "-------- When there are no candidates for retrying, null is returned");
+        NGSISinkImpl sink = new NGSISinkImpl();
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
+        ArrayList<Accumulator> rollbackedAccumulations = new ArrayList<Accumulator>();
+        sink.setRollbackedAccumulations(rollbackedAccumulations);
+        
+        try {
+            assertEquals(null, sink.getRollbackedAccumulationForRetry());
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "-  OK  - There is no candidate for retrying having an empty list");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "- FAIL - A candidate for retrying was found having an empty list");
+            throw e;
+        } // try catch
+        
+        rollbackedAccumulations = new ArrayList<Accumulator>();
+        Accumulator acc = sink.new Accumulator();
+        // this accumulation has supposedly been retried 10 miliseconds ago, so it is not a candidate
+        acc.setLastRetry(new Date().getTime() - 10);
+        rollbackedAccumulations.add(acc);
+        sink.setRollbackedAccumulations(rollbackedAccumulations);
+        
+        try {
+            assertEquals(null, sink.getRollbackedAccumulationForRetry());
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "-  OK  - There is no candidate for retrying having an empty list");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "- FAIL - A candidate for retrying was found having an empty list");
+            throw e;
+        } // try catch
+    } // getRollbackedAccumulationForRetryNoCandidates
+    
+    /**
+     * [NGSISink.getRollbackedAccumulationForRetry] -------- When there is a candidate for retrying, it is returned.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testGetRollbackedAccumulationForRetryCandidateOK() throws Exception {
+        System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                + "-------- When there is a candidate for retrying, it is returned");
+        NGSISinkImpl sink = new NGSISinkImpl();
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
+        ArrayList<Accumulator> rollbackedAccumulations = new ArrayList<Accumulator>();
+        Accumulator acc = sink.new Accumulator();
+        // this accumulation has supposedly been retried 10000 miliseconds ago, so it is a candidate
+        acc.setLastRetry(new Date().getTime() - 10000);
+        rollbackedAccumulations.add(acc);
+        sink.setRollbackedAccumulations(rollbackedAccumulations);
+        
+        try {
+            assertEquals(acc, sink.getRollbackedAccumulationForRetry());
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "-  OK  - There is a candidate for retrying");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.getRollbackedAccumulationForRetry]")
+                    + "- FAIL - There is no candidate for retrying");
+            throw e;
+        } // try catch
+    } // getRollbackedAccumulationForRetryCandidateOK
+    
+    /**
+     * [NGSISink.doRollback] -------- When rollbacking for the first time, the accumulator is added to the rollbacked
+     * accumulations having the maximum TTL.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testDoRollback() throws Exception {
+        System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                + "-------- When rollbacking for the first time, the accumulator is added to the rollbacked "
+                + "accumulations having the maximum TTL");
+        NGSISinkImpl sink = new NGSISinkImpl();
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
+        Accumulator acc = sink.new Accumulator();
+        sink.doRollback(acc);
+        
+        try {
+            assertEquals(10, acc.getTTL());
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "-  OK  - Rollbacked accumulation TTL has the maximum value");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "- FAIL - Rollbacked accumulation TTL has not the maximum value");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(acc, sink.getRollbackedAccumulations().get(0));
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "-  OK  - The accumulation has been added to the rollback queue");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "- FAIL - The accumulation has not been added to the rollback queue");
+            throw e;
+        } // try catch
+    } // testDoRollback
+    
+    /**
+     * [NGSISink.doRollbackAgain] -------- When rollbacking after the first time, the accumulator is added to the
+     * rollbacked accumulations having a decreased TTL.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testDoRollbackAgagin() throws Exception {
+        System.out.println(getTestTraceHead("[NGSISink.doRollbackAgain]")
+                + "-------- When rollbacking after the first time, the accumulator is added to the rollbacked "
+                + "accumulations having a decreased TTL");
+        NGSISinkImpl sink = new NGSISinkImpl();
+        sink.configure(createContext(null, null, null, null, null, null, null, null)); // default configuration
+        Accumulator acc = sink.new Accumulator();
+        int ttl = 3;
+        acc.setTTL(ttl);
+        sink.doRollback(acc);
+        sink.doRollbackAgain(acc);
+        
+        try {
+            assertEquals(ttl - 1, acc.getTTL());
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "-  OK  - Rollbacked accumulation TTL has the maximum value");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "- FAIL - Rollbacked accumulation TTL has not the maximum value");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(acc, sink.getRollbackedAccumulations().get(0));
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "-  OK  - The accumulation has been added to the rollback queue");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.doRollback]")
+                    + "- FAIL - The accumulation has not been added to the rollback queue");
+            throw e;
+        } // try catch
+    } // testDoRollbackAgain
+    
+    private Context createContext(String batchRetryIntervals, String batchSize, String batchTimeout, String batchTTL,
+            String dataModel, String enableGrouping, String enableLowercase, String enableNameMappings) {
         Context context = new Context();
+        context.put("batch_retry_intervals", batchRetryIntervals);
         context.put("batch_size", batchSize);
         context.put("batch_timeout", batchTimeout);
         context.put("batch_ttl", batchTTL);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
@@ -371,6 +371,22 @@ public class NGSISinkTest {
                     + configuredEnableNameMappings + "' has not been detected");
             throw e;
         } // try catch
+        
+        sink = new NGSISinkImpl();
+        String batchRetryIntervals = "1000,2000,-3000";
+        sink.configure(createContext(batchRetryIntervals, null, null, null, null, null, null, null));
+        
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSISink.configure]")
+                    + "-  OK  - A wrong configuration 'batch_retry_intervals='"
+                    + batchRetryIntervals + "' has been detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSISink.configure]")
+                    + "- FAIL - A wrong configuration 'batch_retry_intervals='"
+                    + batchRetryIntervals + "' has not been detected");
+            throw e;
+        } // try catch
     } // testConfigureInvalidConfiguration
     
     /**

--- a/cygnus-twitter/src/main/java/com/telefonica/iot/cygnus/sinks/TwitterHDFSSink.java
+++ b/cygnus-twitter/src/main/java/com/telefonica/iot/cygnus/sinks/TwitterHDFSSink.java
@@ -21,6 +21,7 @@ package com.telefonica.iot.cygnus.sinks;
 import com.telefonica.iot.cygnus.backends.hdfs.HDFSBackend;
 import com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplBinary;
 import com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import org.apache.flume.Context;
 
@@ -362,9 +363,9 @@ public class TwitterHDFSSink extends TwitterSink {
         String aggregation = aggregator.getAggregation().trim();
         String hdfsFolder = aggregator.getFolder(enableLowercase);
         String hdfsFile = aggregator.getFile(enableLowercase);
-
         LOGGER.info("[" + this.getName() + "] Persisting data at TwitterHDFSSink. HDFS file ("
                 + hdfsFile + ")");
+        boolean persisted = false;
         
         for (HDFSBackend persistenceBackend: persistenceBackends) {
             try {
@@ -382,12 +383,17 @@ public class TwitterHDFSSink extends TwitterSink {
                             + ") in the first place of the list");
                 } // if
 
+                persisted = true;
                 break;
             } catch (Exception e) {
                 LOGGER.info("[" + this.getName() + "] There was some problem with the current endpoint, "
                         + "trying other one. Details: " + e.getMessage());
             } // try catch
         } // for
+        
+        if (!persisted) {
+            throw new CygnusPersistenceError("[" + this.getName() + "] No endpoint was available");
+        } // if
     } // persistAggregation
 
 } // TwitterHDFSSink

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -385,21 +385,22 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsx000
 
 | Parameter | Mandatory | Default value | Comments |
 |---|---|---|---|
-| type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSICartoDBSink</i> |
+| type | yes | N/A | Must be `com.telefonica.iot.cygnus.sinks.NGSICartoDBSink` |
 | channel | yes | N/A ||
 | enable\_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
 | enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity |  <i>dm-by-service-path</i> or <i>dm-by-entity</i>. |
+| data\_model | no | dm-by-entity |  <i>dm-by-service-path</i> or <i>dm-by-entity</i>. |
 | keys\_conf\_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/CartoDB usernames and CartoDB API Keys. |
 | flip\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
 | enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw based storage is done. |
 | enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance based storage is done. |
-| batch_size | no | 1 | Number of events accumulated before persistence. |
-| batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
-| backend.max_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. |
-| backend.max_conns_per_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. |
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
+| backend.max\_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. |
+| backend.max\_conns\_per\_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. |
 
 A configuration example could be:
 
@@ -420,6 +421,7 @@ cygnus-ngsi.sinks.cartodb-sink.data_model = dm-by-entity
 cygnus-ngsi.sinks.cartodb-sink.batch_size = 10
 cygnus-ngsi.sinks.cartodb-sink.batch_timeout = 5
 cygnus-ngsi.sinks.cartodb-sink.batch_ttl = 0
+cygnus-ngsi.sinks.cartodb-sink.batch_retries_intervals = 5000
 cygnus-ngsi.sinks.cartodb-sink.backend.max_conns = 500
 cygnus-ngsi.sinks.cartodb-sink.backend.max_conns_per_route = 100
 ```
@@ -476,6 +478,8 @@ As explained in the [programmers guide](#section3), `NGSICartoDBSink` extends `N
 What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of inserts is dramatically reduced. Let's see an example, let's assume a batch of 100 Flume events. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same CartoDB table. If processing the events one by one, we would need 100 inserts in CartoDB; nevertheless, in this example only one insert is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination CartoDB table. In the worst case, the whole 100 entities will be about 100 different entities (100 different CartoDB destinations), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 inserts of the event by event approach with only 10-15 inserts.
 
 The batching mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
 
 By default, `NGSICartoDBSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_dynamodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_dynamodb_sink.md
@@ -171,8 +171,8 @@ If `attr_persistence=colum` then `NGSIDynamoDBSink` will persist the data within
 |---|---|---|---|
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSIDynamoDBSink</i> |
 | channel | yes | N/A ||
-| enable_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
-| enable_name_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
+| enable\_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
+| enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
 | data_model | no | dm-by-entity |  <i>dm-by-entity</i> or <i>dm-by-service-path</i>. |
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>. |
@@ -181,7 +181,8 @@ If `attr_persistence=colum` then `NGSIDynamoDBSink` will persist the data within
 | region | no | eu-central-1 | [AWS regions](http://docs.aws.amazon.com/general/latest/gr/rande.html). |
 | batch\_size | no | 1 | Number of events accumulated before persistence (Maximum 25, check [Amazon Web Services Documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) for more information). |
 | batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 
 A configuration example could be:
 
@@ -192,7 +193,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.dynamodb-sink.channel = dynamodb-channel
     cygnus-ngsi.sinks.dynamodb-sink.enable_grouping = false
     cygnus-ngsi.sinks.dynamodb-sink.enable_lowercase = false
-    ygnus-ngsi.sinks.dynamodb-sink.enable_name_mappings = false
+    cygnus-ngsi.sinks.dynamodb-sink.enable_name_mappings = false
     cygnus-ngsi.sinks.dynamodb-sink.data_model = dm-by-entity
     cygnus-ngsi.sinks.dynamodb-sink.attr_persistence = column
     cygnus-ngsi.sinks.dynamodb-sink.access_key_id = xxxxxxxx
@@ -201,6 +202,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.dynamodb-sink.batch_size = 25
     cygnus-ngsi.sinks.dynamodb-sink.batch_timeout = 30
     cygnus-ngsi.sinks.dynamodb-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.dynamodb-sink.batch_retry_intervals = 5000
 
 [Top](#top)
 
@@ -230,6 +232,8 @@ As explained in the [programmers guide](#section3), `NGSIDynamoDBSink` extends `
 What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of inserts is dramatically reduced. Let's see an example, let's assume a batch of 100 Flume events. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same DynamoDB table. If processing the events one by one, we would need 100 inserts into DynamoDB; nevertheless, in this example only one insert is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination DynamoDB table. In the worst case, the whole 100 entities will be about 100 different entities (100 different DynamoDB tables), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 inserts of the event by event approach with only 10-15 inserts.
 
 The batch mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
 
 By default, `NGSIDynamoDBSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink.md
@@ -269,33 +269,34 @@ NOTE: `hive` is the Hive CLI for locally querying the data.
 |---|---|---|---|
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSIHDFSSink</i> |
 | channel | yes | N/A ||
-| enable_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
-| enable_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
+| enable\_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
+| enable\_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
 | enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity |  Always <i>dm-by-entity</i>, even if not configured. |
-| file_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>. |
+| data\_model | no | dm-by-entity |  Always <i>dm-by-entity</i>, even if not configured. |
+| file\_format | no | json-row | <i>json-row</i>, <i>json-column</i>, <i>csv-row</i> or <i>json-column</i>. |
 | backend.impl | no | rest | <i>rest</i>, if a WebHDFS/HttpFS-based implementation is used when interacting with HDFS; or <i>binary</i>, if a Hadoop API-based implementation is used when interacting with HDFS. |
-| backend.max_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
-| backend.max_conns_per_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
-| hdfs_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run. |
-| hdfs_port | no | 14000 | <i>14000</i> if using HttpFS (rest), <i>50070</i> if using WebHDFS (rest), <i>8020</i> if using the Hadoop API (binary). |
-| hdfs_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser. |
-| hdfs_password | yes | N/A | Password for the above `hdfs_username`; this is only required for Hive authentication. |
-| oauth2_token | yes | N/A | OAuth2 token required for the HDFS authentication. |
+| backend.max\_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
+| backend.max\_conns\_per\_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. Ignored if using a binary backend implementation. |
+| hdfs\_host | no | localhost | FQDN/IP address where HDFS Namenode runs, or comma-separated list of FQDN/IP addresses where HDFS HA Namenodes run. |
+| hdfs\_port | no | 14000 | <i>14000</i> if using HttpFS (rest), <i>50070</i> if using WebHDFS (rest), <i>8020</i> if using the Hadoop API (binary). |
+| hdfs\_username | yes | N/A | If `service_as_namespace=false` then it must be an already existent user in HDFS. If `service_as_namespace=true` then it must be a HDFS superuser. |
+| hdfs\_password | yes | N/A | Password for the above `hdfs_username`; this is only required for Hive authentication. |
+| oauth2\_token | yes | N/A | OAuth2 token required for the HDFS authentication. |
 | service\_as\_namespace | no | false | If configured as <i>true</i> then the `fiware-service` (or the default one) is used as the HDFS namespace instead of `hdfs_username`, which in this case must be a HDFS superuser. |
-| csv_separator | no | , ||
-| batch_size | no | 1 | Number of events accumulated before persistence. |
-| batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| csv\_separator | no | , ||
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 | hive | no | true | <i>true</i> or <i>false</i>. |
 | hive.server\_version | no | 2 | `1` if the remote Hive server runs HiveServer1 or `2` if the remote Hive server runs HiveServer2. |
 | hive.host | no | localhost ||
 | hive.port | no | 10000 ||
-| hive.db_type | no | default-db | <i>default-db</i> or <i>namespace-db</i>. If `hive.db_type=default-db` then the default Hive database is used. If `hive.db_type=namespace-db` and `service_as_namespace=false` then the `hdfs_username` is used as Hive database. If `hive.db_type=namespace-db` and `service_as_namespace=true` then the notified fiware-service is used as Hive database. |
-| krb5_auth | no | false | <i>true</i> or <i>false</i>. |
-| krb5_user | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise. |
-| krb5_password | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise. |
+| hive.db\_type | no | default-db | <i>default-db</i> or <i>namespace-db</i>. If `hive.db_type=default-db` then the default Hive database is used. If `hive.db_type=namespace-db` and `service_as_namespace=false` then the `hdfs_username` is used as Hive database. If `hive.db_type=namespace-db` and `service_as_namespace=true` then the notified fiware-service is used as Hive database. |
+| krb5\_auth | no | false | <i>true</i> or <i>false</i>. |
+| krb5\_user | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise. |
+| krb5\_password | yes | <i>empty</i> | Ignored if `krb5_auth=false`, mandatory otherwise. |
 | krb5\_login\_conf\_file | no | /usr/cygnus/conf/krb5_login.conf | Ignored if `krb5_auth=false`. |
 | krb5\_conf\_file | no | /usr/cygnus/conf/krb5.conf | Ignored if `krb5_auth=false`. |
 
@@ -324,10 +325,10 @@ A configuration example could be:
     cygnus-ngsi.sinks.hdfs-sink.batch_size = 100
     cygnus-ngsi.sinks.hdfs-sink.batch_timeout = 30
     cygnus-ngsi.sinks.hdfs-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.hdfs-sink.batch_retry_intervals = 5000
     cygnus-ngsi.sinks.hdfs-sink.cygnus-ngsi
     cygnus-ngsi.sinks.hdfs-sink.hive = false
     cygnus-ngsi.sinks.hdfs-sink.krb5_auth = false
->>>>>>> develop
 
 [Top](#top)
 
@@ -364,6 +365,8 @@ As explained in the [programmers guide](#section3), `NGSIHDFSSink` extends `NGSI
 What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of writes is dramatically reduced. Let's see an example, let's assume a batch of 100 Flume events. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same HDFS file. If processing the events one by one, we would need 100 writes to HDFS; nevertheless, in this example only one write is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination HDFS file. In the worst case, the whole 100 entities will be about 100 different entities (100 different HDFS destinations), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 writes of the event by event approach with only 10-15 writes.
 
 The batch mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
 
 By default, `NGSIHDFSSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_kafka_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_kafka_sink.md
@@ -131,17 +131,18 @@ Let's assume a topic name `vehiclesxffffx002f4wheelsxffffcar1xffffcarxffffspeed`
 |---|---|---|---|
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSIKafkaSink</i> |
 | channel | yes | N/A ||
-| enable_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
+| enable\_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
 | enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity |  <i>dm-by-service</i>, <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <i>dm-by-attribute</i>. |
-| broker_list | no | localhost:9092 | Comma-separated list of Kafka brokers (a broker is defined as <i>host:port</i>). |
-| zookeeper_endpoint | no | localhost:2181 | Zookeeper endpoint needed to create Kafka topics, in the form of <i>host:port</i>. |
+| data\_model | no | dm-by-entity |  <i>dm-by-service</i>, <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <i>dm-by-attribute</i>. |
+| broker\_list | no | localhost:9092 | Comma-separated list of Kafka brokers (a broker is defined as <i>host:port</i>). |
+| zookeeper\_endpoint | no | localhost:2181 | Zookeeper endpoint needed to create Kafka topics, in the form of <i>host:port</i>. |
 | partitions |  no | 1 | Number of partitions for a topic. |
-| replication_factor | no | 1 | For a topic with replication factor N, Kafka will tolerate N-1 server failures without losing any messages committed to the log. Replication factor must be less than or equal to the number of brokers created. |
-| batch_size | no | 1 | Number of events accumulated before persistence. |
-| batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| replication\_factor | no | 1 | For a topic with replication factor N, Kafka will tolerate N-1 server failures without losing any messages committed to the log. Replication factor must be less than or equal to the number of brokers created. |
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 
 A configuration example could be:
 
@@ -161,6 +162,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.kafka-sink.batch_size = 100
     cygnus-ngsi.sinks.kafka-sink.batch_timeout = 30
     cygnus-ngsi.sinks.kafka-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.kafka-sink.batch_retry_intervals = 5000
 
 [Top](#top)
 
@@ -176,6 +178,8 @@ As explained in the [programmers guide](#section3), `NGSIKafkaSink` extends `NGS
 What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of writes is dramatically reduced. Let's see an example, let's assume a batch of 100 Flume events. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same Kafka topic. If processing the events one by one, we would need 100 writes to Kafka; nevertheless, in this example only one write is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination Kafka topic. In the worst case, the whole 100 entities will be about 100 different entities (100 different Kafka topics), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 writes of the event by event approach with only 10-15 writes.
 
 The batch mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
 
 By default, `NGSIKafkaSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
@@ -203,18 +203,19 @@ If `attr_persistence=colum` then `NGSIMySQLSink` will persist the data within th
 | type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSIMySQLSink</i> |
 | channel | yes | N/A ||
 | enable_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
-| enable_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
+| enable\_grouping | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_grouping_interceptor.md) for more details. ||
 | enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity | <i>dm-by-service-path</i> or <i>dm-by-entity</i>. <i>dm-by-service</i> and <dm-by-attribute</i> are not currently supported. |
-| mysql_host | no | localhost | FQDN/IP address where the MySQL server runs |
-| mysql_port | no | 3306 ||
-| mysql_username | no | root | `root` is the default username that is created automatically |
-| mysql_password | no | N/A | Empty value as default (no password is created automatically) |
-| attr_persistence | no | row | <i>row</i> or <i>column</i>
-| batch_size | no | 1 | Number of events accumulated before persistence. |
-| batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| data\_model | no | dm-by-entity | <i>dm-by-service-path</i> or <i>dm-by-entity</i>. <i>dm-by-service</i> and <dm-by-attribute</i> are not currently supported. |
+| mysql\_host | no | localhost | FQDN/IP address where the MySQL server runs |
+| mysql\_port | no | 3306 ||
+| mysql\_username | no | root | `root` is the default username that is created automatically |
+| mysql\_password | no | N/A | Empty value as default (no password is created automatically) |
+| attr\_persistence | no | row | <i>row</i> or <i>column</i>
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 
 A configuration example could be:
 
@@ -236,6 +237,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.mysql-sink.batch_size = 100
     cygnus-ngsi.sinks.mysql-sink.batch_timeout = 30
     cygnus-ngsi.sinks.mysql-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.mysql-sink.batch_retry_intervals = 5000
 
 [Top](#top)
 
@@ -267,6 +269,8 @@ As explained in the [programmers guide](#section3), `NGSIMySQLSink` extends `NGS
 What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of writes is dramatically reduced. Let's see an example, let's assume a batch of 100 Flume events. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same MySQL table. If processing the events one by one, we would need 100 inserts into MySQL; nevertheless, in this example only one insert is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination MySQL table. In the worst case, the whole 100 entities will be about 100 different entities (100 different MySQL tables), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 inserts of the event by event approach with only 10-15 inserts.
 
 The batch mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
 
 By default, `NGSIMySQLSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
@@ -297,21 +297,22 @@ Assuming `data_model=dm-by-entity` and all the possible resolutions as configura
 |---|---|---|---|
 | type | yes | N/A | com.telefonica.iot.cygnus.sinks.NGSISTHSink |
 | channel | yes | N/A |
-| enable_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
-| enable_grouping | no | false | Always <i>false</i>. ||
-| enable_name_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
+| enable\_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
+| enable\_grouping | no | false | Always <i>false</i>. ||
+| enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
-| data_model | no | dm-by-entity | <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <dm-by-attribute</i>. <i>dm-by-service</i> is not currently supported. |
-| mongo_hosts | no | localhost:27017 | FQDN/IP:port where the MongoDB server runs (standalone case) or comma-separated list of FQDN/IP:port pairs where the MongoDB replica set members run. |
-| mongo_username | no | <i>empty</i> | If empty, no authentication is done. |
-| mongo_password | no | <i>empty</i> | If empty, no authentication is done. |
-| db_prefix | no | sth_ ||
-| collection_prefix | no | sth_ | `system.` is not accepted. |
+| data\_model | no | dm-by-entity | <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <dm-by-attribute</i>. <i>dm-by-service</i> is not currently supported. |
+| mongo\_hosts | no | localhost:27017 | FQDN/IP:port where the MongoDB server runs (standalone case) or comma-separated list of FQDN/IP:port pairs where the MongoDB replica set members run. |
+| mongo\_username | no | <i>empty</i> | If empty, no authentication is done. |
+| mongo\_password | no | <i>empty</i> | If empty, no authentication is done. |
+| db\_prefix | no | sth_ ||
+| collection\_prefix | no | sth_ | `system.` is not accepted. |
 | resolutions | no | month,day,hour,minute,second | Resolutions for which it is desired to aggregate data. Accepted values are <i>month</i>, <i>day</i>, <i>hour</i>, <i>minute</i> and <i>second</i> separated  by comma. |
-| batch_size | no | 1 | Number of events accumulated before persistence. |
-| batch_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
-| batch_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
-| data_expiration | no | 0 | Collections will be removed if older than the value specified in seconds. The reference of time is the one stored in the `_id.origin` property. Set to 0 if not wanting this policy. |
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
+| data\_expiration | no | 0 | Collections will be removed if older than the value specified in seconds. The reference of time is the one stored in the `_id.origin` property. Set to 0 if not wanting this policy. |
 | ignore\_white\_spaces | no | true | <i>true</i> if exclusively white space-based attribute values must be ignored, <i>false</i> otherwise. |
 
 A configuration example could be:
@@ -335,6 +336,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.sth-sink.batch_size = 100
     cygnus-ngsi.sinks.sth-sink.batch_timeout = 30
     cygnus-ngsi.sinks.sth-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.sth-sink.batch_retry_intervals = 5000
     cygnus-ngsi.sinks.sth-sink.data_expiration = 0
     cygnus-ngsi.sinks.sth-sink.ignore_white_spaces = true
 


### PR DESCRIPTION
* Implemets issue #1138 
* 100 unit tests passed:

`cygnus-common`
```
Tests run: 73, Failures: 0, Errors: 0, Skipped: 0
```

`cygnus-ngsi`:
```
Tests run: 241, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:

```
[NGSISink.configure] ------------------------------------------------ When not configured, the default values are used for non mandatory parameters
[NGSISink.configure] -----------------------------------------  OK  - The default configuration value for 'batch_retry_intervals' is '5000'
[NGSISink.doRollbackAgain] ------------------------------------------ When rollbacking after the first time, the accumulator is added to the rollbacked accumulations having a decreased TTL
[NGSISink.doRollback] ----------------------------------------  OK  - Rollbacked accumulation TTL has the maximum value
[NGSISink.doRollback] ----------------------------------------  OK  - The accumulation has been added to the rollback queue
[NGSISink.getRollbackedAccumulationForRetry] ------------------------ When there are no candidates for retrying, null is returned
[NGSISink.getRollbackedAccumulationForRetry] -----------------  OK  - There is no candidate for retrying having an empty list
[NGSISink.getRollbackedAccumulationForRetry] -----------------  OK  - There is no candidate for retrying having an empty list
[NGSISink.getRollbackedAccumulationForRetry] ------------------------ When there is a candidate for retrying, it is returned
[NGSISink.getRollbackedAccumulationForRetry] -----------------  OK  - There is a candidate for retrying
[NGSISink.doRollback] ----------------------------------------------- When rollbacking for the first time, the accumulator is added to the rollbacked accumulations having the maximum TTL
[NGSISink.doRollback] ----------------------------------------  OK  - Rollbacked accumulation TTL has the maximum value
[NGSISink.doRollback] ----------------------------------------  OK  - The accumulation has been added to the rollback queue
[NGSISink.configure] ------------------------------------------------ The configuration becomes invalid upon out-of-the-limits configured values for parameters having a discrete set of accepted values, or numerical values having upper or lower limits
[NGSISink.configure] -----------------------------------------  OK  - A wrong configuration 'batch_retry_intervals='1000,2000,-3000' has been detected
```

* (unofficial) e2e tests passed:

Single notification, `batch_ttl=5`, `batch_retry_intervals=5000,10000,60000`:
```
time=2016-10-13T07:25:49.516UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollback | msg=com.telefonica.iot.cygnus.sinks.NGSISink[595] : Rollbacking (c4aba82d-99eb-4d95-a2d6-535b31ba2521), 5 retries will be done
+5 (+3)
time=2016-10-13T07:25:57.522UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (c4aba82d-99eb-4d95-a2d6-535b31ba2521), this was retry #1
+10 (+3)
time=2016-10-13T07:26:10.542UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (c4aba82d-99eb-4d95-a2d6-535b31ba2521), this was retry #2
+60 (+3)
time=2016-10-13T07:27:13.610UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (c4aba82d-99eb-4d95-a2d6-535b31ba2521), this was retry #3
+60 (+3)
time=2016-10-13T07:28:16.679UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (c4aba82d-99eb-4d95-a2d6-535b31ba2521), this was retry #4
+60 (+3)
time=2016-10-13T07:29:19.750UTC | lvl=INFO | corr=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | trans=c4aba82d-99eb-4d95-a2d6-535b31ba2521 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[422] : Finishing internal transaction (c4aba82d-99eb-4d95-a2d6-535b31ba2521), this was retry #5
```

Two notifications, `batch_ttl=5`, `batch_retry_intervals=5000,10000,60000`:
```
notif1 - time=2016-10-13T07:41:51.116UTC | lvl=INFO | corr=5156039e-6ec6-4e29-9dff-c40baaf6d905 | trans=5156039e-6ec6-4e29-9dff-c40baaf6d905 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollback | msg=com.telefonica.iot.cygnus.sinks.NGSISink[595] : Rollbacking (5156039e-6ec6-4e29-9dff-c40baaf6d905), 5 retries will be done
notif1 +5 (+3) - time=2016-10-13T07:41:59.128UTC | lvl=INFO | corr=5156039e-6ec6-4e29-9dff-c40baaf6d905 | trans=5156039e-6ec6-4e29-9dff-c40baaf6d905 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (5156039e-6ec6-4e29-9dff-c40baaf6d905), this was retry #1
notif2 - time=2016-10-13T07:42:04.514UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollback | msg=com.telefonica.iot.cygnus.sinks.NGSISink[595] : Rollbacking (62ab0b3f-670d-4791-aba5-44b190a0721b), 5 retries will be done
notif1 +10 (+3) - time=2016-10-13T07:42:12.523UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (5156039e-6ec6-4e29-9dff-c40baaf6d905), this was retry #2
notif2 +5 (+3) - time=2016-10-13T07:42:12.525UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (62ab0b3f-670d-4791-aba5-44b190a0721b), this was retry #1
notif2 +10 (+3) -  time=2016-10-13T07:42:25.544UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (62ab0b3f-670d-4791-aba5-44b190a0721b), this was retry #2
notif1 +60 (+3) - time=2016-10-13T07:43:15.607UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (5156039e-6ec6-4e29-9dff-c40baaf6d905), this was retry #3
notif2 +60 (+3) - time=2016-10-13T07:43:28.630UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (62ab0b3f-670d-4791-aba5-44b190a0721b), this was retry #3
notif1 +60 (+3) -  time=2016-10-13T07:44:18.686UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (5156039e-6ec6-4e29-9dff-c40baaf6d905), this was retry #4
notif2 +60 (+3) - time=2016-10-13T07:44:31.700UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[416] : Rollbacking again (62ab0b3f-670d-4791-aba5-44b190a0721b), this was retry #4
notif1 +60 (+3) - time=2016-10-13T07:45:21.755UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[422] : Finishing internal transaction (5156039e-6ec6-4e29-9dff-c40baaf6d905), this was retry #5
notif2 +60 (+3) - time=2016-10-13T07:45:34.773UTC | lvl=INFO | corr=62ab0b3f-670d-4791-aba5-44b190a0721b | trans=62ab0b3f-670d-4791-aba5-44b190a0721b | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRollbackAgain | msg=com.telefonica.iot.cygnus.sinks.NGSISink[422] : Finishing internal transaction (62ab0b3f-670d-4791-aba5-44b190a0721b), this was retry #5
```