### PR TITLE
hardening/1280_produce_ngsievent_at_grouping_rules

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - [cygnus-ngsi][hardening] Update migration script for HDFS regarding new encoding (#1271)
 - [cygnus-ngsi][feature] Add support for geo:json Orion's type in NGSICartoDBSink (#1275)
 - [cygnus-common][hardening] Add IPv6 support to API and GUI (#1261)
+- [cygnus-ngsi][hardening] Produce NGSIEvent's at Grouping Rules interceptor (#1280)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -125,6 +125,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         NGSIEvent ngsiEvent = new NGSIEvent(headers, originalNCR, map.getRight());
         
         // Return the intercepted event
+        LOGGER.debug("[nmi] Event put in the channel, id=" + event.hashCode());
         return ngsiEvent;
     } // intercept
 
@@ -133,7 +134,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         if (invalidConfiguration) {
             return events;
         } else {
-            List<Event> interceptedEvents = new ArrayList<Event>(events.size());
+            List<Event> interceptedEvents = new ArrayList<>(events.size());
         
             for (Event event : events) {
                 Event interceptedEvent = intercept(event);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -493,45 +493,19 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 LOGGER.error("Runtime error (" + e.getMessage() + ")");
             } // catch
 
-            if (event instanceof com.telefonica.iot.cygnus.interceptors.NGSIEvent) {
-                NotifyContextRequest originalNCR =
-                        ((com.telefonica.iot.cygnus.interceptors.NGSIEvent) event).getOriginalNCR();
-                NotifyContextRequest mappedNCR =
-                        ((com.telefonica.iot.cygnus.interceptors.NGSIEvent) event).getMappedNCR();
+            NotifyContextRequest originalNCR =
+                    ((com.telefonica.iot.cygnus.interceptors.NGSIEvent) event).getOriginalNCR();
+            NotifyContextRequest mappedNCR =
+                    ((com.telefonica.iot.cygnus.interceptors.NGSIEvent) event).getMappedNCR();
 
-                // Accumulate the event
-                try {
-                    accumulator.accumulate(event.getHeaders(), originalNCR, mappedNCR);
-                    numProcessedEvents++;
-                } catch (Exception e) {
-                    LOGGER.error("There was some problem when accumulating the notified context element. "
-                            + "Details: " + e.getMessage());
-                } // try catch
-            } else {
-                // 'TODO': to be removed
-                LOGGER.debug("Event got from the channel (id=" + event.hashCode() + ", headers="
-                        + event.getHeaders().toString() + ", bodyLength=" + event.getBody().length + ")");
-
-                // Parse the event
-                NotifyContextRequest notification;
-                
-                try {
-                    notification = parseEventBody(event);
-                } catch (Exception e) {
-                    LOGGER.error("There was some problem when parsing the notified context element. Details: "
-                            + e.getMessage());
-                    continue;
-                } // try catch
-            
-                // Accumulate the event
-                try {
-                    accumulator.accumulate(event.getHeaders(), notification, null);
-                    numProcessedEvents++;
-                } catch (Exception e) {
-                    LOGGER.error("There was some problem when accumulating the notified context element. "
-                            + "Details: " + e.getMessage());
-                } // try catch
-            } // if else
+            // Accumulate the event
+            try {
+                accumulator.accumulate(event.getHeaders(), originalNCR, mappedNCR);
+                numProcessedEvents++;
+            } catch (Exception e) {
+                LOGGER.error("There was some problem when accumulating the notified context element. "
+                        + "Details: " + e.getMessage());
+            } // try catch
         } // for
 
         // save the current index for next run of the process() method
@@ -605,29 +579,6 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
             } // if
         } // if else
     } // doRollback
