### PR TITLE
hardening/1279_avoid_concatenation_when_no_entity_type

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - [cygnus-ngsi][hardening] Produce NGSIEvent's at Grouping Rules interceptor (#1280)
 - [cygnus-ngsi][hardening] NGSIEvent must contain ContextElement's instead of NotifyContextRequest's (#1203)
 - [cygnus-ngsi][hardening] Add a note regarding supported NGSI version (#1288)
+- [cygnus-ngsi][hardening] Avoid concatenation on entities naming when the type is null or empty (#1279)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
@@ -138,11 +138,21 @@ public class NGSIEvent implements Event {
         if (enableGrouping) {
             return headers.get(NGSIConstants.FLUME_HEADER_GROUPED_ENTITY);
         } else if (enableMappings) {
-            return mappedCE.getId() + (enableEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
-                    + mappedCE.getType();
+            if (mappedCE.getType() == null || mappedCE.getType().isEmpty()) {
+                return mappedCE.getId();
+            } else {
+                return mappedCE.getId()
+                        + (enableEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
+                        + mappedCE.getType();
+            } // if else
         } else {
-            return originalCE.getId() + (enableEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
-                    + originalCE.getType();
+            if (originalCE.getType() == null || originalCE.getType().isEmpty()) {
+                return originalCE.getId(); // should never occur since Orion does not allow it
+            } else {
+                return originalCE.getId()
+                        + (enableEncoding ? CommonConstants.INTERNAL_CONCATENATOR : "_")
+                        + originalCE.getType();
+            } // if else
         } // if else
     } // getEntityForNaming
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
@@ -1,0 +1,554 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.interceptors;
+
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.utils.CommonConstants;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import com.telefonica.iot.cygnus.utils.TestUtils;
+import java.util.HashMap;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSIEventTest {
+    
+    private final String originalCEStr = ""
+            + "{"
+            +   "\"attributes\" : ["
+            +     "{"
+            +       "\"name\" : \"temperature\","
+            +       "\"type\" : \"centigrade\","
+            +       "\"value\" : \"26.5\""
+            +     "}"
+            +   "],"
+            +   "\"type\" : \"Room\","
+            +   "\"isPattern\" : \"false\","
+            +   "\"id\" : \"Room1\""
+            + "}";
+    private final String mappedCEStr = ""
+            + "{"
+            +   "\"attributes\" : ["
+            +     "{"
+            +       "\"name\" : \"temp\","
+            +       "\"type\" : \"cent\","
+            +       "\"value\" : \"26.5\""
+            +     "}"
+            +   "],"
+            +   "\"type\" : \"room\","
+            +   "\"isPattern\" : \"false\","
+            +   "\"id\" : \"all_rooms\""
+            + "}";
+    private final String mappedCEEmptyTypeStr = ""
+            + "{"
+            +   "\"attributes\" : ["
+            +     "{"
+            +       "\"name\" : \"temp\","
+            +       "\"type\" : \"cent\","
+            +       "\"value\" : \"26.5\""
+            +     "}"
+            +   "],"
+            +   "\"type\" : \"\","
+            +   "\"isPattern\" : \"false\","
+            +   "\"id\" : \"all_rooms\""
+            + "}";
+    private final String timestamp = "123456789";
+    private final String originalService = "rooms";
+    private final String mappedService = "new_rooms";
+    private final String originalServicePath = "/hotel1";
+    private final String mappedServicePath = "/hotels";
+    private final String groupedServicePath = "/hotels";
+    private final String originalEntityNoEncoding = "Room1_Room";
+    private final String originalEntityEncoding = "Room1=Room";
+    private final String groupedEntity = "all_rooms";
+    private final String mappedEntityID = "all_rooms";
+    private final String mappedEntityType = "room";
+    private final String originalAttribute = "temperature";
+    private final String mappedAttribute = "temp";
+
+    /**
+     * Constructor.
+     */
+    public NGSIEventTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSIEventTest
+    
+    /**
+     * [NGSIEvent.getRecvTimeTs] -------- The timestamp is returned.
+     */
+    @Test
+    public void testGetRecvTimeTs() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getRecvTimeTs]")
+                + "-------- The timestamp is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(NGSIConstants.FLUME_HEADER_TIMESTAMP, timestamp);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(new Long(timestamp).longValue(), event.getRecvTimeTs());
+            System.out.println(getTestTraceHead("[NGSIEvent.getRecvTimeTs]")
+                    + "-  OK  - The timestamp has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getRecvTimeTs]")
+                    + "- FAIL - The timestamp has not been returned");
+            throw e;
+        } // try catch
+    } // testGetRecvTimeTs
+    
+    /**
+     * [NGSIEvent.getServiceForNaming] -------- When name mappings are not enabled, the original service is returned.
+     */
+    @Test
+    public void testGetServiceForNamingNoNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                + "-------- When name mappings are not enabled, the original service is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE, originalService);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE, mappedService);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalService, event.getServiceForNaming(false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                    + "-  OK  - The original service has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                    + "- FAIL - The original service has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServiceForNamingNoNM
+    
+    /**
+     * [NGSIEvent.getServiceForNaming] -------- When name mappings are enabled, the mapped service is returned.
+     */
+    @Test
+    public void testGetServiceForNamingNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                + "-------- When name mappings are enabled, the mapped service is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE, originalService);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE, mappedService);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedService, event.getServiceForNaming(true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                    + "-  OK  - The original service has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForNaming]")
+                    + "- FAIL - The original service has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServiceForNamingNM
+    
+    /**
+     * [NGSIEvent.getServicePathForData] -------- The original service path is returned.
+     */
+    @Test
+    public void testGetServicePathForData() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForData]")
+                + "-------- The original service path is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE_PATH, originalServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE_PATH, mappedServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATH, groupedServicePath);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalServicePath, event.getServicePathForData());
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForData]")
+                    + "-  OK  - The original service path has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForData]")
+                    + "- FAIL - The original service path has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServicePathForData
+    
+    /**
+     * [NGSIEvent.getServicePathForNaming] -------- When grouping and mappings are not enabled, the original service
+     * path is returned.
+     */
+    @Test
+    public void testGetServicePathForNamingNoGRNoNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                + "-------- When grouping and mappings are not enabled, the original service path is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE_PATH, originalServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE_PATH, mappedServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATH, groupedServicePath);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalServicePath, event.getServicePathForNaming(false, false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "-  OK  - The original service path has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "- FAIL - The original service path has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServicePathForNamingNoGRNoNM
+    
+    /**
+     * [NGSIEvent.getServicePathForNaming] -------- When grouping is enabled, the grouped service path is returned.
+     */
+    @Test
+    public void testGetServicePathForNamingGR() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                + "-------- When grouping is enabled, the grouped service path is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE_PATH, originalServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE_PATH, mappedServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATH, groupedServicePath);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(groupedServicePath, event.getServicePathForNaming(true, false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "-  OK  - The grouped service path has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "- FAIL - The grouped service path has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServicePathForNamingGR
+    
+    /**
+     * [NGSIEvent.getServicePathForNaming] -------- When mappings are enabled, the mapped service path is returned.
+     */
+    @Test
+    public void testGetServicePathForNamingNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                + "-------- When mappings are enabled, the mapped service path is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE_PATH, originalServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE_PATH, mappedServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_SERVICE_PATH, groupedServicePath);
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedServicePath, event.getServicePathForNaming(false, true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "-  OK  - The grouped service path has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServicePathForNaming]")
+                    + "- FAIL - The grouped service path has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServicePathForNamingNM
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When grouping, mappings and new encoding are not enabled, the original
+     * entity (not encoded) is returned.
+     */
+    @Test
+    public void testGetEntityForNamingNoGRNoNMNoEncoding() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When grouping, mappings and new encoding are not enabled, the original entity "
+                + "(not encoded) is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalEntityNoEncoding, event.getEntityForNaming(false, false, false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The original entity (not encoded) has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The original entity (not encoded) has not been returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingNoGRNoNMNoEncoding
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When grouping and mappings are not enabled and new encoding is enabled,
+     * the original entity (encoded) is returned.
+     */
+    @Test
+    public void testGetEntityForNamingNoGRNoNMEncoding() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When grouping and mappings are not enabled and new encoding is enabled, the original "
+                + "entity (encoded) is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalEntityEncoding, event.getEntityForNaming(false, false, true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The original entity (not encoded) has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The original entity (not encoded) has not been returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingNoGRNoNMEncoding
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When grouping is enabled, independently of the new encoding, the grouped
+     * entity is returned.
+     */
+    @Test
+    public void testGetEntityForNamingGR() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When grouping is enabled, independently of the new encoding, the grouped entity is "
+                + "returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(NGSIConstants.FLUME_HEADER_GROUPED_ENTITY, groupedEntity);
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(groupedEntity, event.getEntityForNaming(true, false, true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The grouped entity has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The grouped entity has not been returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingGR
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When mappings is enabled and new encoding is not enabled, the
+     * concatenation of the mapped entity ID and type (no encoding) is returned.
+     */
+    @Test
+    public void testGetEntityForNamingNMNoEncoding() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When mappings is enabled and new encoding is not enabled, the concatenation of the mapped "
+                + "entity ID and type (no encoding) is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedEntityID + "_" + mappedEntityType, event.getEntityForNaming(false, true, false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The concatenation of the mapped entity ID and type (no encoding) has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The concatenation of the mapped entity ID and type (no encoding) has not been "
+                    + "returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingNMNoEncoding
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When mappings and new encoding are enabled, the concatenation of the
+     * mapped entity ID and type (encoding) is returned.
+     */
+    @Test
+    public void testGetEntityForNamingNMEncoding() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When mappings and new encoding are enabled, the concatenation of the mapped entity ID and "
+                + "type (no encoding) is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedEntityID + "=" + mappedEntityType, event.getEntityForNaming(false, true, true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The concatenation of the mapped entity ID and type (encoding) has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The concatenation of the mapped entity ID and type (encoding) has not been returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingNMEncoding
+    
+    /**
+     * [NGSIEvent.getEntityForNaming] -------- When mappings is enabled and the mapped type is empty, independently of
+     * the new encoding, the mapped entity ID is returned.
+     */
+    @Test
+    public void testGetEntityForNamingNMEmptyType() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                + "-------- When mappings is enabled and the mapped type is empty, independently of the new encoding, "
+                + "the mapped entity ID is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEEmptyTypeStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedEntityID, event.getEntityForNaming(false, true, true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "-  OK  - The entity ID has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getEntityForNaming]")
+                    + "- FAIL - The entity ID has not been returned");
+            throw e;
+        } // try catch
+    } // testGetEntityForNamingNoNMEmptyType
+    
+    /**
+     * [NGSIEvent.getAttributeForNaming] -------- When mappings is not enabled, the original attribute name is returned.
+     */
+    @Test
+    public void testGetAttributeForNamingNoNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                + "-------- When mappings is not enabled, the original attribute name is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalAttribute, event.getAttributeForNaming(false));
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "-  OK  - The original attribute name has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "- FAIL - The original attribute has not been returned");
+            throw e;
+        } // try catch
+    } // testGetAttributeForNamingNoNM
+    
+    /**
+     * [NGSIEvent.getAttributeForNaming] -------- When mappings is enabled, the mapped attribute name is returned.
+     */
+    @Test
+    public void testGetAttributeForNamingNM() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                + "-------- When mappings is enabled, the mapped attribute name is returned");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        ContextElement originalCE;
+        ContextElement mappedCE;
+        
+        try {
+            originalCE = TestUtils.createJsonContextElement(originalCEStr);
+            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "- FAIL - There was some problem when setting up the test");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent event = new NGSIEvent(headers, originalCE, mappedCE);
+        
+        try {
+            assertEquals(mappedAttribute, event.getAttributeForNaming(true));
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "-  OK  - The mapped attribute name has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getAttributeForNaming]")
+                    + "- FAIL - The mapped attribute has not been returned");
+            throw e;
+        } // try catch
+    } // testGetAttributeForNamingNM
+    
+} // NGSIEventTest


