### PR TITLE
feature/1275_geojson_support_ngsicartodbsink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - [cygnus-ngsi][hardening] Update migration script for HDFS regarding new encoding (#1271)
-
+- [cygnus-ngsi][feature] Add support for geo:json Orion's type in NGSICartoDBSink (#1275)

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
@@ -18,6 +18,7 @@
 package com.telefonica.iot.cygnus.utils;
 
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.json.simple.JSONArray;
@@ -39,42 +40,43 @@ public class NGSIUtilsTest {
     } // NGSIUtilsTest
     
     /**
-     * [NGSIUtils.getLocation] -------- When getting a location, a CartoDB point is obtained when passing
+     * [NGSIUtils.getGeometry] -------- When getting a geometry, a CartoDB point is obtained when passing
      * an attribute of type 'geo:point'.
      */
     @Test
-    public void testGetLocationType() {
+    public void testGetGeometryGeopoint() {
         System.out.println(getTestTraceHead("[Utils.getLocation]")
-                + "-------- When getting a location, a CartoDB point is obtained when passing an attribute "
+                + "-------- When getting a geometry, a CartoDB point is obtained when passing an attribute "
                 + "of type 'geo:point'");
         String attrMetadataStr = "[]";
         String attrValue = "-3.7167, 40.3833";
         String attrType = "geo:point";
         boolean flipCoordinates = false; // irrelevant for this test
-        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+        ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
+                attrValue, attrType, attrMetadataStr, flipCoordinates);
 
         try {
-            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", location);
+            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", geometry.getLeft());
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "-  OK  - Location '" + location + "' obtained for an attribute of type '" + attrType
+                    + "-  OK  - Geometry '" + geometry.getLeft() + "' obtained for an attribute of type '" + attrType
                     + "' and value '" + attrValue + "'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "- FAIL - Location '" + location + "' obtained for an attribute of type '" + attrType
+                    + "- FAIL - Geometry '" + geometry.getLeft() + "' obtained for an attribute of type '" + attrType
                     + "' and value '" + attrValue + "'");
             throw e;
-        } // try catch
-    } // testGetLocationType
+        } // try catch // try catch
+    } // testGetGeometryGeopoint
     
     /**
-     * [NGSIUtils.getLocation] -------- When getting a location, a CartoDB point is obtained when passing
-     * an attribute of type 'geo:point'.
+     * [NGSIUtils.getGeometry] -------- When getting a geometry, a CartoDB point is obtained when passing
+     * an attribute with 'geometry' metadata.
      */
     @Test
-    public void testGetLocationMetadata() {
+    public void testGetGeometryMetadata() {
         System.out.println(getTestTraceHead("[Utils.getLocation]")
-                + "-------- When getting a location, a CartoDB point is obtained when passing an attribute "
-                + "of type 'geo:point'");
+                + "-------- When getting a geometry, a CartoDB point is obtained when passing an attribute "
+                + "with 'location' metadata");
         JSONObject metadataJson = new JSONObject();
         metadataJson.put("name", "location");
         metadataJson.put("type", "string");
@@ -85,45 +87,76 @@ public class NGSIUtilsTest {
         String attrValue = "-3.7167, 40.3833";
         String attrType = "coordinates"; // irrelevant for this test
         boolean flipCoordinates = false; // irrelevant for this test
-        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+        ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
+                attrValue, attrType, attrMetadataStr, flipCoordinates);
 
         try {
-            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", location);
+            assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", geometry.getLeft());
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "-  OK  - Location '" + location + "' obtained for an attribute with metadata '"
+                    + "-  OK  - Geometry '" + geometry.getLeft() + "' obtained for an attribute with metadata '"
                     + attrMetadataStr + "' and value '" + attrValue + "'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "- FAIL - Location '" + location + "' obtained for an attribute with metadata '"
+                    + "- FAIL - Geometry '" + geometry.getLeft() + "' obtained for an attribute with metadata '"
                     + attrMetadataStr + "' and value '" + attrValue + "'");
             throw e;
-        } // try catch
-    } // testGetLocationMetadata
+        } // try catch // try catch
+    } // testGetGeometryMetadata
     
     /**
-     * [NGSIUtils.getLocation] -------- When getting a location, the original attribute is returned when the
-     * attribute type is not geo:point and there is no WGS84 location metadata.
+     * [NGSIUtils.getGeometry] -------- When getting a geometry, the original attribute is returned when the
+     * attribute type is not geo:point and there is no WGS84 geometry metadata.
      */
     @Test
