### PR TITLE
hardening/1202_support_regex_name_mappings

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [cygnus][doc] Add entry for Grouping Rules in Installation and Administration Guide (#1206)
 - [cygnus-ngsi][hardening] Delay the retries of not persisted batches (#1138)
+- [cygnus-ngsi][hardening] Add support for regular expressions in Name Mappings (#1202)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NameMappings.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NameMappings.java
@@ -18,6 +18,7 @@
 package com.telefonica.iot.cygnus.containers;
 
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -39,11 +40,27 @@ public class NameMappings {
     } // getServiceMappings
     
     /**
+     * Purges the Name Mappings if any field is missing or has an invalid value.
+     */
+    public void purge() {
+    } // purge
+    
+    /**
+     * Compiles the regular expressions into Java Patterns.
+     */
+    public void compilePatterns() {
+        for (ServiceMapping serviceMapping : serviceMappings) {
+            serviceMapping.compilePatterns();
+        } // for
+    } // compilePatterns
+    
+    /**
      * ServiceMapping class.
      */
     public class ServiceMapping {
         
         private String originalService;
+        private Pattern originalServicePattern;
         private String newService;
         private final ArrayList<ServicePathMapping> servicePathMappings;
     
@@ -66,6 +83,21 @@ public class NameMappings {
             return newService;
         } // getNewService
         
+        public Pattern getOriginalServicePattern() {
+            return originalServicePattern;
+        } // getOriginalServicePattern
+        
+        /**
+         * Compiles the regular expressions into Java Patterns.
+         */
+        public void compilePatterns() {
+            originalServicePattern = Pattern.compile(originalService);
+
+            for (ServicePathMapping servicePathMapping : servicePathMappings) {
+                servicePathMapping.compilePatterns();
+            } // for
+        } // compilePatterns
+        
     } // ServiceMapping
     
     /**
@@ -74,6 +106,7 @@ public class NameMappings {
     public class ServicePathMapping {
         
         private String originalServicePath;
+        private Pattern originalServicePathPattern;
         private String newServicePath;
         private final ArrayList<EntityMapping> entityMappings;
         
@@ -96,6 +129,21 @@ public class NameMappings {
             return newServicePath;
         } // getNewServicePath
         
+        public Pattern getOriginalServicePathPattern() {
+            return originalServicePathPattern;
+        } // getOriginalServicePathPattern
+        
+        /**
+         * Compiles the regular expressions into Java Patterns.
+         */
+        public void compilePatterns() {
+            originalServicePathPattern = Pattern.compile(originalServicePath);
+
+            for (EntityMapping entityMapping : entityMappings) {
+                entityMapping.compilePatterns();
+            } // for
+        } // compilePatterns
+        
     } // ServicePathMapping
     
     /**
@@ -104,7 +152,9 @@ public class NameMappings {
     public class EntityMapping {
         
         private String originalEntityId;
+        private Pattern originalEntityIdPattern;
         private String originalEntityType;
+        private Pattern originalEntityTypePattern;
         private String newEntityId;
         private String newEntityType;
         private final ArrayList<AttributeMapping> attributeMappings;
@@ -136,6 +186,26 @@ public class NameMappings {
             return newEntityType;
         } // getNewEntityType
         
+        public Pattern getOriginalEntityIdPattern() {
+            return originalEntityIdPattern;
+        } // getOriginalEntityIdPattern
+        
+        public Pattern getOriginalEntityTypePattern() {
+            return originalEntityTypePattern;
+        } // getOriginalEntityTypePattern
+        
+        /**
+         * Compiles the regular expressions into Java Patterns.
+         */
+        public void compilePatterns() {
+            originalEntityIdPattern = Pattern.compile(originalEntityId);
+            originalEntityTypePattern = Pattern.compile(originalEntityType);
+
+            for (AttributeMapping attributeMapping : attributeMappings) {
+                attributeMapping.compilePatterns();
+            } // for
+        } // compilePatterns
+        
     } // EntityMapping
     
     /**
@@ -144,7 +214,9 @@ public class NameMappings {
     public class AttributeMapping {
         
         private String originalAttributeName;
+        private Pattern originalAttributeNamePattern;
         private String originalAttributeType;
+        private Pattern originalAttributeTypePattern;
         private String newAttributeName;
         private String newAttributeType;
         
@@ -169,6 +241,22 @@ public class NameMappings {
         public String getNewAttributeType() {
             return newAttributeType;
         } // getNewAttributeType
+        
+        public Pattern getOriginalAttributeNamePattern() {
+            return originalAttributeNamePattern;
+        } // getOriginalAttributeNamePattern
+        
+        public Pattern getOriginalAttributeTypePattern() {
+            return originalAttributeTypePattern;
+        } // getOriginalAttributeTypePattern
+        
+        /**
+         * Compiles the regular expressions into Java Patterns.
+         */
+        public void compilePatterns() {
+            originalAttributeNamePattern = Pattern.compile(originalAttributeName);
+            originalAttributeTypePattern = Pattern.compile(originalAttributeType);
+        } // compilePatterns
         
     } // AttributeMapping
     

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -275,12 +275,13 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         } // try catch
 
         // Check if any of the mappings is not valid, e.g. some field is missing
