### PR TITLE
hardening/1319_improve_hdfsbackendimplrest_debug_logs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [cygnus-ngsi][hardening] Deprecate Grouping Rules (#1182)
 - [cygnus-ngsi][feature] Add raw snapshot analysis mode to NGSICKANSink (#1273)
 - [cygnus-ngsi][bug] Fix getting location header when creating Json responses in HttpBackend (#1318)
+- [cygnus-ngsi][hardening] Improve HDFSBackendImplREST debug logs (#1319)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
@@ -76,7 +76,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
         
         // add the OAuth2 token as a the unique header that will be sent
         if (oauth2Token != null && oauth2Token.length() > 0) {
-            headers = new ArrayList<Header>();
+            headers = new ArrayList<>();
             headers.add(new BasicHeader("X-Auth-Token", oauth2Token));
             headers.add(new BasicHeader("Content-Type", "text/plain; charset=utf-8"));
         } else {
@@ -92,10 +92,16 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
 
         // check the status
         if (response.getStatusCode() != 200) {
+            LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + dirPath + " directory could not be created in HDFS. Server response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
             throw new CygnusPersistenceError("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
                     + dirPath + " directory could not be created in HDFS. Server response: "
                     + response.getStatusCode() + " " + response.getReasonPhrase());
         } // if
+        
+        LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + dirPath + " directory was created in HDFS");
     } // createDir
     
     @Override
@@ -107,10 +113,16 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
         
         // check the status
         if (response.getStatusCode() != 307) {
+            LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file could not be created in HDFS. Server response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
             throw new CygnusPersistenceError("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
                     + filePath + " file could not be created in HDFS. Server response: "
                     + response.getStatusCode() + " " + response.getReasonPhrase());
         } // if
+        
+        LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file was created in HDFS");
         
         // get the redirection location
         Header header = response.getLocationHeader();
@@ -118,7 +130,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
 
         // do second step
         if (headers == null) {
-            headers = new ArrayList<Header>();
+            headers = new ArrayList<>();
         } // if
         
         headers.add(new BasicHeader("Content-Type", "application/octet-stream"));
@@ -126,10 +138,16 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     
         // check the status
         if (response.getStatusCode() != 201) {
+            LOGGER.debug("/user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file created in HDFS, but could not write the data. Server response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
             throw new CygnusPersistenceError("/user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
                     + filePath + " file created in HDFS, but could not write the data. Server response: "
                     + response.getStatusCode() + " " + response.getReasonPhrase());
         } // if
+        
+        LOGGER.debug("Data was written in /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath);
     } // createFile
     
     @Override
@@ -140,10 +158,16 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
 
         // check the status
         if (response.getStatusCode() != 307) {
+            LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file seems to not exist in HDFS. Server response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
             throw new CygnusPersistenceError("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
                     + filePath + " file seems to not exist in HDFS. Server response: "
                     + response.getStatusCode() + " " + response.getReasonPhrase());
         } // if
+        
+        LOGGER.debug("The /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file was found in HDFS");
 
         // get the redirection location
         Header header = response.getLocationHeader();
@@ -151,7 +175,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
 
         // do second step
         if (headers == null) {
-            headers = new ArrayList<Header>();
+            headers = new ArrayList<>();
         } // if
 
         headers.add(new BasicHeader("Content-Type", "application/octet-stream"));
@@ -159,10 +183,16 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
         
         // check the status
         if (response.getStatusCode() != 200) {
+            LOGGER.debug("/user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath + " file exists in HDFS, but could not write the data. Server response: "
+                    + response.getStatusCode() + " " + response.getReasonPhrase());
             throw new CygnusPersistenceError("/user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
                     + filePath + " file exists in HDFS, but could not write the data. Server response: "
                     + response.getStatusCode() + " " + response.getReasonPhrase());
         } // if
+        
+        LOGGER.debug("Data was written in /user/" + (serviceAsNamespace ? "" : (hdfsUser + "/"))
+                    + filePath);
     } // append
     
     @Override


### PR DESCRIPTION
* Implements issue #1319 
* Logs:

```
time=2016-11-24T15:15:08.340UTC | lvl=INFO | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[988] : [hdfs-sink] Persisting data at NGSIHDFSSink. HDFS file (default/Room111_Room/Room111_Room.txt), Data ({"recvTimeTs":"1480000503","recvTime":"2016-11-24T15:15:03.326Z","fiwareServicePath":"/","entityId":"Room111","entityType":"Room","attrName":"temperature","attrType":"centigrade","attrValue":"26.5","attrMd":[]})
time=2016-11-24T15:15:08.344UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: GET http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/Room111_Room/Room111_Room.txt?op=getfilestatus&user.name=frb HTTP/1.1
time=2016-11-24T15:15:08.570UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[291] : Http response status line: HTTP/1.1 404 Not Found
time=2016-11-24T15:15:08.572UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: {"RemoteException":{"message":"File does not exist: \/user\/frb\/default\/Room111_Room\/Room111_Room.txt","exception":"FileNotFoundException","javaClassName":"java.io.FileNotFoundException"}}
time=2016-11-24T15:15:08.578UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/Room111_Room?op=mkdirs&user.name=frb HTTP/1.1
time=2016-11-24T15:15:08.721UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[291] : Http response status line: HTTP/1.1 200 OK
time=2016-11-24T15:15:08.722UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: {"boolean":true}
time=2016-11-24T15:15:08.722UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createDir | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[103] : The /user/frb/default/Room111_Room directory was created in HDFS
time=2016-11-24T15:15:08.722UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/Room111_Room/Room111_Room.txt?op=create&user.name=frb HTTP/1.1
time=2016-11-24T15:15:08.828UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[291] : Http response status line: HTTP/1.1 307 Temporary Redirect
time=2016-11-24T15:15:08.829UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: 
time=2016-11-24T15:15:08.829UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createFile | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[124] : The /user/frb/default/Room111_Room/Room111_Room.txt file was created in HDFS
time=2016-11-24T15:15:08.831UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=doRequest | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[186] : Http request: PUT http://storage.cosmos.lab.fiware.org:14000/webhdfs/v1/user/frb/default/Room111_Room/Room111_Room.txt?op=CREATE&user.name=frb&data=true HTTP/1.1
time=2016-11-24T15:15:08.997UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[291] : Http response status line: HTTP/1.1 201 Created
time=2016-11-24T15:15:08.998UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: 
time=2016-11-24T15:15:08.998UTC | lvl=DEBUG | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=createFile | msg=com.telefonica.iot.cygnus.backends.hdfs.HDFSBackendImplREST[149] : Data was written in /user/frb/default/Room111_Room/Room111_Room.txt
time=2016-11-24T15:15:08.998UTC | lvl=INFO | corr=968da364-cccf-44b7-8331-523f683e87ae | trans=968da364-cccf-44b7-8331-523f683e87ae | srv=default | subsrv=/ | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (968da364-cccf-44b7-8331-523f683e87ae)
```