### PR TITLE
hardening/1233_fix_use_of_old_libs_in_docker

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,3 +14,4 @@
 - [cygnus][doc] Replace references to JDK 1.6 with JDK 1.7 (#1232)
 - [cygnus][hardening] Add NGSIHDFSSink configuration in docker's agent.conf file (#1172)
 - [cygnus][hardening] Fix NGSIMySQLSink configuration in docker's agent.conf file (#1237)
+- [cygnus][hardening] Fix use of Apache Flume httpclient,httpcore and libthrift old libs (#1233)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,4 +14,4 @@
 - [cygnus][doc] Replace references to JDK 1.6 with JDK 1.7 (#1232)
 - [cygnus][hardening] Add NGSIHDFSSink configuration in docker's agent.conf file (#1172)
 - [cygnus][hardening] Fix NGSIMySQLSink configuration in docker's agent.conf file (#1237)
-- [cygnus][hardening] Fix use of Apache Flume httpclient,httpcore and libthrift old libs (#1233)
+- [cygnus][hardening] Force the usage of certain version in libraries used by cygnus-ngsi docker (#1233)

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -47,9 +47,9 @@ ENV CYGNUS_HDFS_USER "hdfs"
 ENV CYGNUS_HDFS_TOKEN ""
 
 # NOTE: Configure correctly GIT_URL_CYGNUS and GIT_REV_CYGNUS for each git branch/fork used
-ENV GIT_URL_CYGNUS "https://github.com/telefonicaid/fiware-cygnus.git"
+ENV GIT_URL_CYGNUS "https://github.com/pcoello25/fiware-cygnus.git"
 # ENV GIT_URL_CYGNUS "https://github.com/myuser/fiware-cygnus.git"
-ENV GIT_REV_CYGNUS "master"
+ENV GIT_REV_CYGNUS "hardening/1233_fix_use_of_old_libs_in_docker"
 # ENV GIT_REV_CYGNUS "mybranch"
 
 ENV MVN_VER "3.3.9"

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -83,6 +83,9 @@ RUN \
     curl --remote-name --location --insecure --silent --show-error "${FLUME_URL}" && \
     tar zxf apache-flume-${FLUME_VER}-bin.tar.gz && \
     mv apache-flume-${FLUME_VER}-bin ${FLUME_HOME} && \
+    mv ${FLUME_HOME}/lib/httpclient-4.2.1.jar ${FLUME_HOME}/lib/httpclient-4.2.1.jar.old && \
+    mv ${FLUME_HOME}/lib/httpcore-4.2.1.jar ${FLUME_HOME}/lib/httpcore-4.2.1.jar.old && \
+    mv ${FLUME_HOME}/lib/libthrift-0.7.0.jar ${FLUME_HOME}/lib/libthrift-0.7.0.jar.old && \
     mkdir -p ${FLUME_HOME}/plugins.d/cygnus && \
     mkdir -p ${FLUME_HOME}/plugins.d/cygnus/lib && \
     mkdir -p ${FLUME_HOME}/plugins.d/cygnus/libext && \

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -47,9 +47,9 @@ ENV CYGNUS_HDFS_USER "hdfs"
 ENV CYGNUS_HDFS_TOKEN ""
 
 # NOTE: Configure correctly GIT_URL_CYGNUS and GIT_REV_CYGNUS for each git branch/fork used
-ENV GIT_URL_CYGNUS "https://github.com/pcoello25/fiware-cygnus.git"
+ENV GIT_URL_CYGNUS "https://github.com/telefonicaid/fiware-cygnus.git"
 # ENV GIT_URL_CYGNUS "https://github.com/myuser/fiware-cygnus.git"
-ENV GIT_REV_CYGNUS "hardening/1233_fix_use_of_old_libs_in_docker"
+ENV GIT_REV_CYGNUS "master"
 # ENV GIT_REV_CYGNUS "mybranch"
 
 ENV MVN_VER "3.3.9"


### PR DESCRIPTION
* Fix issue #1233 
* Docker installation traces:
```
[INFO] Downloading: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.3.1/httpcore-4.3.1.jar
[INFO] Downloading: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.3.1/httpclient-4.3.1.jar
[INFO] Downloading: https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.9.1/libthrift-0.9.1.jar
```
* Inside the running docker 
```
[root@5fc09e3383f1 lib]# ls | grep httpclient
httpclient-4.2.1.jar.old
[root@5fc09e3383f1 lib]# ls | grep httpcore  
httpcore-4.2.1.jar.old
[root@5fc09e3383f1 lib]# ls | grep libth   
libthrift-0.7.0.jar.old
```
* Assigee: @frbattid 