### PR TITLE
bug/1217_fix_accepted_charset_kafka

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [cygnus][doc] Add entry for Grouping Rules in Installation and Administration Guide (#1206)
 - [cygnus-ngsi][hardening] Delay the retries of not persisted batches (#1138)
+- [cygnus-ngsi][bug] Fix accepted charset by Kafka (#1217)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -404,8 +404,13 @@ public final class NGSICharsets {
         
         for (int i = 0; i < in.length(); i++) {
             char c = in.charAt(i);
+            int code = c;
             
-            if (c == 'x') {
+            if (code >= 65 && code <= 90) { // A-Z --> A-Z
+                out += c;
+            } else if (code >= 97 && code <= 119) { // a-w --> a-w
+                out += c;
+            } else if (c == 'x') {
                 String next4;
             
                 if (i + 4 < in.length()) {
@@ -419,10 +424,21 @@ public final class NGSICharsets {
                 } else { // x --> x
                     out += c;
                 } // if else
+            } else if (code == 121 || code == 122) { // yz --> yz
+                out += c;
+            } else if (code >= 48 && code <= 57) { // 0-9 --> 0-9
+                out += c;
+            } else if (c == '_') { // _ --> _
+                out += c;
+            } else if (c == '-') { // - --> -
+                out += c;
+            } else if (c == '.') { // . --> .
+                out += c;
             } else if (c == '=') { // = --> xffff
                 out += "xffff";
-            } else {
-                out += c;
+            } else { // --> xUNICODE
+                String hex = Integer.toHexString(code);
+                out += "x" + ("0000" + hex).substring(hex.length());
             } // else
         } // for
         

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIKafkaSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIKafkaSinkTest.java
@@ -110,7 +110,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/servicePath";
+            expectedTopic = "servicexffffx002fservicePath";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
@@ -136,7 +136,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/";
+            expectedTopic = "servicexffffx002f";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
@@ -162,7 +162,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/servicePathxffffentityIdxffffentityType";
+            expectedTopic = "servicexffffx002fservicePathxffffentityIdxffffentityType";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
@@ -188,7 +188,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/xffffentityIdxffffentityType";
+            expectedTopic = "servicexffffx002fxffffentityIdxffffentityType";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
@@ -215,7 +215,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePath, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/servicePathxffffentityIdxffffentityTypexffffattributeName";
+            expectedTopic = "servicexffffx002fservicePathxffffentityIdxffffentityTypexffffattributeName";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);
@@ -241,7 +241,7 @@ public class NGSIKafkaSinkTest {
         String topic = sink.buildTopicName(service, servicePathSlash, entity, attribute);
         
         try {
-            expectedTopic = "servicexffff/xffffentityIdxffffentityTypexffffattributeName";
+            expectedTopic = "servicexffffx002fxffffentityIdxffffentityTypexffffattributeName";
             assertEquals(expectedTopic, topic);
             System.out.println(getTestTraceHead("[NGSIKafkaSink.buildTopicName]") + "-  OK  - "
                     + "Created topic is equals to " + expectedTopic);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
@@ -1490,7 +1490,7 @@ public class NGSICharsetsTest {
                 + "-------- Non lower case alphanumerics and underscore are encoded");
         String in = "ÁÉÍÓÚáéíóúÑñÇç";
         String expected = "x00c1x00c9x00cdx00d3x00dax00e1x00e9x00edx00f3x00fax00d1x00f1x00c7x00e7";
-        String out = NGSICharsets.encodeMySQL(in);
+        String out = NGSICharsets.encodeDynamoDB(in);
         
         try {
             assertEquals(expected, out);
@@ -1504,7 +1504,7 @@ public class NGSICharsetsTest {
         
         in = "!\"#$%&'()*+,/";
         expected = "x0021x0022x0023x0024x0025x0026x0027x0028x0029x002ax002bx002cx002f";
-        out = NGSICharsets.encodeMySQL(in);
+        out = NGSICharsets.encodeDynamoDB(in);
         
         try {
             assertEquals(expected, out);
@@ -1519,7 +1519,7 @@ public class NGSICharsetsTest {
         // '=' has been excluded from here since it is not notified by Orion and it is used as concatenator
         in = ":;<>?@";
         expected = "x003ax003bx003cx003ex003fx0040";
-        out = NGSICharsets.encodeMySQL(in);
+        out = NGSICharsets.encodeDynamoDB(in);
         
         try {
             assertEquals(expected, out);
@@ -1533,7 +1533,7 @@ public class NGSICharsetsTest {
         
         in = "[\\]^`";
         expected = "x005bx005cx005dx005ex0060";
-        out = NGSICharsets.encodeMySQL(in);
+        out = NGSICharsets.encodeDynamoDB(in);
         
         try {
             assertEquals(expected, out);
@@ -1547,7 +1547,7 @@ public class NGSICharsetsTest {
         
         in = "{|}~";
         expected = "x007bx007cx007dx007e";
-        out = NGSICharsets.encodeMySQL(in);
+        out = NGSICharsets.encodeDynamoDB(in);
         
         try {
             assertEquals(expected, out);
@@ -1559,6 +1559,140 @@ public class NGSICharsetsTest {
             throw e;
         } // try catch
     } // testEncodeDynamoDBRare
+    
+    // ---------- Kafka ----------
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Upper case not accented characters are not encoded.
+     */
+    @Test
+    public void testEncodeKafkaUpperCase() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Upper case not accented characters are not encoded");
+        String in = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String expected = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaUpperCase
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Lower case not accented characters except 'x' are not encoded.
+     */
+    @Test
+    public void testEncodeKafkaLowerCase() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Lower case not accented characters are not encoded");
+        String in = "abcdefghijklmnopqrstuvwyz";
+        String expected = "abcdefghijklmnopqrstuvwyz";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaLowerCase
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Numbers are not encoded.
+     */
+    @Test
+    public void testEncodeKafkaBNums() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Numbers are not encoded");
+        String in = "0123456789";
+        String expected = "0123456789";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaNums
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Underscore is not encoded.
+     */
+    @Test
+    public void testEncodeKafkaUnderscore() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Underscore is not encoded");
+        String in = "_";
+        String expected = "_";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaUnderscore
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Hyphen is not encoded.
+     */
+    @Test
+    public void testEncodeKafkaHyphen() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Hyphen is not encoded");
+        String in = "-";
+        String expected = "-";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaHyphen
+    
+    /**
+     * [NGSICharsets.encodeKafka] -------- Dot is not encoded.
+     */
+    @Test
+    public void testEncodeKafkaDot() {
+        System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                + "-------- Dot is not encoded");
+        String in = ".";
+        String expected = ".";
+        String out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has not been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+            throw e;
+        } // try catch
+    } // testEncodeKafkaDot
     
     /**
      * [NGSICharsets.encodeKafka] -------- '=' (internal concatenator) is encoded as "xffff" (public concatenator).
@@ -1627,23 +1761,81 @@ public class NGSICharsetsTest {
     } // testEncodeKafkaxffff
     
     /**
-     * [NGSICharsets.encodeKafka] -------- Rare characters are not encoded.
+     * [NGSICharsets.encodeKafka] -------- Non lower case alphanumerics nor underscore nor hyphen nor dot are
+     * encoded.
      */
     @Test
     public void testEncodeKafkaRare() {
         System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
-                + "-------- Rare characters are not encoded");
-        String in = "ÁÉÍÓÚáéíóúÑñÇç!/\"#$%&'()*+,.-_:;<>?@[\\]^`{|}~";
-        String expected = "ÁÉÍÓÚáéíóúÑñÇç!/\"#$%&'()*+,.-_:;<>?@[\\]^`{|}~";
+                + "-------- Non lower case alphanumerics and underscore are encoded");
+        String in = "ÁÉÍÓÚáéíóúÑñÇç";
+        String expected = "x00c1x00c9x00cdx00d3x00dax00e1x00e9x00edx00f3x00fax00d1x00f1x00c7x00e7";
         String out = NGSICharsets.encodeKafka(in);
         
         try {
             assertEquals(expected, out);
             System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
-                    + "-  OK  - '" + in + "' has not been encoded");
+                    + "-  OK  - '" + in + "' has been encoded");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
-                    + "- FAIL - '" + in + "' has been encoded as '" + out + "'");
+                    + "- FAIL - '" + in + "' has not been encoded");
+            throw e;
+        } // try catch
+        
+        in = "!\"#$%&'()*+,/";
+        expected = "x0021x0022x0023x0024x0025x0026x0027x0028x0029x002ax002bx002cx002f";
+        out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has not been encoded");
+            throw e;
+        } // try catch
+        
+        // '=' has been excluded from here since it is not notified by Orion and it is used as concatenator
+        in = ":;<>?@";
+        expected = "x003ax003bx003cx003ex003fx0040";
+        out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has not been encoded");
+            throw e;
+        } // try catch
+        
+        in = "[\\]^`";
+        expected = "x005bx005cx005dx005ex0060";
+        out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has not been encoded");
+            throw e;
+        } // try catch
+        
+        in = "{|}~";
+        expected = "x007bx007cx007dx007e";
+        out = NGSICharsets.encodeKafka(in);
+        
+        try {
+            assertEquals(expected, out);
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "-  OK  - '" + in + "' has been encoded");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICharsets.encodeKafka]")
+                    + "- FAIL - '" + in + "' has not been encoded");
             throw e;
         } // try catch
     } // testEncodeKafkaRare

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_kafka_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_kafka_sink.md
@@ -188,9 +188,14 @@ By default, `NGSIKafkaSink` has a configured batch size and batch accumulation t
 ####<a name="section2.3.2"></a>About the encoding
 Cygnus applies this specific encoding tailored to Kafka data structures:
 
