### PR TITLE
hardening/1258_do_configurable_ckan_viewer

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -21,3 +21,4 @@
 - [cygnus][hardening] Add FIWARE architecture section in the documentation (#1248)
 - [cygnus][doc] Fix API entries in documentation (#1246)
 - [cygnus][doc] Add entries about running as process and running as service in documentation (#1255)
+- [cygnus][hardening] Do configurable the CKAN viewer attached to resources (#1258)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -42,6 +42,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
     private static final CygnusLogger LOGGER = new CygnusLogger(CKANBackendImpl.class);
     private final String orionUrl;
     private final String apiKey;
+    private final String viewer;
     private CKANCache cache;
 
     /**
@@ -53,14 +54,16 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
      * @param ssl
      * @param maxConns
      * @param maxConnsPerRoute
+     * @param ckanViewer
      */
     public CKANBackendImpl(String apiKey, String ckanHost, String ckanPort, String orionUrl,
-            boolean ssl, int maxConns, int maxConnsPerRoute) {
+            boolean ssl, int maxConns, int maxConnsPerRoute, String ckanViewer) {
         super(ckanHost, ckanPort, ssl, false, null, null, null, null, maxConns, maxConnsPerRoute);
         
         // this class attributes
         this.apiKey = apiKey;
         this.orionUrl = orionUrl;
+        this.viewer = ckanViewer;
         
         // create the cache
         cache = new CKANCache(ckanHost, ckanPort, ssl, apiKey, maxConns, maxConnsPerRoute);
@@ -379,7 +382,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             try {
                 // create the CKAN request JSON
                 String jsonString = "{ \"resource_id\": \"" + resourceId + "\","
-                        + "\"view_type\": \"recline_grid_view\","
+                        + "\"view_type\": \"" + viewer + "\","
                         + "\"title\": \"Recline grid view\" }";
 
                 // create the CKAN request URL

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImplTest.java
@@ -67,6 +67,7 @@ public class CKANBackendImplTest {
     private final HashMap<String, String> attrMdList = new HashMap<String, String>();
     private final int maxConns = 50;
     private final int maxConnsPerRoute = 10;
+    private final String viewer = "recline_grid_view";
     
     /**
      * Sets up tests by creating a unique instance of the tested class, and by defining the behaviour of the mocked
@@ -77,7 +78,7 @@ public class CKANBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new CKANBackendImpl(apiKey, host, port, orionURL, ssl, maxConns, maxConnsPerRoute);
+        backend = new CKANBackendImpl(apiKey, host, port, orionURL, ssl, maxConns, maxConnsPerRoute, viewer);
 
         // set up the behaviour of the mocked classes
         when(mockCache.isCachedOrg(orgName)).thenReturn(true);

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -138,6 +138,8 @@ cygnus-ngsi.sinks.ckan-sink.api_key = ckanapikey
 #cygnus-ngsi.sinks.ckan-sink.ckan_host = x.y.z.w
 # the port for the CKAN API endpoint
 #cygnus-ngsi.sinks.ckan-sink.ckan_port = 80
+# the viewer attached to the created resources
+#cygnus-ngsi.sinks.ckan-sink.ckan_viewer = recline_grid_view
 # Orion URL used to compose the resource URL with the convenience operation URL to query it
 #cygnus-ngsi.sinks.ckan-sink.orion_url = http://localhost:1026
 # how the attributes are stored, either per row either per column (row, column)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -49,6 +49,7 @@ public class NGSICKANSink extends NGSISink {
     private boolean ssl;
     private int backendMaxConns;
     private int backendMaxConnsPerRoute;
+    private String ckanViewer;
     private CKANBackend persistenceBackend;
 
     /**
@@ -133,6 +134,14 @@ public class NGSICKANSink extends NGSISink {
     protected int getBackendMaxConnsPerRoute() {
         return backendMaxConnsPerRoute;
     } // getBackendMaxConnsPerRoute
+    
+    /**
+     * Gets the CKAN Viewer. It is protected for testing purposes.
+     * @return The CKAN viewer
+     */
+    protected String getCKANViewer() {
+        return ckanViewer;
+    } // getCKANViewer
 
     @Override
     public void configure(Context context) {
@@ -182,7 +191,9 @@ public class NGSICKANSink extends NGSISink {
         backendMaxConnsPerRoute = context.getInteger("backend.max_conns_per_route", 100);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (backend.max_conns_per_route="
                 + backendMaxConnsPerRoute + ")");
-        
+        ckanViewer = context.getString("ckan_viewer", "recline_grid_view");
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (ckan_viewer=" + ckanViewer + ")");
+
         super.configure(context);
         
         // Techdebt: allow this sink to work with all the data models
@@ -196,7 +207,7 @@ public class NGSICKANSink extends NGSISink {
     public void start() {
         try {
             persistenceBackend = new CKANBackendImpl(apiKey, ckanHost, ckanPort, orionUrl, ssl, backendMaxConns,
-                    backendMaxConnsPerRoute);
+                    backendMaxConnsPerRoute, ckanViewer);
             LOGGER.debug("[" + this.getName() + "] CKAN persistence backend created");
         } catch (Exception e) {
             LOGGER.error("Error while creating the CKAN persistence backend. Details="

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -64,9 +64,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getRowAttrPersistence());
@@ -207,6 +209,16 @@ public class NGSICKANSinkTest {
                     + "- FAIL - 'ssl=false' not configured by default");
             throw e;
         } // try catch
+        
+        try {
+            assertEquals("recline_grid_view", sink.getCKANViewer());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'ckan_viewer=recline_grid_view' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'ckan_viewer=recline_grid_view' not configured by default");
+            throw e;
+        } // try catch
     } // testConfigureDefaults
     
     /**
@@ -230,9 +242,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertEquals(25, sink.getBackendMaxConns());
@@ -266,9 +280,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertEquals(3, sink.getBackendMaxConnsPerRoute());
@@ -302,9 +318,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -338,9 +356,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -374,9 +394,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -411,9 +433,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -447,9 +471,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
@@ -486,9 +512,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         
         try {
@@ -534,9 +562,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         
         try {
@@ -585,9 +615,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         String servicePath = "/someServicePath";
         
@@ -639,9 +671,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         String servicePath = "/someServicePath";
         
@@ -693,9 +727,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         String servicePath = "/";
         
@@ -747,9 +783,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "someService";
         String servicePath = "/";
         
@@ -799,9 +837,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String entity = "someId=someType";
         
         try {
@@ -849,9 +889,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String entity = "someId=someType";
         
         try {
@@ -897,9 +939,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogService";
         
@@ -937,9 +981,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String service = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogService";
         String servicePath = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
@@ -979,9 +1025,11 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
+        String viewer = null; // default
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl));
+                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
+                viewer));
         String entity = "veryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
                 + "ooooogEntity";
         
@@ -1009,7 +1057,7 @@ public class NGSICKANSinkTest {
     private Context createContext(String apiKey, String attrPersistence, String backendMaxConns,
             String backendMaxConnsPerRoute, String batchSize, String batchTime, String batchTTL, String dataModel,
             String enableEncoding, String enableGrouping, String enableLowercase, String host, String port,
-            String ssl) {
+            String ssl, String viewer) {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("attr_persistence", attrPersistence);
@@ -1020,6 +1068,7 @@ public class NGSICKANSinkTest {
         context.put("batch_ttl", batchTTL);
         context.put("ckan_host", host);
         context.put("ckan_port", port);
+        context.put("ckan_viewer", viewer);
         context.put("data_model", dataModel);
         context.put("enable_encoding", enableEncoding);
         context.put("enable_grouping", enableGrouping);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -222,16 +222,16 @@ public class NGSICKANSinkTest {
     } // testConfigureDefaults
     
     /**
-     * [NGSICKANSink.configure] -------- backend.max_conns gets the configured value.
+     * [NGSICKANSink.configure] -------- Parameters get the configured value.
      */
     @Test
-    public void testConfigureMaxConns() {
+    public void testConfigureGetConfiguration() {
         System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                + "-------- backend.max_conns gets the configured value");
+                + "-------- Parameters gets the configured value");
         String apiKey = null; // default
         String attrPersistence = null; // default
         String backendMaxConns = "25";
-        String backendMaxConnsPerRoute = null; // default
+        String backendMaxConnsPerRoute = "3";
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
@@ -242,7 +242,7 @@ public class NGSICKANSinkTest {
         String host = null; // default
         String port = null; // default
         String ssl = null; // default
-        String viewer = null; // default
+        String viewer = "recline_view";
         NGSICKANSink sink = new NGSICKANSink();
         sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
                 batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
@@ -257,34 +257,6 @@ public class NGSICKANSinkTest {
                     + "- FAIL - 'backend.max_conns=25' was not configured");
             throw e;
         } // try catch
-    } // testConfigureMaxConns
-    
-    /**
-     * [NGSICKANSink.configure] -------- backend.max_conns_per_route gets the configured value.
-     */
-    @Test
-    public void testConfigureMaxConnsPerRoute() {
-        System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
-                + "-------- backend.max_conns_per_route gets the configured value");
-        String apiKey = null; // default
-        String attrPersistence = null; // default
-        String backendMaxConns = null; // default
-        String backendMaxConnsPerRoute = "3";
-        String batchSize = null; // default
-        String batchTime = null; // default
-        String batchTTL = null; // default
-        String dataModel = null; // default
-        String enableEncoding = "falso";
-        String enableGrouping = null; // default
-        String enableLowercase = null; // default
-        String host = null; // default
-        String port = null; // default
-        String ssl = null; // default
-        String viewer = null; // default
-        NGSICKANSink sink = new NGSICKANSink();
-        sink.configure(createContext(apiKey, attrPersistence, backendMaxConns, backendMaxConnsPerRoute, batchSize,
-                batchTime, batchTTL, dataModel, enableEncoding, enableGrouping, enableLowercase, host, port, ssl,
-                viewer));
         
         try {
             assertEquals(3, sink.getBackendMaxConnsPerRoute());
@@ -295,7 +267,17 @@ public class NGSICKANSinkTest {
                     + "- FAIL - 'backend.max_conns_per_route=3' was not configured");
             throw e;
         } // try catch
-    } // testConfigureMaxConnsPerRoute
+        
+        try {
+            assertEquals("recline_view", sink.getCKANViewer());
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "-  OK  - 'ckan_viewer=recline_view' was configured");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICKANSink.configure]")
+                    + "- FAIL - 'ckan_viewer=recline_view' was not configured");
+            throw e;
+        } // try catch
+    } // testConfigureGetConfiguration
     
     /**
      * [NGSICKANSink.configure] -------- enable_encoding can only be 'true' or 'false'.

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
@@ -329,6 +329,7 @@ NOTE: `curl` is a Unix command allowing for interacting with REST APIs such as t
 | attr\_persistence | no | row | <i>row</i> or <i>column.</i>|
 | ckan\_host | no | localhost | FQDN/IP address where the CKAN server runs. ||
 | ckan\_port | no | 80 ||
+| ckan\_viewer | no | recline\_grid\_view | Please check the [available](http://docs.ckan.org/en/latest/maintaining/data-viewer.html) viewers at CKAN documentation. |
 | ssl | no | false ||
 | api\_key | yes | N/A ||
 | orion\_url | no | http://localhost:1026 | To be put as the filestore URL. |
@@ -353,6 +354,7 @@ A configuration example could be:
     cygnus-ngsi.sinks.ckan-sink.attr_persistence = column
     cygnus-ngsi.sinks.ckan-sink.ckan_host = 192.168.80.34
     cygnus-ngsi.sinks.ckan-sink.ckan_port = 80
+    cygnus-ngsi.sinks.ckan-sink.ckan_viewer = recline_grid_view
     cygnus-ngsi.sinks.ckan-sink.ssl = false
     cygnus-ngsi.sinks.ckan-sink.api_key = myapikey
     cygnus-ngsi.sinks.ckan-sink.orion_url = http://localhost:1026

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -128,6 +128,8 @@ cygnus-ngsi.sinks.ckan-sink.api_key = ckanapikey
 #cygnus-ngsi.sinks.ckan-sink.ckan_host = x.y.z.w
 # the port for the CKAN API endpoint
 #cygnus-ngsi.sinks.ckan-sink.ckan_port = 80
+# the viewer attached to the created resources
+#cygnus-ngsi.sinks.ckan-sink.ckan_viewer = recline_grid_view
 # Orion URL used to compose the resource URL with the convenience operation URL to query it
 #cygnus-ngsi.sinks.ckan-sink.orion_url = http://localhost:1026
 # how the attributes are stored, either per row either per column (row, column)


### PR DESCRIPTION
* Implements issue #1258 
* 100% unit tests passed:
`cygnus-common`:
```
Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
```

`cygnus-ngsi`:
```
Tests run: 248, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[NGSICKANSink.configure] -------------------------------------------- When not configured, not mandatory parameters get default values
[NGSICKANSink.configure] -------------------------------------  OK  - 'ckan_viewer=recline_grid_view' configured by default
[NGSICKANSink.configure] -------------------------------------------- Parameters gets the configured value
[NGSICKANSink.configure] -------------------------------------  OK  - 'ckan_viewer=recline_view' was configured
```

* (unofficial) e2e tests passed:

Default value, but not used because a view is created automatically:
```
time=2016-10-26T14:21:34.838UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=configure | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[195] : [ckan-sink] Reading configuration (ckan_viewer=recline_grid_view)
..
..
time=2016-10-26T14:22:13.016UTC | lvl=INFO | corr=cfb4c004-f80c-424e-8fbc-7960336379bf | trans=cfb4c004-f80c-424e-8fbc-7960336379bf | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (cfb4c004-f80c-424e-8fbc-7960336379bf)
time=2016-10-26T14:22:13.017UTC | lvl=INFO | corr=cfb4c004-f80c-424e-8fbc-7960336379bf | trans=cfb4c004-f80c-424e-8fbc-7960336379bf | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room2"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-10-26T14:22:20.122UTC | lvl=INFO | corr=cfb4c004-f80c-424e-8fbc-7960336379bf | trans=cfb4c004-f80c-424e-8fbc-7960336379bf | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[446] : [ckan-sink] Persisting data at NGSICKANSink (orgName=default, pkgName=default_any, resName=room2_room, data={"recvTimeTs": "1477491733","recvTime": "2016-10-26T14:22:13.19Z","fiwareServicePath": "/any","entityId": "Room2","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"})
time=2016-10-26T14:22:25.692UTC | lvl=INFO | corr=cfb4c004-f80c-424e-8fbc-7960336379bf | trans=cfb4c004-f80c-424e-8fbc-7960336379bf | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (cfb4c004-f80c-424e-8fbc-7960336379bf)
..
..
$ curl -X POST "http://demo.ckan.org/api/3/action/resource_view_list" -d '{"id":"cbf8254b-de5d-4361-bb0b-8f37b3a51fad"}'
{"help": "http://demo.ckan.org/api/3/action/help_show?name=resource_view_list", "success": true, "result": [{"description": "", "title": "Data Explorer", "resource_id": "cbf8254b-de5d-4361-bb0b-8f37b3a51fad", "view_type": "recline_view", "id": "11208507-6474-4709-8961-397608893ee5", "package_id": "473258a6-4842-4b1b-8250-7713e0566851"}]}
```

Configured value:
```
time=2016-10-26T14:09:35.482UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=configure | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[195] : [ckan-sink] Reading configuration (ckan_viewer=recline_view)
..
..
time=2016-10-26T14:01:16.474UTC | lvl=INFO | corr=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | trans=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (44237263-8d6b-40d2-af39-5ec3f4bbbdfb)
time=2016-10-26T14:01:16.476UTC | lvl=INFO | corr=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | trans=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room3"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-10-26T14:01:34.562UTC | lvl=INFO | corr=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | trans=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[446] : [ckan-sink] Persisting data at NGSICKANSink (orgName=default, pkgName=default_any, resName=room3_room, data={"recvTimeTs": "1477490476","recvTime": "2016-10-26T14:01:16.478Z","fiwareServicePath": "/any","entityId": "Room3","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"})
time=2016-10-26T14:01:39.502UTC | lvl=INFO | corr=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | trans=44237263-8d6b-40d2-af39-5ec3f4bbbdfb | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (44237263-8d6b-40d2-af39-5ec3f4bbbdfb)
..
..
$ curl -X POST "http://demo.ckan.org/api/3/action/resource_view_list" -d '{"id":"4b5ddfb7-e7f3-4dc8-8da0-970e42a25d83"}'
{"help": "http://demo.ckan.org/api/3/action/help_show?name=resource_view_list", "success": true, "result": [{"description": "", "title": "Data Explorer", "resource_id": "4b5ddfb7-e7f3-4dc8-8da0-970e42a25d83", "view_type": "recline_view", "id": "29295570-dba8-4cb0-9626-ce585aa2cb58", "package_id": "473258a6-4842-4b1b-8250-7713e0566851"}]}
```