-    
-    /**
-     * Given an event, it is parsed before it is persisted. Depending on the content type, it is appropriately
-     * parsed (Json or XML) in order to obtain a NotifyContextRequest instance.
-     *
-     * @param event A Flume event containing the data to be persistedDestinations and certain metadata (headers).
-     * @throws Exception
-     */
-    private NotifyContextRequest parseEventBody(Event event) throws Exception {
-        String eventData = new String(event.getBody());
-
-        // parse the event body as a Json document
-        NotifyContextRequest notification = null;
-        Gson gson = new Gson();
-
-        try {
-            notification = gson.fromJson(eventData, NotifyContextRequest.class);
-        } catch (Exception e) {
-            throw new CygnusBadContextData(e.getMessage());
-        } // try catch
-
-        return notification;
-    } // parseEventBody
 
     /**
      * Utility class for batch-like event accumulation purposes.


### PR DESCRIPTION
* Implements issue #1280 
* 100% unit tests passed:

`cygnus-ngsi`:
```
Tests run: 249, Failures: 0, Errors: 0, Skipped: 0
```

* (Unofficial) e2e tests passed:

Using GR, not enabled:
```
time=2016-11-04T10:09:18.193UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header host received with value localhost:5050
time=2016-11-04T10:09:18.194UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-type received with value application/json; charset=utf-8
time=2016-11-04T10:09:18.194UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header accept received with value application/json
time=2016-11-04T10:09:18.194UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header user-agent received with value orion/0.10.0
time=2016-11-04T10:09:18.195UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-service received with value default
time=2016-11-04T10:09:18.195UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-servicepath received with value /any
time=2016-11-04T10:09:18.195UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-length received with value 460
time=2016-11-04T10:09:18.196UTC | lvl=INFO | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (34b212dc-863e-423e-9915-017194727430)
time=2016-11-04T10:09:18.197UTC | lvl=INFO | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-04T10:09:18.197UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[276] : [NGSIRestHandler] Adding flume event header (name=fiware-service, value=default)
time=2016-11-04T10:09:18.197UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[280] : [NGSIRestHandler] Adding flume event header (name=fiware-servicepath, value=/any)
time=2016-11-04T10:09:18.197UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[283] : [NGSIRestHandler] Adding flume event header (name=fiware-correlator, value=34b212dc-863e-423e-9915-017194727430)
time=2016-11-04T10:09:18.198UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[286] : [NGSIRestHandler] Adding flume event header (name=transaction-id, value=34b212dc-863e-423e-9915-017194727430)
time=2016-11-04T10:09:18.199UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[293] : [NGSIRestHandler] Event put in the channel, id=362196722
time=2016-11-04T10:09:18.199UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[86] : [gi] Event intercepted, id=362196722
time=2016-11-04T10:09:18.253UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[102] : [gi] Original NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"Room1","type":"Room","isPattern":"false","attributes":[{"name":"temperature","type":"centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:09:18.254UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[148] : [gi] Adding flume event header (name=notified-entities, value=Room1_Room)
time=2016-11-04T10:09:18.254UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[152] : [gi] Adding flume event header (name=grouped-entities, value=all_rooms)
time=2016-11-04T10:09:18.254UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[156] : [gi] Adding flume event header (name=grouped-servicepaths, value=/any)
time=2016-11-04T10:09:18.255UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[165] : [gi] Event put in the channel, id=362196722
time=2016-11-04T10:09:29.339UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[460] : Batch accumulation time reached, the batch will be processed as it is
time=2016-11-04T10:09:29.339UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[517] : Batch completed, persisting it
time=2016-11-04T10:09:29.340UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[465] : [hdfs-sink] Processing sub-batch regarding the default_/any_Room1_Room destination
time=2016-11-04T10:09:29.343UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[608] : [hdfs-sink] Processing context element (id=Room1, type=Room)
time=2016-11-04T10:09:29.344UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[625] : [hdfs-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-11-04T10:09:29.344UTC | lvl=INFO | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[986] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (default/any/Room1_Room/Room1_Room.txt), Data ({"recvTimeTs":"1478254158","recvTime":"2016-11-04T10:09:18.199Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-11-04T10:09:29.348UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-11-04T10:09:29.978UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:09:29.979UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"FileStatus":{"pathSuffix":"","type":"FILE","length":1272,"owner":"frb","group":"frb","permission":"755","accessTime":1477389562697,"modificationTime":1478254018835,"blockSize":134217728,"replication":3}}
time=2016-11-04T10:09:29.980UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=append&user.name=frb HTTP/1.1
time=2016-11-04T10:09:30.671UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-11-04T10:09:30.671UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:09:30.673UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=APPEND&user.name=frb&data=true HTTP/1.1
time=2016-11-04T10:09:31.415UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:09:31.415UTC | lvl=DEBUG | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:09:31.415UTC | lvl=INFO | corr=34b212dc-863e-423e-9915-017194727430 | trans=34b212dc-863e-423e-9915-017194727430 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[522] : Finishing internal transaction (34b212dc-863e-423e-9915-017194727430)
..
..
$ sudo -u frb hadoop fs -cat /user/frb/default/any/Room1_Room/Room1_Room.txt
{"recvTimeTs":"1478254158","recvTime":"2016-11-04T10:09:18.199Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```

Using GR, enabled:
```
time=2016-11-04T10:11:19.364UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header host received with value localhost:5050
time=2016-11-04T10:11:19.364UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-type received with value application/json; charset=utf-8
time=2016-11-04T10:11:19.364UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header accept received with value application/json
time=2016-11-04T10:11:19.364UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header user-agent received with value orion/0.10.0
time=2016-11-04T10:11:19.365UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-service received with value default
time=2016-11-04T10:11:19.365UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-servicepath received with value /any
time=2016-11-04T10:11:19.365UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-length received with value 460
time=2016-11-04T10:11:19.366UTC | lvl=INFO | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (6f441376-a490-463e-810f-9a02e1bd401e)
time=2016-11-04T10:11:19.367UTC | lvl=INFO | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-04T10:11:19.367UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[276] : [NGSIRestHandler] Adding flume event header (name=fiware-service, value=default)
time=2016-11-04T10:11:19.367UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[280] : [NGSIRestHandler] Adding flume event header (name=fiware-servicepath, value=/any)
time=2016-11-04T10:11:19.368UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[283] : [NGSIRestHandler] Adding flume event header (name=fiware-correlator, value=6f441376-a490-463e-810f-9a02e1bd401e)
time=2016-11-04T10:11:19.368UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[286] : [NGSIRestHandler] Adding flume event header (name=transaction-id, value=6f441376-a490-463e-810f-9a02e1bd401e)
time=2016-11-04T10:11:19.369UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[293] : [NGSIRestHandler] Event put in the channel, id=1894356876
time=2016-11-04T10:11:19.370UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[86] : [gi] Event intercepted, id=1894356876
time=2016-11-04T10:11:19.423UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[102] : [gi] Original NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"Room1","type":"Room","isPattern":"false","attributes":[{"name":"temperature","type":"centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:11:19.423UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[148] : [gi] Adding flume event header (name=notified-entities, value=Room1_Room)
time=2016-11-04T10:11:19.424UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[152] : [gi] Adding flume event header (name=grouped-entities, value=all_rooms)
time=2016-11-04T10:11:19.424UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[156] : [gi] Adding flume event header (name=grouped-servicepaths, value=/any)
time=2016-11-04T10:11:19.424UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSIGroupingInterceptor[165] : [gi] Event put in the channel, id=1894356876
time=2016-11-04T10:11:30.926UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[460] : Batch accumulation time reached, the batch will be processed as it is
time=2016-11-04T10:11:30.927UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[517] : Batch completed, persisting it
time=2016-11-04T10:11:30.927UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[465] : [hdfs-sink] Processing sub-batch regarding the default_/any_all_rooms destination
time=2016-11-04T10:11:30.935UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[608] : [hdfs-sink] Processing context element (id=Room1, type=Room)
time=2016-11-04T10:11:30.935UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[625] : [hdfs-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-11-04T10:11:30.936UTC | lvl=INFO | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[986] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (default/any/all_rooms/all_rooms.txt), Data ({"recvTimeTs":"1478254279","recvTime":"2016-11-04T10:11:19.370Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-11-04T10:11:30.952UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/all_rooms/all_rooms.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-11-04T10:11:31.307UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:11:31.309UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"FileStatus":{"pathSuffix":"","type":"FILE","length":210,"owner":"frb","group":"frb","permission":"755","accessTime":1478253675637,"modificationTime":1478253675682,"blockSize":134217728,"replication":3}}
time=2016-11-04T10:11:31.311UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/all_rooms/all_rooms.txt?op=append&user.name=frb HTTP/1.1
time=2016-11-04T10:11:31.409UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-11-04T10:11:31.410UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:11:31.411UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/all_rooms/all_rooms.txt?op=APPEND&user.name=frb&data=true HTTP/1.1
time=2016-11-04T10:11:31.615UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:11:31.616UTC | lvl=DEBUG | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:11:31.616UTC | lvl=INFO | corr=6f441376-a490-463e-810f-9a02e1bd401e | trans=6f441376-a490-463e-810f-9a02e1bd401e | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[522] : Finishing internal transaction (6f441376-a490-463e-810f-9a02e1bd401e)
..
..
$ sudo -u frb hadoop fs -cat /user/frb/default/any/all_rooms/all_rooms.txt
{"recvTimeTs":"1478254279","recvTime":"2016-11-04T10:11:19.370Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```

Using NM, not enabled:
```
time=2016-11-04T10:13:18.902UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header host received with value localhost:5050
time=2016-11-04T10:13:18.902UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-type received with value application/json; charset=utf-8
time=2016-11-04T10:13:18.902UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header accept received with value application/json
time=2016-11-04T10:13:18.903UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header user-agent received with value orion/0.10.0
time=2016-11-04T10:13:18.903UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-service received with value default
time=2016-11-04T10:13:18.903UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-servicepath received with value /any
time=2016-11-04T10:13:18.903UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-length received with value 460
time=2016-11-04T10:13:18.904UTC | lvl=INFO | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (16d6a076-f593-4cb8-a818-8d162c9651e4)
time=2016-11-04T10:13:18.906UTC | lvl=INFO | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-04T10:13:18.907UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[276] : [NGSIRestHandler] Adding flume event header (name=fiware-service, value=default)
time=2016-11-04T10:13:18.907UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[280] : [NGSIRestHandler] Adding flume event header (name=fiware-servicepath, value=/any)
time=2016-11-04T10:13:18.907UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[283] : [NGSIRestHandler] Adding flume event header (name=fiware-correlator, value=16d6a076-f593-4cb8-a818-8d162c9651e4)
time=2016-11-04T10:13:18.907UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[286] : [NGSIRestHandler] Adding flume event header (name=transaction-id, value=16d6a076-f593-4cb8-a818-8d162c9651e4)
time=2016-11-04T10:13:18.909UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[293] : [NGSIRestHandler] Event put in the channel, id=28638378
time=2016-11-04T10:13:18.909UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[86] : [nmi] Event intercepted, id=28638378
time=2016-11-04T10:13:18.926UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[103] : [nmi] Original NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"Room1","type":"Room","isPattern":"false","attributes":[{"name":"temperature","type":"centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:13:18.927UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[334] : [nmi] FIWARE service found: default
time=2016-11-04T10:13:18.927UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[359] : [nmi] FIWARE service path found: /any
time=2016-11-04T10:13:18.927UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[390] : [nmi] Entity found: Room1, Room
time=2016-11-04T10:13:18.927UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[428] : [nmi] Attribute found: temperature, centigrade
time=2016-11-04T10:13:18.943UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[112] : [nmi] Mapped NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"new_Room1","type":"new_Room","isPattern":"false","attributes":[{"name":"new_temperature","type":"new_centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:13:18.943UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[116] : [nmi] Adding flume event header 'mapped-fiware-service:new_default'
time=2016-11-04T10:13:18.944UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[119] : [nmi] Adding flume event header 'mapped-fiware-servicepath:/new_any'
time=2016-11-04T10:13:18.944UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[128] : [nmi] Event put in the channel, id=28638378
time=2016-11-04T10:13:27.969UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[460] : Batch accumulation time reached, the batch will be processed as it is
time=2016-11-04T10:13:27.969UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[517] : Batch completed, persisting it
time=2016-11-04T10:13:27.969UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[465] : [hdfs-sink] Processing sub-batch regarding the default_/any_Room1_Room destination
time=2016-11-04T10:13:27.973UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[608] : [hdfs-sink] Processing context element (id=Room1, type=Room)
time=2016-11-04T10:13:27.973UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[625] : [hdfs-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-11-04T10:13:27.973UTC | lvl=INFO | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[986] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (default/any/Room1_Room/Room1_Room.txt), Data ({"recvTimeTs":"1478254398","recvTime":"2016-11-04T10:13:18.909Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-11-04T10:13:27.977UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-11-04T10:13:28.208UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:13:28.209UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"FileStatus":{"pathSuffix":"","type":"FILE","length":1484,"owner":"frb","group":"frb","permission":"755","accessTime":1477389562697,"modificationTime":1478254171383,"blockSize":134217728,"replication":3}}
time=2016-11-04T10:13:28.214UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=append&user.name=frb HTTP/1.1
time=2016-11-04T10:13:28.327UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-11-04T10:13:28.327UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:13:28.329UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/any/Room1_Room/Room1_Room.txt?op=APPEND&user.name=frb&data=true HTTP/1.1
time=2016-11-04T10:13:28.549UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:13:28.549UTC | lvl=DEBUG | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:13:28.550UTC | lvl=INFO | corr=16d6a076-f593-4cb8-a818-8d162c9651e4 | trans=16d6a076-f593-4cb8-a818-8d162c9651e4 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[522] : Finishing internal transaction (16d6a076-f593-4cb8-a818-8d162c9651e4)
..
..
$ sudo -u frb hadoop fs -cat /user/frb/default/any/all_rooms/all_rooms.txt
{"recvTimeTs":"1478254398","recvTime":"2016-11-04T10:13:18.909Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```

Using NM, enabled:
```
time=2016-11-04T10:15:02.827UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header host received with value localhost:5050
time=2016-11-04T10:15:02.828UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-type received with value application/json; charset=utf-8
time=2016-11-04T10:15:02.828UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header accept received with value application/json
time=2016-11-04T10:15:02.828UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header user-agent received with value orion/0.10.0
time=2016-11-04T10:15:02.828UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-service received with value default
time=2016-11-04T10:15:02.828UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header fiware-servicepath received with value /any
time=2016-11-04T10:15:02.829UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[192] : [NGSIRestHandler] Header content-length received with value 460
time=2016-11-04T10:15:02.829UTC | lvl=INFO | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[255] : [NGSIRestHandler] Starting internal transaction (e3f93bef-2cdc-4dca-9499-f3925705be97)
time=2016-11-04T10:15:02.830UTC | lvl=INFO | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[271] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-04T10:15:02.830UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[276] : [NGSIRestHandler] Adding flume event header (name=fiware-service, value=default)
time=2016-11-04T10:15:02.831UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[280] : [NGSIRestHandler] Adding flume event header (name=fiware-servicepath, value=/any)
time=2016-11-04T10:15:02.831UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[283] : [NGSIRestHandler] Adding flume event header (name=fiware-correlator, value=e3f93bef-2cdc-4dca-9499-f3925705be97)
time=2016-11-04T10:15:02.831UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[286] : [NGSIRestHandler] Adding flume event header (name=transaction-id, value=e3f93bef-2cdc-4dca-9499-f3925705be97)
time=2016-11-04T10:15:02.832UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[293] : [NGSIRestHandler] Event put in the channel, id=1306727394
time=2016-11-04T10:15:02.833UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[86] : [nmi] Event intercepted, id=1306727394
time=2016-11-04T10:15:02.845UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[103] : [nmi] Original NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"Room1","type":"Room","isPattern":"false","attributes":[{"name":"temperature","type":"centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:15:02.845UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[334] : [nmi] FIWARE service found: default
time=2016-11-04T10:15:02.846UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[359] : [nmi] FIWARE service path found: /any
time=2016-11-04T10:15:02.846UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[390] : [nmi] Entity found: Room1, Room
time=2016-11-04T10:15:02.846UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doMap | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[428] : [nmi] Attribute found: temperature, centigrade
time=2016-11-04T10:15:02.849UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[112] : [nmi] Mapped NotifyContextRequest: {"subscriptionId":"51c0ac9ed714fb3b37d7d5a8","originator":"localhost","contextResponses":[{"contextElement":{"id":"new_Room1","type":"new_Room","isPattern":"false","attributes":[{"name":"new_temperature","type":"new_centigrade","value":""26.5"","metadatas":[]}]},"statusCode":{"code":"200","reasonPhrase":"OK"}}]}
time=2016-11-04T10:15:02.849UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[116] : [nmi] Adding flume event header 'mapped-fiware-service:new_default'
time=2016-11-04T10:15:02.849UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[119] : [nmi] Adding flume event header 'mapped-fiware-servicepath:/new_any'
time=2016-11-04T10:15:02.850UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=intercept | msg=com.telefonica.iot.cygnus.interceptors.NGSINameMappingsInterceptor[128] : [nmi] Event put in the channel, id=1306727394
time=2016-11-04T10:15:14.371UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[460] : Batch accumulation time reached, the batch will be processed as it is
time=2016-11-04T10:15:14.371UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[517] : Batch completed, persisting it
time=2016-11-04T10:15:14.371UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[465] : [hdfs-sink] Processing sub-batch regarding the new_default_/new_any_new_Room1_new_Room destination
time=2016-11-04T10:15:14.375UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[608] : [hdfs-sink] Processing context element (id=Room1, type=Room)
time=2016-11-04T10:15:14.375UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=aggregate | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink$JSONRowAggregator[625] : [hdfs-sink] Processing context attribute (name=temperature, type=centigrade)
time=2016-11-04T10:15:14.375UTC | lvl=INFO | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[986] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (new_default/new_any/new_Room1_new_Room/new_Room1_new_Room.txt), Data ({"recvTimeTs":"1478254502","recvTime":"2016-11-04T10:15:02.833Z","fiwareServicePath":"/new_any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-11-04T10:15:14.379UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/new_default/new_any/new_Room1_new_Room/new_Room1_new_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-11-04T10:15:14.622UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 404 Not Found
time=2016-11-04T10:15:14.624UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"RemoteException":{"message":"File does not exist: \/user\/frb\/new_default\/new_any\/new_Room1_new_Room\/new_Room1_new_Room.txt","exception":"FileNotFoundException","javaClassName":"java.io.FileNotFoundException"}}
time=2016-11-04T10:15:14.629UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/new_default/new_any/new_Room1_new_Room?op=mkdirs&user.name=frb HTTP/1.1
time=2016-11-04T10:15:14.835UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 200 OK
time=2016-11-04T10:15:14.836UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"boolean":true}
time=2016-11-04T10:15:14.836UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/new_default/new_any/new_Room1_new_Room/new_Room1_new_Room.txt?op=create&user.name=frb HTTP/1.1
time=2016-11-04T10:15:14.942UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-11-04T10:15:14.942UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:15:14.944UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/new_default/new_any/new_Room1_new_Room/new_Room1_new_Room.txt?op=CREATE&user.name=frb&data=true HTTP/1.1
time=2016-11-04T10:15:15.110UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[283] : Http response status line: HTTP/1.1 201 Created
time=2016-11-04T10:15:15.111UTC | lvl=DEBUG | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: 
time=2016-11-04T10:15:15.111UTC | lvl=INFO | corr=e3f93bef-2cdc-4dca-9499-f3925705be97 | trans=e3f93bef-2cdc-4dca-9499-f3925705be97 | srv=default | subsrv=/any | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[522] : Finishing internal transaction (e3f93bef-2cdc-4dca-9499-f3925705be97)
..
..
$ sudo -u frb hadoop fs -cat /user/frb/new_default/new_any/new_Room1_new_Room/new_Room1_new_Room.txt
{"recvTimeTs":"1478254502","recvTime":"2016-11-04T10:15:02.833Z","fiwareServicePath":"/new_any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]}
```