-        purge();
+        nameMappings.purge();
         LOGGER.debug("[nmi] Reading name mappings, Json purged");
+        
+        // Pre-compile the regular expressions
+        nameMappings.compilePatterns();
+        LOGGER.debug("[nmi] Reading name mappings, regular expressions pre-compiled");
     } // loadNameMappings
-    
-    private void purge() {
-    } // purge
     
     /**
      * Applies the mappings to the input NotifyContextRequest object.
@@ -306,7 +307,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         for (ServiceMapping sm : nameMappings.getServiceMappings()) {
             serviceMapping = sm;
             
-            if (!serviceMapping.getOriginalService().equals(originalService)) {
+            if (!serviceMapping.getOriginalServicePattern().matcher(originalService).matches()) {
                 serviceMapping = null;
                 continue;
             } // if
@@ -331,7 +332,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         for (ServicePathMapping spm : serviceMapping.getServicePathMappings()) {
             servicePathMapping = spm;
             
-            if (!servicePathMapping.getOriginalServicePath().equals(originalServicePath)) {
+            if (!servicePathMapping.getOriginalServicePathPattern().matcher(originalServicePath).matches()) {
                 servicePathMapping = null;
                 continue;
             } // if
@@ -361,8 +362,8 @@ public class NGSINameMappingsInterceptor implements Interceptor {
             for (EntityMapping em : servicePathMapping.getEntityMappings()) {
                 entityMapping = em;
 
-                if (!entityMapping.getOriginalEntityId().equals(originalEntityId)
-                        || !entityMapping.getOriginalEntityType().equals(originalEntityType)) {
+                if (!entityMapping.getOriginalEntityIdPattern().matcher(originalEntityId).matches()
+                        || !entityMapping.getOriginalEntityTypePattern().matcher(originalEntityType).matches()) {
                     entityMapping = null;
                     continue;
                 } // if
@@ -398,8 +399,9 @@ public class NGSINameMappingsInterceptor implements Interceptor {
                 for (AttributeMapping am : entityMapping.getAttributeMappings()) {
                     attributeMapping = am;
 
-                    if (!attributeMapping.getOriginalAttributeName().equals(originalAttributeName)
-                            || !attributeMapping.getOriginalAttributeType().equals(originalAttributeType)) {
+                    if (!attributeMapping.getOriginalAttributeNamePattern().matcher(originalAttributeName).matches()
+                            || !attributeMapping.getOriginalAttributeTypePattern().matcher(originalAttributeType).
+                                    matches()) {
                         attributeMapping = null;
                         continue;
                     } // if

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -258,7 +258,14 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         } catch (Exception e) {
             LOGGER.error("[nmi] Runtime error (" + e.getMessage() + ")");
             nameMappings = null;
+            return;
         } // try catch
+        
+        if (jsonStr == null) {
+            LOGGER.debug("[nmi] Reding name mappings, no file to read");
+            nameMappings = null;
+            return;
+        } // if
 
         // Parse the Json string
         Gson gson = new Gson();
@@ -269,9 +276,11 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         } catch (JsonIOException e) {
             LOGGER.error("[nmi] Runtime error (" + e.getMessage() + ")");
             nameMappings = null;
+            return;
         } catch (JsonSyntaxException e) {
             LOGGER.error("[nmi] Runtime error (" + e.getMessage() + ")");
             nameMappings = null;
+            return;
         } // try catch
 
         // Check if any of the mappings is not valid, e.g. some field is missing

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -250,7 +250,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
     
     private void loadNameMappings() {
         // Read the Json string from the configuration file
-        String jsonStr = null;
+        String jsonStr;
 
         try {
             jsonStr = JsonUtils.readJsonFile(nameMappingsConfFile);
@@ -261,6 +261,15 @@ public class NGSINameMappingsInterceptor implements Interceptor {
             return;
         } // try catch
         
+        loadNameMappings(jsonStr);
+    } // loadNameMappings
+    
+    /**
+     * Loads the Name Mappings given a Json string. It is protected since it only can be used by this class and test
+     * classes.
+     * @param jsonStr
+     */
+    protected void loadNameMappings(String jsonStr) {
         if (jsonStr == null) {
             LOGGER.debug("[nmi] Reding name mappings, no file to read");
             nameMappings = null;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtilsForTests.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtilsForTests.java
@@ -17,6 +17,10 @@
  */
 package com.telefonica.iot.cygnus.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import org.apache.flume.Context;
 
 /**
@@ -60,5 +64,22 @@ public final class NGSIUtilsForTests {
         context.put("mongo_username", "");
         return context;
     } // createContextForMongoSTH
+    
+    /**
+     * Creates a NotifyContextRequest object from a Json string.
+     * @param jsonStr
+     * @return A NotifyContextRequest object
+     */
+    public static NotifyContextRequest createNotifyContextRequest(String jsonStr) {
+        Gson gson = new Gson();
+
+        try {
+            return gson.fromJson(jsonStr, NotifyContextRequest.class);
+        } catch (JsonIOException e) {
+            return null;
+        } catch (JsonSyntaxException e) {
+            return null;
+        } // try catch
+    } // createNotifyContextRequest
     
 } // NGSIUtilsForTests

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/containers/NameMappingsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/containers/NameMappingsTest.java
@@ -24,6 +24,7 @@ import com.telefonica.iot.cygnus.containers.NameMappings.ServicePathMapping;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.TestUtils;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -236,6 +237,38 @@ public class NameMappingsTest {
             + "   ]"
             + "}";
     
+    private final String nameMappingsRegex = "" 
+            + "{"
+            + "   \"serviceMappings\": ["
+            + "      {"
+            + "         \"originalService\": \".*\","
+            + "         \"newService\": \"new_default\","
+            + "         \"servicePathMappings\": ["
+            + "            {"
+            + "               \"originalServicePath\": \"/.*\","
+            + "               \"newServicePath\": \"/new_default\","
+            + "               \"entityMappings\": ["
+            + "                  {"
+            + "                     \"originalEntityId\": \"Room\\.(\\d*)\","
+            + "                     \"originalEntityType\": \"Room\","
+            + "                     \"newEntityId\": \"new_Room1\","
+            + "                     \"newEntityType\": \"new_Room\","
+            + "                     \"attributeMappings\": ["
+            + "                        {"
+            + "                           \"originalAttributeName\": \"temp*\","
+            + "                           \"originalAttributeType\": \"cent*\","
+            + "                           \"newAttributeName\": \"new_temperature\","
+            + "                           \"newAttributeType\": \"new_centigrade\""
+            + "                        }"
+            + "                     ]"
+            + "                  }"
+            + "               ]"
+            + "            }"
+            + "         ]"
+            + "      }"
+            + "   ]"
+            + "}";
+    
     /**
      * [NameMappings.getServiceMappings] -------- Service mappings can be retrieved.
      * @throws java.lang.Exception
@@ -427,5 +460,90 @@ public class NameMappingsTest {
             } // for
         } // for
     } // testNameMappingsSuccessfullyParsed
+    
+    /**
+     * [NameMappings.compilePatterns] -------- Patterns are successfully compiled.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testNameMappingsPatternsCompiled() throws Exception {
+        System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                + "-------- Patterns are successfully compiled");
+        NameMappings nameMappings = TestUtils.createJsonNameMappings(nameMappingsRegex);
+        nameMappings.compilePatterns();
+        ServiceMapping serviceMapping = nameMappings.getServiceMappings().get(0);
+       
+        try {
+            assertEquals(Pattern.compile(serviceMapping.getOriginalService()).pattern(),
+                    serviceMapping.getOriginalServicePattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original service matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original service does not match the expected one");
+            throw e;
+        } // try catch
+        
+        ServicePathMapping servicePathMapping = serviceMapping.getServicePathMappings().get(0);
+        
+        try {
+            assertEquals(Pattern.compile(servicePathMapping.getOriginalServicePath()).pattern(),
+                    servicePathMapping.getOriginalServicePathPattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original service path matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original service path does not match the expected one");
+            throw e;
+        } // try catch
+        
+        EntityMapping entityMapping = servicePathMapping.getEntityMappings().get(0);
+        
+        try {
+            assertEquals(Pattern.compile(entityMapping.getOriginalEntityId()).pattern(),
+                    entityMapping.getOriginalEntityIdPattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original entity ID matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original entity ID does not match the expected one");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(Pattern.compile(entityMapping.getOriginalEntityType()).pattern(),
+                    entityMapping.getOriginalEntityTypePattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original entity type matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original entity type does not match the expected one");
+            throw e;
+        } // try catch
+        
+        AttributeMapping attributeMapping = entityMapping.getAttributeMappings().get(0);
+        
+        try {
+            assertEquals(Pattern.compile(attributeMapping.getOriginalAttributeName()).pattern(),
+                    attributeMapping.getOriginalAttributeNamePattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original attribute name matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original attribute name does not match the expected one");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(Pattern.compile(attributeMapping.getOriginalAttributeType()).pattern(),
+                    attributeMapping.getOriginalAttributeTypePattern().pattern());
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "-  OK  - The retrieved pattern for the original attribute type matches the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NameMappings.compilePatterns]")
+                    + "- FAIL - The retrieved pattern for the original attribute type does not match the expected one");
+            throw e;
+        } // try catch
+    } // testNameMappingsPatternsCompiled
     
 } // NameMappingsTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
  */
 public class NGSINameMappingsInterceptorTest {
     
-    private final String nameMappingsStr = "" 
+    private final String nameMappingsStr = ""
             + "{"
             + "   \"serviceMappings\": ["
             + "      {"
@@ -52,7 +52,7 @@ public class NGSINameMappingsInterceptorTest {
             + "               \"newServicePath\": \"/new_any\","
             + "               \"entityMappings\": ["
             + "                  {"
-            + "                     \"originalEntityId\": \"Room\\.(\\d*)\","
+            + "                     \"originalEntityId\": \"Room(\\\\d*)\","
             + "                     \"originalEntityType\": \"Room\","
             + "                     \"newEntityId\": \"new_Room1\","
             + "                     \"newEntityType\": \"new_Room\","

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
@@ -17,12 +17,14 @@
  */
 package com.telefonica.iot.cygnus.interceptors;
 
-import com.telefonica.iot.cygnus.containers.NameMappings;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.createEvent;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import com.telefonica.iot.cygnus.utils.NGSIUtilsForTests;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.flume.Context;
@@ -38,6 +40,39 @@ import org.junit.Test;
  */
 public class NGSINameMappingsInterceptorTest {
     
+    private final String nameMappingsStr = "" 
+            + "{"
+            + "   \"serviceMappings\": ["
+            + "      {"
+            + "         \"originalService\": \".*\","
+            + "         \"newService\": \"new_default\","
+            + "         \"servicePathMappings\": ["
+            + "            {"
+            + "               \"originalServicePath\": \"/.*\","
+            + "               \"newServicePath\": \"/new_any\","
+            + "               \"entityMappings\": ["
+            + "                  {"
+            + "                     \"originalEntityId\": \"Room\\.(\\d*)\","
+            + "                     \"originalEntityType\": \"Room\","
+            + "                     \"newEntityId\": \"new_Room1\","
+            + "                     \"newEntityType\": \"new_Room\","
+            + "                     \"attributeMappings\": ["
+            + "                        {"
+            + "                           \"originalAttributeName\": \"temp(.*)\","
+            + "                           \"originalAttributeType\": \"cent(.*)\","
+            + "                           \"newAttributeName\": \"new_temperature\","
+            + "                           \"newAttributeType\": \"new_centigrade\""
+            + "                        }"
+            + "                     ]"
+            + "                  }"
+            + "               ]"
+            + "            }"
+            + "         ]"
+            + "      }"
+            + "   ]"
+            + "}";
+    private final String originalService = "default";
+    private final String originalServicePath = "/any";
     private final String originalNCRStr = ""
             + "{"
             +   "\"subscriptionId\" : \"51c0ac9ed714fb3b37d7d5a8\","
@@ -63,8 +98,7 @@ public class NGSINameMappingsInterceptorTest {
             +     "}"
             +   "]"
             + "}";
-    
-    private final String mappedNCRStr = ""
+    private final String expectedNCRStr = ""
             + "{"
             +   "\"subscriptionId\" : \"51c0ac9ed714fb3b37d7d5a8\","
             +   "\"originator\" : \"localhost\","
@@ -153,10 +187,10 @@ public class NGSINameMappingsInterceptorTest {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                 + "-------- When a NGSI event is put in the channel, it contains fiware-service, fiware-servicepath, "
                 + "fiware-correlator, transaction-id, mapped-fiware-service and mapped-fiware-servicepath headers");
-        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
-        nameMappingInterceptor.initialize();
+        NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
+        nameMappingsInterceptor.initialize();
         Event originalEvent = createEvent();
-        Map<String, String> interceptedEventHeaders = nameMappingInterceptor.intercept(originalEvent).getHeaders();
+        Map<String, String> interceptedEventHeaders = nameMappingsInterceptor.intercept(originalEvent).getHeaders();
 
         try {
             assertTrue(interceptedEventHeaders.containsKey(CommonConstants.HEADER_FIWARE_SERVICE));
@@ -240,41 +274,77 @@ public class NGSINameMappingsInterceptorTest {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                 + "-------- When a Flume event is put in the channel, it contains the original NotifyContextRequest "
                 + "and the mapped one");
-        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
-        nameMappingInterceptor.initialize();
+        NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
+        nameMappingsInterceptor.loadNameMappings(nameMappingsStr);
         Event originalEvent = createEvent();
-        NGSIEvent ngsiEvent = (NGSIEvent) nameMappingInterceptor.intercept(originalEvent);
+        NGSIEvent ngsiEvent = (NGSIEvent) nameMappingsInterceptor.intercept(originalEvent);
 
         try {
             assertTrue(ngsiEvent.getMappedNCR() != null);
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                     + "-  OK  - The generated NGSI event contains the original NotifyContextRequest");
-        } catch (AssertionError e1) {
+        } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                     + "- FAIL - The generated NGSI event does not contain the original NotifyContextRequest");
-            throw e1;
+            throw e;
         } // try catch
         
         try {
             assertTrue(ngsiEvent.getOriginalNCR() != null);
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                     + "-  OK  - The generated NGSI event contains the mapped NotifyContextRequest");
-        } catch (AssertionError e1) {
+        } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                     + "- FAIL - The generated NGSI event does not contain the mapped NotifyContextRequest");
-            throw e1;
+            throw e;
         } // try catch
     } // testGetNCRsInNGSIEvent
     
     /**
      * [NGSIGroupingInterceptor.doMap] -------- A mapped NotifyContextRequest can be obtained from the Name Mappings.
      */
