### PR TITLE
bug/1318_fix_get_location_header_httpbackend__1.5.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi][bug] Fix getting location header when creating Json responses in HttpBackend (#1318)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -270,14 +270,22 @@ public abstract class HttpBackend {
                 return null;
             } // if
             
+            // get the location header
+            Header locationHeader = null;
+            Header[] headers = httpRes.getHeaders("Location");
+            
+            if (headers.length > 0) {
+                locationHeader = headers[0];
+            } // if
+            
             if (httpRes.getHeaders("Content-Type").length == 0) {
                 return new JsonResponse(null, httpRes.getStatusLine().getStatusCode(),
-                    httpRes.getStatusLine().getReasonPhrase(), null);
+                    httpRes.getStatusLine().getReasonPhrase(), locationHeader);
             } // if
             
             if (!httpRes.getHeaders("Content-Type")[0].getValue().contains("application/json")) {
                 return new JsonResponse(null, httpRes.getStatusLine().getStatusCode(),
-                    httpRes.getStatusLine().getReasonPhrase(), null);
+                    httpRes.getStatusLine().getReasonPhrase(), locationHeader);
             } // if
             
             LOGGER.debug("Http response status line: " + httpRes.getStatusLine().toString());
@@ -309,14 +317,6 @@ public abstract class HttpBackend {
                         jsonPayload = (JSONObject) jsonParser.parse(res);
                     } // if else
                 } // if
-            } // if
-
-            // get the location header
-            Header locationHeader = null;
-            Header[] headers = httpRes.getHeaders("Location");
-            
-            if (headers.length > 0) {
-                locationHeader = headers[0];
             } // if
             
             // return the result


### PR DESCRIPTION
* Fixes issue #1318 
* 100% unit tests passed:

`cygnus-common`:
```
Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
```

`cygnus-ngsi`:
```
Tests run: 248, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[HttpBackend.createJsonResponse] ------------------------------------ A JsonResponse object is created if the response content-type header is 'application/json' and the response contains a location header
[HttpBackend.createJsonResponse] -----------------------------  OK  - The JsonResponse object has a Json apyload
[HttpBackend.createJsonResponse] -----------------------------  OK  - The JsonResponse object has a Location header
[HttpBackend.createJsonResponse] ------------------------------------ A JsonResponse object is created if the content-type header contains 'application/json' but no location header
[HttpBackend.createJsonResponse] -----------------------------  OK  - The JsonResponse object was created with null location header
[HttpBackend.createJsonResponse] ------------------------------------ A JsonResponse object is not created if the content-type header does not contains 'application/json'
[HttpBackend.createJsonResponse] -----------------------------  OK  - The JsonResponse object could not be created with a 'text/html' content type header
```

* (Unofficial) e2e tests passed:

HDFS:
```
time=2016-11-24T13:38:32.392UTC | lvl=DEBUG | corr=b42afb12-b238-467b-b1e1-64e6cc0c4b66 | trans=b42afb12-b238-467b-b1e1-64e6cc0c4b66 | srv=default | subsrv=/ | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: POST http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/Room1_Room/Room1_Room.txt?op=APPEND&user.name=frb&data=true HTTP/1.1
time=2016-11-24T13:38:32.599UTC | lvl=DEBUG | corr=b42afb12-b238-467b-b1e1-64e6cc0c4b66 | trans=b42afb12-b238-467b-b1e1-64e6cc0c4b66 | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[291] : Http response status line: HTTP/1.1 200 OK
```

CKAN:
```
time=2016-11-24T13:45:20.541UTC | lvl=DEBUG | corr=649a9bee-be05-4150-a84c-b2282b082af4 | trans=649a9bee-be05-4150-a84c-b2282b082af4 | srv=sc_mad | subsrv=/road | comp=cygnus-ngsi | op=insert | msg=com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl[179] : Successful insert (resource/datastore id=fda3243c-07c1-467f-ac4c-0aab366452d5)
```