### PR TITLE
bug/1243_change_cygnus_error_ckan_with_no_200

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -21,7 +21,7 @@ package com.telefonica.iot.cygnus.backends.ckan;
 import com.telefonica.iot.cygnus.backends.http.JsonResponse;
 import com.telefonica.iot.cygnus.backends.http.HttpBackend;
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
-import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class CKANCache extends HttpBackend {
     
     /**
      * Constructor.
-     * @param hosts
+     * @param host
      * @param port
      * @param ssl
      * @param apiKey
@@ -196,7 +196,8 @@ public class CKANCache extends HttpBackend {
         } else if (res.getStatusCode() == 404) {
             return false;
         } else {
-            throw new CygnusRuntimeError("Don't know how to treat response code " + res.getStatusCode() + ")");
+            throw new CygnusPersistenceError("Could not check if the organization exists ("
+                    + "orgName=" + orgName + ", statusCode=" + res.getStatusCode() + ")");
         } // if else
     } // isCachedOrg
     
@@ -252,7 +253,8 @@ public class CKANCache extends HttpBackend {
         } else if (res.getStatusCode() == 404) {
             return false;
         } else {
-            throw new CygnusRuntimeError("Don't know how to treat response code " + res.getStatusCode() + ")");
+            throw new CygnusPersistenceError("Could not check if the package exists ("
+                    + "orgName=" + orgName + ", pkgName=" + pkgName + ", statusCode=" + res.getStatusCode() + ")");
         } // if else
     } // isCachedPkg
     
@@ -318,10 +320,11 @@ public class CKANCache extends HttpBackend {
                 } // if else
             } // if else
         } else if (res.getStatusCode() == 404) {
-            throw new CygnusRuntimeError("Unexpected package error when updating its resources... the package was "
-                    + "supposed to exist!");
+            return false;
         } else {
-            throw new CygnusRuntimeError("Don't know how to treat response code " + res.getStatusCode() + ")");
+            throw new CygnusPersistenceError("Could not check if the resource exists ("
+                    + "orgName=" + orgName + ", pkgName=" + pkgName + ", resName=" + resName
+                    + ", statusCode=" + res.getStatusCode() + ")");
         } // if else
     } // isCachedRes
 


### PR DESCRIPTION
* Re-fixes issue #1243 (the issue was re-opened)
** No CHANGES_NEXT_RELEASE update is required  
* 100% unit tests passed:
```
Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

```
time=2016-10-28T11:56:01.935UTC | lvl=INFO | corr=5c145389-02ce-429c-9b7a-11b116a94086 | trans=5c145389-02ce-429c-9b7a-11b116a94086 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (5c145389-02ce-429c-9b7a-11b116a94086)
time=2016-10-28T11:56:01.936UTC | lvl=INFO | corr=5c145389-02ce-429c-9b7a-11b116a94086 | trans=5c145389-02ce-429c-9b7a-11b116a94086 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-10-28T11:56:24.098UTC | lvl=INFO | corr=5c145389-02ce-429c-9b7a-11b116a94086 | trans=5c145389-02ce-429c-9b7a-11b116a94086 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICKANSink[446] : [ckan-sink] Persisting data at NGSICKANSink (orgName=default, pkgName=default_any, resName=room1_room, data={"recvTimeTs": "1477655761","recvTime": "2016-10-28T11:56:01.953Z","fiwareServicePath": "/any","entityId": "Room1","entityType": "Room","attrName": "temperature","attrType": "centigrade","attrValue": "26.5"})
time=2016-10-28T11:56:27.577UTC | lvl=INFO | corr=5c145389-02ce-429c-9b7a-11b116a94086 | trans=5c145389-02ce-429c-9b7a-11b116a94086 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (5c145389-02ce-429c-9b7a-11b116a94086)
```
![ckan_test](https://cloud.githubusercontent.com/assets/3865056/19805748/88e72e48-9d16-11e6-9f1a-74c3d80129e7.png)
