### PR TITLE
hardening/1261_add_ipv6_support

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - [cygnus-ngsi][hardening] Update migration script for HDFS regarding new encoding (#1271)
-
+- [cygnus-common][hardening] Add IPv6 support (#1261)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - [cygnus-ngsi][hardening] Update migration script for HDFS regarding new encoding (#1271)
-- [cygnus-common][hardening] Add IPv6 support (#1261)
+- [cygnus-common][hardening] Add IPv6 support to API and GUI (#1261)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
@@ -37,21 +37,30 @@ public class JettyServer extends Thread {
      * @param mgmtIfPort
      * @param guiPort
      * @param handler
+     * @param ipv6
      */
-    public JettyServer(int mgmtIfPort, int guiPort, AbstractHandler handler) {
+    public JettyServer(int mgmtIfPort, int guiPort, AbstractHandler handler, boolean ipv6) {
         // create the server
         server = new Server();
         
         // add the Management Interface connector
         SelectChannelConnector conn1 = new SelectChannelConnector();
-        conn1.setHost("0.0.0.0");
+        if (ipv6) {
+            conn1.setHost("::0");
+        } else {
+            conn1.setHost("0.0.0.0");
+        }
         conn1.setPort(mgmtIfPort);
         server.addConnector(conn1);
         
         if (guiPort != 0) {
             // add the GUI connector
             SelectChannelConnector conn2 = new SelectChannelConnector();
-            conn2.setHost("0.0.0.0");
+            if (ipv6) {
+                conn2.setHost("0.0.0.0");
+            } else {
+                conn2.setHost("::0");
+            }
             conn2.setPort(guiPort);
             server.addConnector(conn2);
         } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/http/JettyServer.java
@@ -45,22 +45,26 @@ public class JettyServer extends Thread {
         
         // add the Management Interface connector
         SelectChannelConnector conn1 = new SelectChannelConnector();
+        
         if (ipv6) {
             conn1.setHost("::0");
         } else {
             conn1.setHost("0.0.0.0");
-        }
+        } // if else
+        
         conn1.setPort(mgmtIfPort);
         server.addConnector(conn1);
         
         if (guiPort != 0) {
             // add the GUI connector
             SelectChannelConnector conn2 = new SelectChannelConnector();
+            
             if (ipv6) {
-                conn2.setHost("0.0.0.0");
-            } else {
                 conn2.setHost("::0");
-            }
+            } else {
+                conn2.setHost("0.0.0.0");
+            } // if else
+            
             conn2.setPort(guiPort);
             server.addConnector(conn2);
         } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -195,6 +195,9 @@ public class CygnusApplication extends Application {
             option = new Option("t", "polling-interval", true, "polling interval");
             option.setRequired(false);
             options.addOption(option);
+            
+            option = new Option("6", "ipv6", false, "use ipv6 instead ipv4");
+            options.addOption(option);
 
             // Read the options
             CommandLineParser parser = new GnuParser();
@@ -229,6 +232,12 @@ public class CygnusApplication extends Application {
             
             if (commandLine.hasOption('t')) {
                 pollingInterval = new Integer(commandLine.getOptionValue('t'));
+            } // if
+            
+            boolean ipv6 = false;
+            
+            if (commandLine.hasOption('6')) {
+                ipv6 = true;
             } // if
             
             // the following is to ensure that by default the agent will fail on startup if the file does not exist
@@ -286,9 +295,13 @@ public class CygnusApplication extends Application {
             } // try catch
             
             // start the Management Interface, passing references to Flume components
-            LOGGER.info("Starting a Jetty server listening on port " + apiPort + " (Management Interface)");
+            if (ipv6) {
+                LOGGER.info("Starting a Jetty server listening on ::0:" + apiPort + " (Management Interface)");
+            } else {
+                LOGGER.info("Starting a Jetty server listening on 0.0.0.0:" + apiPort + " (Management Interface)");
+            }
             mgmtIfServer = new JettyServer(apiPort, guiPort, new ManagementInterface(configurationPath,
-                    configurationFile, sourcesRef, channelsRef, sinksRef, apiPort, guiPort));
+                    configurationFile, sourcesRef, channelsRef, sinksRef, apiPort, guiPort), ipv6);
             mgmtIfServer.start();
 
             // create a hook "listening" for shutdown interrupts (runtime.exit(int), crtl+c, etc)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/nodes/CygnusApplication.java
@@ -299,7 +299,8 @@ public class CygnusApplication extends Application {
                 LOGGER.info("Starting a Jetty server listening on ::0:" + apiPort + " (Management Interface)");
             } else {
                 LOGGER.info("Starting a Jetty server listening on 0.0.0.0:" + apiPort + " (Management Interface)");
-            }
+            } // if else
+            
             mgmtIfServer = new JettyServer(apiPort, guiPort, new ManagementInterface(configurationPath,
                     configurationFile, sourcesRef, channelsRef, sinksRef, apiPort, guiPort), ipv6);
             mgmtIfServer.start();


### PR DESCRIPTION
* Fix issue #1261 
* Starting Cygnus with `-6` option:
```
$ bin/cygnus-flume-ng agent --conf conf -f conf/agent_mysql.conf -n cygnus-ngsi -6 -Dflume.root.logger=DEBUG,console -Duser.timezone=UTC
time=2016-11-03T08:58:20.643UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=Cygnus | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[299] : Starting a Jetty server listening on ::0:8081 (Management Interface)
```
* Starting Cygnus without `-6` option:
```
$ bin/cygnus-flume-ng agent --conf conf -f conf/agent_mysql.conf -n cygnus-ngsi -Dflume.root.logger=DEBUG,console -Duser.timezone=UTC
time=2016-11-03T08:58:20.643UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=Cygnus | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[299] : Starting a Jetty server listening on 0.0.0.0:8081 (Management Interface)
```
* Assignee: @frbattid 