-    public void testGetLocationNoGeolocation() {
+    public void testGetGeometryNoGeolocation() {
         System.out.println(getTestTraceHead("[Utils.getLocation]")
-                + "-------- When getting a location, the original attribute is returned when the attribute "
+                + "-------- When getting a geometry, the original attribute is returned when the attribute "
                 + "type is not geo:point and there is no WGS84 location metadata");
         String attrMetadataStr = "[]";
         String attrValue = "-3.7167, 40.3833";
         String attrType = "coordinates";
         boolean flipCoordinates = false; // irrelevant for this test
-        String location = NGSIUtils.getLocation(attrValue, attrType, attrMetadataStr, flipCoordinates);
+        ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
+                attrValue, attrType, attrMetadataStr, flipCoordinates);
 
         try {
-            assertEquals(attrValue, location);
+            assertEquals(attrValue, geometry.getLeft());
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "-  OK  - Location '" + location + "' obtained for a not geolocated attribute");
+                    + "-  OK  - Geometry '" + geometry.getLeft() + "' obtained for a not geolocated attribute");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[Utils.getLocation]")
-                    + "- FAIL - Location '" + location + "' obtained for a not geolocated attribute");
+                    + "- FAIL - Geometry '" + geometry.getLeft() + "' obtained for a not geolocated attribute");
             throw e;
-        } // try catch
-    } // testGetLocationNoGeolocation
+        } // try catch // try catch
+    } // testGetGeometryNoGeolocation
+    
+    /**
+     * [NGSIUtils.getGeometry] -------- When getting a geometry, a CartoDB geometry is obtained when passing
+     * an attribute of type 'geo:json'.
+     */
+    @Test
+    public void testGetGeometryGeojson() {
+        System.out.println(getTestTraceHead("[Utils.getLocation]")
+                + "-------- When getting a geometry, a CartoDB geometry is obtained when passing an attribute "
+                + "of type 'geo:json'");
+        String attrMetadataStr = "[]";
+        String attrValue = "{\"coordinates\": [-3.7167, 40.3833], \"type\": \"Point\"}";
+        String attrType = "geo:json";
+        boolean flipCoordinates = false; // irrelevant for this test
+        ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
+                attrValue, attrType, attrMetadataStr, flipCoordinates);
+
+        try {
+            assertEquals("ST_GeomFromGeoJSON('{\"coordinates\": [-3.7167, 40.3833], \"type\": \"Point\"}')", geometry.getLeft());
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "-  OK  - Geometry '" + geometry.getLeft() + "' obtained for an attribute of type '" + attrType
+                    + "' and value '" + attrValue + "'");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[Utils.getLocation]")
+                    + "- FAIL - Geometry '" + geometry.getLeft() + "' obtained for an attribute of type '" + attrType
+                    + "' and value '" + attrValue + "'");
+            throw e;
+        } // try catch // try catch
+    } // testGetGeometryGeojson
 
 } // NGSIUtilsTest

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -542,22 +542,22 @@ Authentication is done by means of an API key related to the username. Once auth
 ###<a name="section4.1"></a>Annex 1: provisioning a table in Carto
 Following you may find the queries required to provision a table in Carto. Start by creating the table:
 
-    $ curl -G "https://iotsupport.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=CREATE TABLE <table_name> (recvTime text, fiwareServicePath text, entityId text, entityType text, <attr_1> <type_1>, <attr_1>_md text, ..., <attr_n> <type_n>, <attr_n>_md text, the_geom geometry(POINT,4326))"
+    $ curl -G "https://<my_user>.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=CREATE TABLE <table_name> (recvTime text, fiwareServicePath text, entityId text, entityType text, <attr_1> <type_1>, <attr_1>_md text, ..., <attr_n> <type_n>, <attr_n>_md text, the_geom geometry(POINT,4326))"
 
 Every table in Carto has to be <i>cartodbfied</i>, if you want it appears in Carto web-based dashboard:
 
-    $ curl -G "https://iotsupport.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=SELECT CDB_CartodbfyTable('<my_user_or_schema>', '<table_name>')"
+    $ curl -G "https://<my_user>.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=SELECT CDB_CartodbfyTable('<my_user_or_schema>', '<table_name>')"
 
 Now, you should be able to insert some data (just for testing purpose, since Cygnus will be in charge of this part):
 
-    $ curl -G "https://iotsupport.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=INSERT INTO <table_name> (recvTime, fiwareServicePath, entityId, entityType, <attr_1>, <attr_1>_md, ..., <attr_n>, <attr_n>_md, the_geom) VALUES ('2016-04-19T07:09:53.116Z', '<service_path>', '<entity_id>', '<entity_type>', '<attr_1_value>', '<attr_1_metadata>', ..., '<attr_n_value>', '<attr_n_metadata>', 'ST_SetSRID(ST_MakePoint(<lat>, <lon>), 4326))"
+    $ curl -G "https://<my_user>.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=INSERT INTO <table_name> (recvTime, fiwareServicePath, entityId, entityType, <attr_1>, <attr_1>_md, ..., <attr_n>, <attr_n>_md, the_geom) VALUES ('2016-04-19T07:09:53.116Z', '<service_path>', '<entity_id>', '<entity_type>', '<attr_1_value>', '<attr_1_metadata>', ..., '<attr_n_value>', '<attr_n_metadata>', 'ST_SetSRID(ST_MakePoint(<lat>, <lon>), 4326))"
 
 You can query the data as:
 