-    //@Test
+    @Test
     public void testDoMap() {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.doMap]")
                 + "-------- A mapped NotifyContextRequest can be obtained from the Name Mappings");
-        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
-        nameMappingInterceptor.initialize();
+        NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
+        nameMappingsInterceptor.loadNameMappings(nameMappingsStr);
+        NotifyContextRequest originalNCR = NGSIUtilsForTests.createNotifyContextRequest(originalNCRStr);
+        NotifyContextRequest expectedNCR = NGSIUtilsForTests.createNotifyContextRequest(expectedNCRStr);
+        ImmutableTriple<String, String, NotifyContextRequest> map = nameMappingsInterceptor.doMap(
+                originalService, originalServicePath, originalNCR);
+        NotifyContextRequest mappedNCR = map.getRight();
+        boolean equals = true;
+        
+        for (int i = 0; i < mappedNCR.getContextResponses().size(); i++) {
+            ContextElement ce = mappedNCR.getContextResponses().get(i).getContextElement();
+            ContextElement expectedCE = expectedNCR.getContextResponses().get(i).getContextElement();
+            
+            if (!ce.getId().equals(expectedCE.getId()) || !ce.getType().equals(expectedCE.getType())) {
+                equals = false;
+                break;
+            } // if
+            
+            for (int j = 0; j < ce.getAttributes().size(); j++) {
+                ContextAttribute ca = ce.getAttributes().get(j);
+                ContextAttribute expectedCA = expectedCE.getAttributes().get(j);
+                
+                if (!ca.getName().equals(expectedCA.getName()) || !ca.getType().equals(expectedCA.getType())) {
+                    equals = false;
+                    break;
+                } // if
+            } // for
+        } // for
+        
+        try {
+            assertTrue(equals);
+            System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.doMap]")
+                    + "-  OK  - The mapped NotifyContextRequest is equals to the expected one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.doMap]")
+                    + "- FAIL - The mapped NotifyContextRequest is not equals to the expected one");
+            throw e;
+        } // try catch
     } // testDoMap
     
     private Context createBuilderContext(String nameMappingsConfFile) {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
@@ -17,11 +17,14 @@
  */
 package com.telefonica.iot.cygnus.interceptors;
 
+import com.telefonica.iot.cygnus.containers.NameMappings;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.createEvent;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.log4j.Level;
@@ -150,7 +153,7 @@ public class NGSINameMappingsInterceptorTest {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                 + "-------- When a NGSI event is put in the channel, it contains fiware-service, fiware-servicepath, "
                 + "fiware-correlator, transaction-id, mapped-fiware-service and mapped-fiware-servicepath headers");
-        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor("", false);
+        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
         nameMappingInterceptor.initialize();
         Event originalEvent = createEvent();
         Map<String, String> interceptedEventHeaders = nameMappingInterceptor.intercept(originalEvent).getHeaders();
@@ -237,7 +240,7 @@ public class NGSINameMappingsInterceptorTest {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
                 + "-------- When a Flume event is put in the channel, it contains the original NotifyContextRequest "
                 + "and the mapped one");
-        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor("", false);
+        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
         nameMappingInterceptor.initialize();
         Event originalEvent = createEvent();
         NGSIEvent ngsiEvent = (NGSIEvent) nameMappingInterceptor.intercept(originalEvent);
@@ -262,6 +265,17 @@ public class NGSINameMappingsInterceptorTest {
             throw e1;
         } // try catch
     } // testGetNCRsInNGSIEvent
