### PR TITLE
feature/1273_add_raw_snapshot_cartodb_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,3 +14,4 @@
 - [cygnus-ngsi][hardening] Document how Name Mappings behave in absence of a "newSomething" field (#1302)
 - [cygnus-ngsi][bug] Close BufferedReader used to read notifications (#1304)
 - [cygnus-ngsi][hardening] Deprecate Grouping Rules (#1182)
+- [cygnus-ngsi][feature] Add 'update' mode to NGSICKANSink (#1273)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,4 +14,4 @@
 - [cygnus-ngsi][hardening] Document how Name Mappings behave in absence of a "newSomething" field (#1302)
 - [cygnus-ngsi][bug] Close BufferedReader used to read notifications (#1304)
 - [cygnus-ngsi][hardening] Deprecate Grouping Rules (#1182)
-- [cygnus-ngsi][feature] Add 'update' mode to NGSICKANSink (#1273)
+- [cygnus-ngsi][feature] Add raw snapshot analysis mode to NGSICKANSink (#1273)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackend.java
@@ -48,8 +48,19 @@ public interface CartoDBBackend {
      * @param withs
      * @param fields
      * @param rows
-     * @throws java.lang.Exception
+     * @throws Exception
      */
     void insert(String schema, String tableName, String withs, String fields, String rows) throws Exception;
+    
+    /**
+     * Updates the given fields with the given values.
+     * @param schema
+     * @param tableName
+     * @param sets
+     * @param where
+     * @return
+     * @throws Exception
+     */
+    boolean update(String schema, String tableName, String sets, String where) throws Exception;
     
 } // CartoDBBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/cartodb/CartoDBBackendImpl.java
@@ -106,4 +106,21 @@ public class CartoDBBackendImpl extends HttpBackend implements CartoDBBackend {
         } // if
     } // insert
     
+    @Override
+    public boolean update(String schema, String tableName, String sets, String where) throws Exception {
+        String query = "UPDATE " + schema + "." + tableName + " SET " + sets + " WHERE " + where;
+        String encodedQuery = URLEncoder.encode(query, "UTF-8");
+        String relativeURL = BASE_URL + encodedQuery + "&api_key=" + apiKey;
+        JsonResponse response = doRequest("GET", relativeURL, true, null, null);
+        
+        // check the status
+        if (response.getStatusCode() != 200) {
+            throw new CygnusPersistenceError("The query '" + query + "' could not be executed. CartoDB response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
+        } else {
+            int totalRows = ((Number) response.getJsonObject().get("total_rows")).intValue();
+            return totalRows == 1;
+        } // if else
+    } // update
+    
 } // CartoDBBackendImpl

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -77,12 +77,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null;
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertEquals(500, sink.getBackendMaxConns());
@@ -183,6 +184,16 @@ public class NGSICartoDBSinkTest {
                     + "- FAIL - 'enable_raw=true' not configured by default");
             throw e;
         } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableSnapshotRaw());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_snapshot_raw=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_snapshot_raw=false' not configured by default");
+            throw e;
+        } // try catch
     } // testConfigureDefaults
     
     /**
@@ -203,12 +214,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null;
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertEquals(25, sink.getBackendMaxConns());
@@ -239,12 +251,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null;
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertEquals(3, sink.getBackendMaxConnsPerRoute());
@@ -276,12 +289,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = "false";
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -312,12 +326,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = "falso"; // wrong value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -348,12 +363,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = "falso"; // wrong value
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -384,12 +400,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -401,6 +418,43 @@ public class NGSICartoDBSinkTest {
             throw e;
         } // try catch
     } // testConfigureEnableDistanceOK
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'.
+     */
+    @Test
+    public void testConfigureEnableSnapshotRawOK() {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'");
+        String apiKey = "1234567890abcdef";
+        String backendMaxConns = null;
+        String backendMaxConnsPerRoute = null;
+        String batchSize = null;
+        String batchTimeout = null;
+        String batchTTL = null;
+        String dataModel = null; // default one
+        String enableDistance = null; // default one
+        String enableGrouping = null;
+        String enableLowercase = null; // default one
+        String enableRaw = null; // default value
+        String enableSnapshotRaw = "falso"; // wrong value
+        String flipCoordinates = null; // default value
+        String keysConfFile = "/keys.conf";
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
+        
+        try {
+            assertTrue(sink.invalidConfiguration);
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_raw=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_raw=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEnableSnapshotRawOK
     
     /**
      * [NGSICartoDBSink.configure] -------- Configured 'keys_conf_file' cannot be empty.
@@ -420,12 +474,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = null; // empty file
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -470,12 +525,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -522,12 +578,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -575,12 +632,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -615,12 +673,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -635,8 +694,8 @@ public class NGSICartoDBSinkTest {
         dataModel = "dm-by-attribute";
         sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -681,12 +740,13 @@ public class NGSICartoDBSinkTest {
         String enableDistance = null; // default one
         String enableGrouping = null;
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -734,12 +794,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -788,12 +849,13 @@ public class NGSICartoDBSinkTest {
         String enableDistance = null; // default one
         String enableGrouping = null;
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -841,12 +903,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -894,12 +957,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -935,12 +999,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String service = "someService";
         
         try {
@@ -984,12 +1049,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1036,12 +1102,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId=someType"; // using the internal concatenator
         String attribute = null; // irrelevant for this test
@@ -1088,12 +1155,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1140,12 +1208,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -1194,12 +1263,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1267,12 +1337,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1359,12 +1430,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1453,12 +1525,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1553,12 +1626,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1636,12 +1710,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = "true";
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1708,12 +1783,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1751,12 +1827,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/tooLoooooooooooooooooooooooooooongServicePath";
         String entity = "tooLoooooooooooooooooooooooooooongEntity";
         String attribute = null; // irrelevant for this test
@@ -1795,12 +1872,13 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
+        String enableSnapshotRaw = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, flipCoordinates,
-                keysConfFile));
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                flipCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";
         String attribute = "tooLooooooooooooongAttribute";
@@ -1819,8 +1897,8 @@ public class NGSICartoDBSinkTest {
     
     private Context createContext(String apiKey, String backendMaxConns, String backendMaxConnsPerRoute,
             String batchSize, String batchTimeout, String batchTTL, String dataModel, String enableDistance,
-            String enableGrouping, String enableLowercase, String enableRaw, String flipCoordinates,
-            String keysConfFile) {
+            String enableGrouping, String enableLowercase, String enableRaw, String enableRawSnapshot,
+            String flipCoordinates, String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("backend.max_conns", backendMaxConns);
@@ -1833,6 +1911,7 @@ public class NGSICartoDBSinkTest {
         context.put("enable_grouping", enableGrouping);
         context.put("enable_lowercase", enableLowercase);
         context.put("enable_raw", enableRaw);
+        context.put("enable_raw_snapshot", enableRawSnapshot);
         context.put("flip_coordinates", flipCoordinates);
         context.put("keys_conf_file", keysConfFile);
         return context;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -420,12 +420,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableDistanceOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'.
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_raw_snapshot' cannot be different than 'true' or 'false'.
      */
     @Test
     public void testConfigureEnableRawSnapshotOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'");
+                + "-------- Configured 'enable_raw_snapshot' cannot be different than 'true' or 'false'");
         String apiKey = "1234567890abcdef";
         String backendMaxConns = null;
         String backendMaxConnsPerRoute = null;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -77,12 +77,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null;
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -188,10 +188,10 @@ public class NGSICartoDBSinkTest {
         try {
             assertTrue(!sink.getEnableSnapshotRaw());
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'enable_snapshot_raw=false' configured by default");
+                    + "-  OK  - 'enable_raw_snapshot=false' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_snapshot_raw=false' not configured by default");
+                    + "- FAIL - 'enable_raw_snapshot=false' not configured by default");
             throw e;
         } // try catch
     } // testConfigureDefaults
@@ -214,12 +214,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null;
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -251,12 +251,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null;
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -289,12 +289,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = "false";
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -326,12 +326,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = "falso"; // wrong value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -363,12 +363,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = "falso"; // wrong value
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -400,12 +400,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -423,7 +423,7 @@ public class NGSICartoDBSinkTest {
      * [NGSICartoDBSink.configure] -------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'.
      */
     @Test
-    public void testConfigureEnableSnapshotRawOK() {
+    public void testConfigureEnableRawSnapshotOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'enable_snapshot_raw' cannot be different than 'true' or 'false'");
         String apiKey = "1234567890abcdef";
@@ -437,24 +437,24 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default value
-        String enableSnapshotRaw = "falso"; // wrong value
+        String enableRawSnapshot = "falso"; // wrong value
         String flipCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'enable_raw=falso' was detected");
+                    + "-  OK  - 'enable_raw_snapshot=falso' was detected");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_raw=falso' was not detected");
+                    + "- FAIL - 'enable_raw_snapshot=falso' was not detected");
             throw e;
         } // try catch
-    } // testConfigureEnableSnapshotRawOK
+    } // testConfigureEnableRawSnapshotOK
     
     /**
      * [NGSICartoDBSink.configure] -------- Configured 'keys_conf_file' cannot be empty.
@@ -474,12 +474,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = null; // empty file
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -525,12 +525,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -578,12 +578,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -632,12 +632,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -673,12 +673,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -694,7 +694,7 @@ public class NGSICartoDBSinkTest {
         dataModel = "dm-by-attribute";
         sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         try {
@@ -740,12 +740,12 @@ public class NGSICartoDBSinkTest {
         String enableDistance = null; // default one
         String enableGrouping = null;
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -794,12 +794,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -849,12 +849,12 @@ public class NGSICartoDBSinkTest {
         String enableDistance = null; // default one
         String enableGrouping = null;
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -903,12 +903,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -957,12 +957,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
@@ -999,12 +999,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String service = "someService";
         
@@ -1049,12 +1049,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
@@ -1102,12 +1102,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId=someType"; // using the internal concatenator
@@ -1155,12 +1155,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
@@ -1208,12 +1208,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = "someId=someType";
@@ -1263,12 +1263,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1337,12 +1337,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1430,12 +1430,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1525,12 +1525,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1626,12 +1626,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1710,12 +1710,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = "true";
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
@@ -1783,12 +1783,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
@@ -1827,12 +1827,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/tooLoooooooooooooooooooooooooooongServicePath";
         String entity = "tooLoooooooooooooooooooooooooooongEntity";
@@ -1872,12 +1872,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableLowercase = null; // default
         String enableRaw = null; // default one
-        String enableSnapshotRaw = null; // defatul one
+        String enableRawSnapshot = null; // defatul one
         String flipCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableSnapshotRaw,
+                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
                 flipCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";


### PR DESCRIPTION
* Partially implements issue #1273 (`enable_raw_snapshot` part).
* 100% unit tests passed:
```
Tests run: 266, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[NGSICartoDBSink.configure] ----------------------------------------- When not configured, not mandatory parameters get default values
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_snapshot_raw=false' configured by default
[NGSICartoDBSink.configure] ----------------------------------------- Configured 'enable_raw_snapshot' cannot be different than 'true' or 'false'
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'enable_raw_snapshot=falso' was detected
```

* (unofficial) e2e tests passed:
```
$ curl -G "https://xxxxx.cartodb.com/api/v2/sql?api_key=xxxxx" --data-urlencode "q=CREATE TABLE x002froomsxffffrawsnapshot (recvTime text, fiwareServicePath text, entityId text, entityType text, temperature text, temperature_md text, the_geom geometry(POINT,4326))"
{"rows":[],"time":0.026,"fields":{},"total_rows":0}
..
..
time=2016-11-22T16:35:25.940UTC | lvl=INFO | corr=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | trans=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=rawUpdateEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[723] : [update-sink] Updating data at NGSICartoDBSink. Schema (xxxxx), Table (x002froomsxffffrawsnapshot), Sets (temperature='26.5',temperature_md='[]',the_geom=ST_SetSRID(ST_MakePoint(4.90,30.4), 4326)), Where (fiwareServicePath='/rooms' AND entityId='Car1' AND entityType='Car')
..
time=2016-11-22T16:35:28.981UTC | lvl=DEBUG | corr=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | trans=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"rows":[],"time":0.005,"fields":{},"total_rows":0}
..
time=2016-11-22T16:35:28.982UTC | lvl=INFO | corr=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | trans=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=rawUpdateEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[730] : [update-sink] Inserting initial data at NGSICartoDBSink. Schema (xxxxx), Table (x002froomsxffffrawsnapshot), Data (('2016-11-22T16:35:18.268Z','/rooms','Car1','Car','26.5','[]',ST_SetSRID(ST_MakePoint(4.90,30.4), 4326)))
..
time=2016-11-22T16:35:29.163UTC | lvl=DEBUG | corr=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | trans=a7d2034e-57bb-4bdc-b6ce-95a2f25311d1 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"rows":[],"time":0.002,"fields":{},"total_rows":1}
..
..
$ curl -G "https://xxxxx.cartodb.com/api/v2/sql?api_key=xxxxx" --data-urlencode "q=SELECT * FROM x002froomsxffffrawsnapshot"
{"rows":[{"recvtime":"2016-11-22T16:35:18.268Z","fiwareservicepath":"/rooms","entityid":"Car1","entitytype":"Car","temperature":"26.5","temperature_md":"[]","the_geom":"0101000020E61000009A999999999913406666666666663E40"}],"time":0.005,"fields":{"recvtime":{"type":"string"},"fiwareservicepath":{"type":"string"},"entityid":{"type":"string"},"entitytype":{"type":"string"},"temperature":{"type":"string"},"temperature_md":{"type":"string"},"the_geom":{"type":"geometry"}},"total_rows":1}
..
..
time=2016-11-22T16:37:58.735UTC | lvl=INFO | corr=4a65dcb8-809c-4c91-8d67-1553228b4c94 | trans=4a65dcb8-809c-4c91-8d67-1553228b4c94 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=rawUpdateEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[723] : [update-sink] Updating data at NGSICartoDBSink. Schema (xxxxx), Table (x002froomsxffffrawsnapshot), Sets (temperature='26.5',temperature_md='[]',the_geom=ST_SetSRID(ST_MakePoint(4.90,30.4), 4326)), Where (fiwareServicePath='/rooms' AND entityId='Car1' AND entityType='Car')
..
time=2016-11-22T16:38:00.266UTC | lvl=DEBUG | corr=4a65dcb8-809c-4c91-8d67-1553228b4c94 | trans=4a65dcb8-809c-4c91-8d67-1553228b4c94 | srv=xxxxx | subsrv=/rooms | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[299] : Http response payload: {"rows":[],"time":0.006,"fields":{},"total_rows":1}
```