+* Alphanumeric characters are not encoded.
+* Numeric characters are not encoded.
+* Underscore character, `_`, is not encoded.
+* Hyphen character, `-`, is not encoded.
+* Dot character, `.`, is not encoded.
 * Equals character, `=`, is encoded as `xffff`.
-* User defined strings composed of a `x` character and a [Unicode](http://unicode-table.com) are encoded as `xx` followed by the Unicode.
-* All the other characters are not encoded.
+* All other characters, including the slash in the FIWARE service paths, are encoded as a `x` character followed by the [Unicode](http://unicode-table.com) of the character.
+* User defined strings composed of a `x` character and a Unicode are encoded as `xx` followed by the Unicode.
 * `xffff` is used as concatenator character.
 
 [Top](#top)


### PR DESCRIPTION
* Fixes issue #1217 
* Related unit test passed:

```
[NGSIKafkaSink.buildTopicName] -------------------------------------- When the root service-path is notified/defaulted and data_model=dm-by-attribute, the Kafka topic name is the concatenation of <service>, <service-path>, <entityId>, <entityType> and <attrName>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002fxffffentityIdxffffentityTypexffffattributeName
[NGSIKafkaSink.buildTopicName] -------------------------------------- When the root service-path is notified/defaulted and data_model=dm-by-entity, the Kafka topic name is the concatenation of <service>, <service-path>, <entityId> and <entityType>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002fxffffentityIdxffffentityType
[NGSIKafkaSink.buildTopicName] -------------------------------------- When a non root service-path is notified/defaulted and data_model=dm-by-service, the Kafka topic name is <service>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equal to service
[NGSIKafkaSink.buildTopicName] -------------------------------------- When the root service-path is notified/defaulted and data_model=dm-by-service-path, the Kafka topic name is the concatenation of <service> and <service-path>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002f
[NGSIKafkaSink.buildTopicName] -------------------------------------- When a non root service-path is notified/defaulted and data_model=dm-by-entity, the Kafka topic name is the concatenation of <service>, <service-path>, <entityId> and <entityType>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002fservicePathxffffentityIdxffffentityType
[NGSIKafkaSink.buildTopicName] -------------------------------------- When a non root service-path is notified/defaulted and data_model=dm-by-service-path, the Kafka topic name is the concatenation of <service> and <service-path>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002fservicePath
[NGSIKafkaSink.buildTopicName] -------------------------------------- When a non root service-path is notified/defaulted and data_model=dm-by-attribute, the Kafka topic name is the concatenation of <service>, <service-path>, <entityId>, <entityType> and <attrName>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to servicexffffx002fservicePathxffffentityIdxffffentityTypexffffattributeName
[NGSIKafkaSink.buildTopicName] -------------------------------------- When the root service-path is notified/defaulted and data_model=dm-by-service, the Kafka topic name is <service>
[NGSIKafkaSink.buildTopicName] -------------------------------  OK  - Created topic is equals to service
[NGSICharsets.encodeKafka] ------------------------------------------ Non lower case alphanumerics and underscore are encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - 'ÁÉÍÓÚáéíóúÑñÇç' has been encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '!"#$%&'()*+,/' has been encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - ':;<>?@' has been encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '[\]^`' has been encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '{|}~' has been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ Dot is not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '.' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ "xffff" is encoded (escaped) as "xxffff"
[NGSICharsets.encodeKafka] -----------------------------------  OK  - 'xffff' has been encoded as 'xxffff'
[NGSICharsets.encodeKafka] ------------------------------------------ Numbers are not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '0123456789' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ Lower case not accented characters are not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - 'abcdefghijklmnopqrstuvwyz' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ A single 'x' is not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - 'x' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ Underscore is not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '_' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ Hyphen is not encoded
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '-' has not been encoded
[NGSICharsets.encodeKafka] ------------------------------------------ '=' (internal concatenator) is encoded as "xffff" (public concatenator)
[NGSICharsets.encodeKafka] -----------------------------------  OK  - '=' has been encoded as 'xffff'
```