+    
+    /**
+     * [NGSIGroupingInterceptor.doMap] -------- A mapped NotifyContextRequest can be obtained from the Name Mappings.
+     */
+    //@Test
+    public void testDoMap() {
+        System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.doMap]")
+                + "-------- A mapped NotifyContextRequest can be obtained from the Name Mappings");
+        NGSINameMappingsInterceptor nameMappingInterceptor = new NGSINameMappingsInterceptor(null, false);
+        nameMappingInterceptor.initialize();
+    } // testDoMap
     
     private Context createBuilderContext(String nameMappingsConfFile) {
         Context context = new Context();


### PR DESCRIPTION
* Implements issue #1202 
* 100% unit tests passed:

`cygnus-ngsi`:
```
Tests run: 249, Failures: 0, Errors: 0, Skipped: 0
```

Relevant unit tests for this PR:

```
[NGSIGroupingInterceptor.doMap] ------------------------------------- A mapped NotifyContextRequest can be obtained from the Name Mappings
[NGSIGroupingInterceptor.doMap] ------------------------------  OK  - The mapped NotifyContextRequest is equals to the expected one
[NameMappings.compilePatterns] -------------------------------------- Patterns are successfully compiled
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original service matches the expected one
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original service path matches the expected one
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original entity ID matches the expected one
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original entity type matches the expected one
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original attribute name matches the expected one
[NameMappings.compilePatterns] -------------------------------  OK  - The retrieved pattern for the original attribute type matches the expected one
```

* (unofficial) e2e tests passed:

```
{
   "serviceMappings": [
      {
         "originalService": ".*",
         "newService": "new_default",
         "servicePathMappings": [
            {
               "originalServicePath": "/(.*)",
               "newServicePath": "/new_any",
               "entityMappings": [
                  {
                     "originalEntityId": "Room(\\d*)",
                     "originalEntityType": "Room",
                     "newEntityId": "new_Room1",
                     "newEntityType": "new_Room",
                     "attributeMappings": [
                        {
                           "originalAttributeName": "temp(.*)",
                           "originalAttributeType": "cent(.*)",
                           "newAttributeName": "new_temperature",
                           "newAttributeType": "new_centigrade"
                        }
                     ]
                  }
               ]
            }
         ]
      }
   ]
}
```
```
time=2016-10-14T12:04:55.214UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[103] : [nmi] Original NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"Room1","type":"Room","isPattern":"false","attributes":[{"name":"temperature","type":"centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-10-14T12:04:55.215UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[333] : [nmi] FIWARE service found: default
time=2016-10-14T12:04:55.215UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[358] : [nmi] FIWARE service path found: /any
time=2016-10-14T12:04:55.215UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[389] : [nmi] Entity found: Room1, Room
time=2016-10-14T12:04:55.215UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[427] : [nmi] Attribute found: temperature, centigrade
time=2016-10-14T12:04:55.235UTC | lvl=DEBUG | corr=be00880d-d306-4573-a712-90fa2db72d5d | trans=be00880d-d306-4573-a712-90fa2db72d5d | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[112] : [nmi] Mapped NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"new_Room1","type":"new_Room","isPattern":"false","attributes":[{"name":"new_temperature","type":"new_centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
```