### PR TITLE
bug/1327_geometry_not_properly_used_carto_sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -19,3 +19,4 @@
 - [cygnus-ngsi][hardening] Update performance document (#1306)
 - [cygnus-ngsi][hardening] Improve HDFSBackendImplREST debug logs (#1319)
 - [cygnus-ngsi][hardening] Update NGSICKANSink documentation regarding resource name length limit imposed by Cygnus (#1325)
+- [cygnus-ngsi][bug] Obtained geometry not properly used in NGSICartoDBSink (#1327)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -574,7 +574,7 @@ public class NGSICartoDBSink extends NGSISink {
                             + "stageTime, stageSpeed, sumDistance, sumTime, sumSpeed, sum2Distance, sum2Time,"
                             + "sum2Speed, maxDistance, minDistance, maxTime, mintime, maxSpeed, minSpeed, numSamples)";
                     String rows = "(" + recvTimeTs + ",'" + servicePath + "','" + entityId + "','" + entityType + "',"
-                            + location + ",0,0,0,0,0,0,0,0,0," + Float.MIN_VALUE + "," + Float.MAX_VALUE + ","
+                            + location.getLeft() + ",0,0,0,0,0,0,0,0,0," + Float.MIN_VALUE + "," + Float.MAX_VALUE + ","
                             + Float.MIN_VALUE + "," + Float.MAX_VALUE + "," + Float.MIN_VALUE + "," + Float.MAX_VALUE
                             + ",1)";
                     LOGGER.info("[" + this.getName() + "] Persisting data at NGSICartoDBSink. Schema (" + schema
@@ -583,7 +583,7 @@ public class NGSICartoDBSink extends NGSISink {
                 } catch (Exception e) {
                     String withs = ""
                             + "WITH geom AS ("
-                            + "   SELECT " + location + " AS point"
+                            + "   SELECT " + location.getLeft() + " AS point"
                             + "), calcs AS ("
                             + "   SELECT"
                             + "      cartodb_id,"


### PR DESCRIPTION
* Fixes issue #1327 
* 100% unit tests passed (`cygnus-ngsi`:
```
Tests run: 266, Failures: 0, Errors: 0, Skipped: 0
```

* (Unofficial) e2e tests passed:
```
time=2016-11-28T14:16:51.048UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "110"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.363, -3.4101",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-28T14:17:00.972UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=rawUpdateEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[723] : [rawsnapshot-sink] Updating data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffrawsnapshot), Sets (speed='110',speed_md='[]',the_geom=ST_SetSRID(ST_MakePoint(-3.4101,40.363), 4326)), Where (fiwareServicePath='/traffic' AND entityId='car1' AND entityType='car')
time=2016-11-28T14:17:00.983UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=persistRawAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[528] : [raw-sink] Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-28T14:16:51.51Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(-3.4101,40.363), 4326),'110','[]'))
time=2016-11-28T14:17:02.398UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (a78d4d99-6259-4427-9d7c-a805a55f15ad)
time=2016-11-28T14:17:02.409UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (a78d4d99-6259-4427-9d7c-a805a55f15ad)
time=2016-11-28T14:17:02.542UTC | lvl=INFO | corr=a78d4d99-6259-4427-9d7c-a805a55f15ad | trans=a78d4d99-6259-4427-9d7c-a805a55f15ad | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=persistDistanceEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[580] : [distance-sink] Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcarxffffdistance), Data ((1480342611051,'/traffic','car1','car',ST_SetSRID(ST_MakePoint(-3.4101,40.363), 4326),0,0,0,0,0,0,0,0,0,1.4E-45,3.4028235E38,1.4E-45,3.4028235E38,1.4E-45,3.4028235E38,1))
time=2016-11-28T14:18:17.997UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "78"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.361, -3.4099",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2016-11-28T14:18:23.478UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=persistRawAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[528] : [raw-sink] Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-28T14:18:18.0Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(-3.4099,40.361), 4326),'78','[]'))
time=2016-11-28T14:18:23.501UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=rawUpdateEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[723] : [rawsnapshot-sink] Updating data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffrawsnapshot), Sets (speed='78',speed_md='[]',the_geom=ST_SetSRID(ST_MakePoint(-3.4099,40.361), 4326)), Where (fiwareServicePath='/traffic' AND entityId='car1' AND entityType='car')
time=2016-11-28T14:18:24.661UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (b9a92f57-d27b-4bbf-8c4d-677448169a8b)
time=2016-11-28T14:18:24.675UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (b9a92f57-d27b-4bbf-8c4d-677448169a8b)
time=2016-11-28T14:18:24.685UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=persistDistanceEvent | msg=com.telefonica.iot.cygnus.sinks.NGSICartoDBSink[653] : [distance-sink] Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcarxffffdistance), Data ((1480342698000,'/traffic','car1','car',(SELECT point FROM geom),(SELECT stage_distance FROM calcs),(SELECT stage_time FROM calcs),(SELECT stage_speed FROM speed),(SELECT sum_dist FROM inserts),(SELECT sum_time FROM inserts),(SELECT sum_speed FROM inserts),(SELECT sum2_dist FROM inserts),(SELECT sum2_time FROM inserts),(SELECT sum2_speed FROM inserts),(SELECT max_distance FROM inserts),(SELECT min_distance FROM inserts),(SELECT max_time FROM inserts),(SELECT min_time FROM inserts),(SELECT max_speed FROM inserts),(SELECT min_speed FROM inserts),(SELECT num_samples FROM inserts)))
time=2016-11-28T14:18:24.900UTC | lvl=INFO | corr=b9a92f57-d27b-4bbf-8c4d-677448169a8b | trans=b9a92f57-d27b-4bbf-8c4d-677448169a8b | srv=xxx | subsrv=/traffic | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[514] : Finishing internal transaction (b9a92f57-d27b-4bbf-8c4d-677448169a8b)
```