### PR TITLE
bug/1291_add_concatenator_to_ckan_package_name

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - [cygnus-ngsi][hardening] Produce NGSIEvent's at Grouping Rules interceptor (#1280)
 - [cygnus-ngsi][hardening] NGSIEvent must contain ContextElement's instead of NotifyContextRequest's (#1203)
 - [cygnus-ngsi][hardening] Add a note regarding supported NGSI version (#1288)
+- [cygnus-ngsi][bug] Add concatenator to CKAN packages when new encoding is enabled (#1291)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -25,6 +25,7 @@ import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
+import com.telefonica.iot.cygnus.utils.CommonConstants;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import com.telefonica.iot.cygnus.utils.NGSICharsets;
 import com.telefonica.iot.cygnus.utils.NGSIConstants;
@@ -497,7 +498,9 @@ public class NGSICKANSink extends NGSISink {
         String pkgName;
         
         if (enableEncoding) {
-            pkgName = NGSICharsets.encodeCKAN(fiwareService) + NGSICharsets.encodeCKAN(fiwareServicePath);
+            pkgName = NGSICharsets.encodeCKAN(fiwareService)
+                    + CommonConstants.CONCATENATOR
+                    + NGSICharsets.encodeCKAN(fiwareServicePath);
         } else {
             if (fiwareServicePath.equals("/")) {
                 pkgName = NGSIUtils.encode(fiwareService, false, true);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICKANSinkTest.java
@@ -663,7 +663,7 @@ public class NGSICKANSinkTest {
         
         try {
             String builtPkgName = sink.buildPkgName(service, servicePath);
-            String expectedPkgName = "somex0053ervicex002fsomex0053ervicex0050ath";
+            String expectedPkgName = "somex0053ervicexffffx002fsomex0053ervicex0050ath";
         
             try {
                 assertEquals(expectedPkgName, builtPkgName);
@@ -775,7 +775,7 @@ public class NGSICKANSinkTest {
         
         try {
             String builtPkgName = sink.buildPkgName(service, servicePath);
-            String expectedPkgName = "somex0053ervicex002f";
+            String expectedPkgName = "somex0053ervicexffffx002f";
         
             try {
                 assertEquals(expectedPkgName, builtPkgName);


### PR DESCRIPTION
* Implements issue #1291 
* 100% unit tests passed:
```
Tests run: 249, Failures: 0, Errors: 0, Skipped: 0
```
* (unofficial) e2e tests passed:

CKAN, dm-by-entity, NM not enabled, encoding enabled
```
orgName=default, pkgName=defaultxffffx002fany, resName=x0052oom1xffffx0052oom
```

CKAN, dm-by-entity, NM enabled, encoding enabled
```
orgName=new_default, pkgName=new_defaultxffffx002fnew_any, resName=new_x0052oom1xffffnew_x0052oom
```

CKAN, dm-by-entity, GR not enabled, encoding enabled
```
orgName=default, pkgName=defaultxffffx002fany, resName=x0052oom1xffffx0052oom
```

CKAN, dm-by-entity, GR enabled, encoding enabled
```
orgName=default, pkgName=defaultxffffx002fany, resName=all_rooms
```