-    $ curl -G "https://iotsupport.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=SELECT * FROM <table_name>"
+    $ curl -G "https://<my_user>.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=SELECT * FROM <table_name>"
 
 For completeness, let's see how to delete a table:
 
-    $ curl -G "https://iotsupport.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=DROP TABLE <table_name>"
+    $ curl -G "https://<my_user>.cartodb.com/api/v2/sql?api_key=<api_key>" --data-urlencode "q=DROP TABLE <table_name>"
 
 [Top](#top)


### PR DESCRIPTION
* Implements issue #1275 
* 100% unit tests passed:

`cygnus-ngsi`:
```
Tests run: 249, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[Utils.getLocation] ------------------------------------------------- When getting a geometry, a CartoDB geometry is obtained when passing an attribute of type 'geo:json'
[Utils.getLocation] ------------------------------------------  OK  - Geometry 'ST_GeomFromGeoJSON('{"coordinates": [-3.7167, 40.3833], "type": "Point"}')' obtained for a
```

* (unofficial) e2e tests passed:
```
https://iotsupport.cartodb.com/api/v2/sql?q=CREATE TABLE x002ftestxffffx0043ar1_x0043ar (recvTime text, fiwareServicePath text, entityId text, entityType text, temperature float, temperature_md text, the_geom geometry(POINT,0))&api_key=xxxxx
{"rows":[],"time":0.007,"fields":{},"total_rows":0}
..
..
time=2016-11-03T15:30:01.267UTC | lvl=INFO | corr=db77ed45-0c22-48a0-aac3-8cd890c04635 | trans=db77ed45-0c22-48a0-aac3-8cd890c04635 | srv=iotsupport | subsrv=/test | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (db77ed45-0c22-48a0-aac3-8cd890c04635)
time=2016-11-03T15:30:01.269UTC | lvl=INFO | corr=db77ed45-0c22-48a0-aac3-8cd890c04635 | trans=db77ed45-0c22-48a0-aac3-8cd890c04635 | srv=iotsupport | subsrv=/test | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          },          {            "name" : "the_geom",            "type" : "geo:json",            "value" : {                                "coordinates": [                                    -4.423032856,                                    36.721290055                                ],                                "type": "Point"                            }          }        ],        "type" : "Car",        "isPattern" : "false",        "id" : "Car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-03T15:30:12.582UTC | lvl=INFO | corr=db77ed45-0c22-48a0-aac3-8cd890c04635 | trans=db77ed45-0c22-48a0-aac3-8cd890c04635 | srv=iotsupport | subsrv=/test | comp=cygnus-ngsi | op=persistRawAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[501] : [raw-sink] Persisting data at NGSICartoDBSink. Schema (iotsupport), Table (x002ftestxffffx0043ar1_x0043ar), Data (('2016-11-03T15:30:01.271Z','/test','Car1','Car',ST_GeomFromGeoJSON('{"coordinates":[-4.423032856,36.721290055],"type":"Point"}'),'26.5','[]'))
time=2016-11-03T15:30:13.634UTC | lvl=INFO | corr=db77ed45-0c22-48a0-aac3-8cd890c04635 | trans=db77ed45-0c22-48a0-aac3-8cd890c04635 | srv=iotsupport | subsrv=/test | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[548] : Finishing internal transaction (db77ed45-0c22-48a0-aac3-8cd890c04635)
..
..
https://iotsupport.cartodb.com/api/v2/sql?q=select%20*%20from%20x002ftestxffffx0043ar1_x0043ar&api_key=xxxxx
{"rows":[{"recvtime":"2016-11-03T15:30:01.271Z","fiwareservicepath":"/test","entityid":"Car1","entitytype":"Car","temperature":26.5,"temperature_md":"[]","the_geom":"0101000000299D66862FB111C0D893863B535C4240"}],"time":0.002,"fields":{"recvtime":{"type":"string"},"fiwareservicepath":{"type":"string"},"entityid":{"type":"string"},"entitytype":{"type":"string"},"temperature":{"type":"number"},"temperature_md":{"type":"string"},"the_geom":{"type":"geometry"}},"total_rows":1}
```