### PR DESCRIPTION
* Implements issue #1279 
* 100% unit tests passed (cygnus-ngsi):
```
Tests run: 264, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:

```
[NGSIEvent.getEntityForNaming] -------------------------------------- When mappings is enabled and the mapped type is empty, independently of the new encoding, the mapped entity ID is returned
[NGSIEvent.getEntityForNaming] -------------------------------  OK  - The entity ID has been returned
```
* (unofficial) e2e tests passed:
```
{
   "serviceMappings": [
      {
         "originalService": ".*",
         "newService": "new_default",
         "servicePathMappings": [
            {
               "originalServicePath": "/.*",
               "newServicePath": "/new_any",
               "entityMappings": [
                  {
                     "originalEntityId": "Room(\\d*)",
                     "originalEntityType": "Room",
                     "newEntityId": "new_Room1",
                     "newEntityType": "",
                     "attributeMappings": [
                        {
                           "originalAttributeName": "temp(.*)",
                           "originalAttributeType": "cent(.*)",
                           "newAttributeName": "new_temperature",
                           "newAttributeType": "new_centigrade"
                        }
                     ]
                  }
               ]
            }
         ]
      }
   ]
}
..
..
[hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (new_default/new_any/new_Room1/new_Room1.txt), Data ({"recvTimeTs":"1478862214","recvTime":"2016-11-11T11:03:34.391Z","fiwareServicePath":"/any","entityId":"Room1","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
```
