### PR TITLE
hardening/1243_fix_condition_check_no_applicationjson_content_type

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -275,7 +275,7 @@ public abstract class HttpBackend {
                     httpRes.getStatusLine().getReasonPhrase(), null);
             } // if
             
-            if (!httpRes.getHeaders("Content-Type")[0].getValue().contains("application\\/json")) {
+            if (!httpRes.getHeaders("Content-Type")[0].getValue().contains("application/json")) {
                 return new JsonResponse(null, httpRes.getStatusLine().getStatusCode(),
                     httpRes.getStatusLine().getReasonPhrase(), null);
             } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -275,7 +275,7 @@ public abstract class HttpBackend {
                     httpRes.getStatusLine().getReasonPhrase(), null);
             } // if
             
-            if (httpRes.getHeaders("Content-Type")[0].getValue().contains("application\\/json")) {
+            if (!httpRes.getHeaders("Content-Type")[0].getValue().contains("application\\/json")) {
                 return new JsonResponse(null, httpRes.getStatusLine().getStatusCode(),
                     httpRes.getStatusLine().getReasonPhrase(), null);
             } // if


### PR DESCRIPTION
* Re-fixes issue #1243 
* 100% unit tests passed:
```
Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[HttpBackend.createJsonResponse] ------------------------------------ A JsonResponse object is not created if the content-type header does not contains 'application/json'
[HttpBackend.createJsonResponse] -----------------------------  OK  - The JsonResponse object could not be created with a 'text/html' content type header
```
* (unofficial) e2e tests passed:

CKAN:
```
time=2016-10-27T16:02:41.035UTC | lvl=INFO | corr=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | trans=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (64173235-a3b4-45ec-a3e8-2b3c39ae5fb5)
time=2016-10-27T16:02:41.036UTC | lvl=INFO | corr=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | trans=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-10-27T16:02:49.783UTC | lvl=INFO | corr=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | trans=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[446] : [ckan-sink] Persisting data at NGSICKANSink (orgName=default, pkgName=default_any, resName=room1_room, data={"recvTimeTs": "1477584161","recvTime": "2016-10-27T16:02:41.46Z","fiwareServicePath": "/any","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"})
time=2016-10-27T16:02:52.013UTC | lvl=INFO | corr=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | trans=64173235-a3b4-45ec-a3e8-2b3c39ae5fb5 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (64173235-a3b4-45ec-a3e8-2b3c39ae5fb5)
```
![ckan_test](https://cloud.githubusercontent.com/assets/3865056/19775444/ad789086-9c70-11e6-9b66-3e37895c3635.png)


HDFS:
```
time=2016-10-27T16:03:48.288UTC | lvl=INFO | corr=c3a73480-35b5-4595-b88d-668b13698878 | trans=c3a73480-35b5-4595-b88d-668b13698878 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (c3a73480-35b5-4595-b88d-668b13698878)
time=2016-10-27T16:03:48.289UTC | lvl=INFO | corr=c3a73480-35b5-4595-b88d-668b13698878 | trans=c3a73480-35b5-4595-b88d-668b13698878 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-10-27T16:03:59.458UTC | lvl=INFO | corr=c3a73480-35b5-4595-b88d-668b13698878 | trans=c3a73480-35b5-4595-b88d-668b13698878 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[986] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (default/any/Room1_Room/Room1_Room.txt), Data ({"recvTimeTs":"1477584228","recvTime":"2016-10-27T16:03:48.292Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-10-27T16:04:01.623UTC | lvl=INFO | corr=c3a73480-35b5-4595-b88d-668b13698878 | trans=c3a73480-35b5-4595-b88d-668b13698878 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (c3a73480-35b5-4595-b88d-668b13698878)
..
..
$ sudo -u frb hadoop fs -cat /user/frb/default/any/Room1_Room/Room1_Room.txt
{"recvTimeTs":"1477584228","recvTime":"2016-10-27T16:03:48.292Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```