### PR TITLE
hardening/1313_flip_coordinates_swap_coordinates

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -20,3 +20,4 @@
 - [cygnus-ngsi][hardening] Improve HDFSBackendImplREST debug logs (#1319)
 - [cygnus-ngsi][hardening] Update NGSICKANSink documentation regarding resource name length limit imposed by Cygnus (#1325)
 - [cygnus-ngsi][bug] Obtained geometry not properly used in NGSICartoDBSink (#1327)
+- [cygnus-ngsi][hardening] Replace flip-coordinates by swap coordinates in NGSICartoDBSink (#1313)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -20,4 +20,4 @@
 - [cygnus-ngsi][hardening] Improve HDFSBackendImplREST debug logs (#1319)
 - [cygnus-ngsi][hardening] Update NGSICKANSink documentation regarding resource name length limit imposed by Cygnus (#1325)
 - [cygnus-ngsi][bug] Obtained geometry not properly used in NGSICartoDBSink (#1327)
-- [cygnus-ngsi][hardening] Replace flip-coordinates by swap coordinates in NGSICartoDBSink (#1313)
+- [cygnus-ngsi][hardening] Replace flip_coordinates with swap_coordinates in NGSICartoDBSink (#1313)

--- a/cygnus-ngsi/conf/agent_ngsi.conf.template
+++ b/cygnus-ngsi/conf/agent_ngsi.conf.template
@@ -386,7 +386,7 @@ cygnus-ngsi.sinks.cartodb-sink.channel = cartodb-channel
 # absolute path to the CartoDB file containing the mapping between FIWARE service/CartoDB usernames and CartoDB API Keys
 cygnus-ngsi.sinks.cartodb-sink.keys_conf_file = /usr/cygnus/conf/cartodb_keys.conf
 # if true the latitude and longitude values are exchanged, false otherwise
-#cygnus-ngsi.sinks.cartodb-sink.flip_coordinates = true
+#cygnus-ngsi.sinks.cartodb-sink.swap_coordinates = true
 # if true, a raw based storage is done, false otherwise
 #cygnus-ngsi.sinks.cartodb-sink.enable_raw = true
 # if true, a distance based storage is done, false otherwise

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -146,16 +146,41 @@ public class NGSICartoDBSink extends NGSISink {
                     + keysConfFile + ")");
         } // if else
         
-        String swapCoordinatesStr = context.getString("swap_coordinates", "false");
+        String swapCoordinatesStr = context.getString("swap_coordinates");
+        boolean wasFlipCoordinates = false;
+        
+        if (swapCoordinatesStr == null || swapCoordinatesStr.isEmpty()) {
+            swapCoordinatesStr = context.getString("flip_coordinates");
+            
+            if (swapCoordinatesStr == null || swapCoordinatesStr.isEmpty()) {
+                swapCoordinatesStr = "false";
+            } else {
+                wasFlipCoordinates = true;
+            } // if else
+        } // if
         
         if (swapCoordinatesStr.equals("true") || swapCoordinatesStr.equals("false")) {
             swapCoordinates = swapCoordinatesStr.equals("true");
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (swap_coordinates="
-                    + swapCoordinatesStr + ")");
+            
+            if (wasFlipCoordinates) {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (flip_coordinates="
+                        + swapCoordinatesStr + ") -- Deprecated, please use 'swap_coordinates' instead");
+            } else {
+                LOGGER.debug("[" + this.getName() + "] Reading configuration (swap_coordinates="
+                        + swapCoordinatesStr + ")");
+            } // if else
         } else {
             invalidConfiguration = true;
-            LOGGER.error("[" + this.getName() + "] Invalid configuration (swap_coordinates="
-                    + swapCoordinatesStr + ") -- Must be 'true' or 'false'");
+            
+            if (wasFlipCoordinates) {
+                LOGGER.error("[" + this.getName() + "] Invalid configuration (flip_coordinates="
+                        + swapCoordinatesStr + ") -- Must be 'true' or 'false' -- Deprecated, please use "
+                        + "'swap_coordinates' instead");
+            } else {
+                LOGGER.error("[" + this.getName() + "] Invalid configuration (swap_coordinates="
+                        + swapCoordinatesStr + ") -- Must be 'true' or 'false'");
+            } // if else
+            
             return;
         } // if else
         

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -47,7 +47,7 @@ public class NGSICartoDBSink extends NGSISink {
     
     private static final CygnusLogger LOGGER = new CygnusLogger(NGSICartoDBSink.class);
     private String keysConfFile;
-    private boolean flipCoordinates;
+    private boolean swapCoordinates;
     private boolean enableRaw;
     private boolean enableDistance;
     private boolean enableRawSnapshot;
@@ -146,16 +146,16 @@ public class NGSICartoDBSink extends NGSISink {
                     + keysConfFile + ")");
         } // if else
         
-        String flipCoordinatesStr = context.getString("flip_coordinates", "false");
+        String swapCoordinatesStr = context.getString("swap_coordinates", "false");
         
-        if (flipCoordinatesStr.equals("true") || flipCoordinatesStr.equals("false")) {
-            flipCoordinates = flipCoordinatesStr.equals("true");
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (flip_coordinates="
-                    + flipCoordinatesStr + ")");
+        if (swapCoordinatesStr.equals("true") || swapCoordinatesStr.equals("false")) {
+            swapCoordinates = swapCoordinatesStr.equals("true");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (swap_coordinates="
+                    + swapCoordinatesStr + ")");
         } else {
             invalidConfiguration = true;
-            LOGGER.error("[" + this.getName() + "] Invalid configuration (flip_coordinates="
-                    + flipCoordinatesStr + ") -- Must be 'true' or 'false'");
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (swap_coordinates="
+                    + swapCoordinatesStr + ") -- Must be 'true' or 'false'");
             return;
         } // if else
         
@@ -459,7 +459,7 @@ public class NGSICartoDBSink extends NGSISink {
                 String attrValue = contextAttribute.getContextValue(false);
                 String attrMetadata = contextAttribute.getContextMetadata();
                 
-                if (!NGSIUtils.getGeometry(attrValue, attrType, attrMetadata, flipCoordinates).getRight()) {
+                if (!NGSIUtils.getGeometry(attrValue, attrType, attrMetadata, swapCoordinates).getRight()) {
                     aggregation.put(attrName, new ArrayList<String>());
                     aggregation.put(attrName + "_md", new ArrayList<String>());
                 } // if
@@ -505,7 +505,7 @@ public class NGSICartoDBSink extends NGSISink {
                 LOGGER.debug("[" + getName() + "] Processing context attribute (name=" + attrName + ", type="
                         + attrType + ")");
                 ImmutablePair<String, Boolean> location = NGSIUtils.getGeometry(attrValue, attrType, attrMetadata,
-                        flipCoordinates);
+                        swapCoordinates);
                 
                 if (location.right) {
                     aggregation.get(NGSIConstants.CARTO_DB_THE_GEOM).add(location.getLeft());
@@ -550,7 +550,7 @@ public class NGSICartoDBSink extends NGSISink {
             String attrValue = contextAttribute.getContextValue(false);
             String attrMetadata = contextAttribute.getContextMetadata();
             ImmutablePair<String, Boolean> location = NGSIUtils.getGeometry(attrValue, attrType, attrMetadata,
-                    flipCoordinates);
+                    swapCoordinates);
             String tableName = buildTableName(event.getServicePathForNaming(enableGrouping, enableNameMappings),
                     event.getEntityForNaming(enableGrouping, enableNameMappings, enableEncoding),
                     event.getAttributeForNaming(enableNameMappings))
@@ -676,7 +676,7 @@ public class NGSICartoDBSink extends NGSISink {
             String attrType = ca.getType();
             String attrMetadata = ca.getContextMetadata();
             ImmutablePair<String, Boolean> location = NGSIUtils.getGeometry(attrValue, attrType, attrMetadata,
-                    flipCoordinates);
+                    swapCoordinates);
             String set;
             String field;
             String row;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -88,16 +88,16 @@ public final class NGSIUtils {
      * @param attrValue
      * @param attrType
      * @param metadata
-     * @param flipCoordinates
+     * @param swapCoordinates
      * @return The geometry value, ready for insertion in CartoDB, or the value as it is
      */
     public static ImmutablePair<String, Boolean> getGeometry(String attrValue, String attrType, String metadata,
-            boolean flipCoordinates) {
+            boolean swapCoordinates) {
         // First, check the attribute type
         if (attrType.equals("geo:point")) {
             String[] split = attrValue.split(",");
                 
-            if (flipCoordinates) {
+            if (swapCoordinates) {
                 return new ImmutablePair(
                         "ST_SetSRID(ST_MakePoint(" + split[1].trim() + "," + split[0].trim() + "), 4326)", true);
             } else {
@@ -130,7 +130,7 @@ public final class NGSIUtils {
             if (mdName.equals("location") && mdType.equals("string") && mdValue.equals("WGS84")) {
                 String[] split = attrValue.split(",");
                 
-                if (flipCoordinates) {
+                if (swapCoordinates) {
                     return new ImmutablePair(
                             "ST_SetSRID(ST_MakePoint(" + split[1].trim() + "," + split[0].trim() + "), 4326)", true);
                 } else {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -78,12 +78,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null;
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertEquals(500, sink.getBackendMaxConns());
@@ -215,12 +215,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null;
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertEquals(25, sink.getBackendMaxConns());
@@ -252,12 +252,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null;
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertEquals(3, sink.getBackendMaxConnsPerRoute());
@@ -290,12 +290,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = "false";
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -309,12 +309,12 @@ public class NGSICartoDBSinkTest {
     } // testConfigureEnableLowercaseAlwaysTrue
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured 'flip_coordinates' cannot be different than 'true' or 'false'.
+     * [NGSICartoDBSink.configure] -------- Configured 'swap_coordinates' cannot be different than 'true' or 'false'.
      */
     @Test
-    public void testConfigureFlipCoordinatesOK() {
+    public void testConfigureSwapCoordinatesOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                + "-------- Configured 'flip_coordinates' cannot be different than 'true' or 'false'");
+                + "-------- Configured 'swap_coordinates' cannot be different than 'true' or 'false'");
         String apiKey = "1234567890abcdef";
         String backendMaxConns = null;
         String backendMaxConnsPerRoute = null;
@@ -327,23 +327,23 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = "falso"; // wrong value
+        String swapCoordinates = "falso"; // wrong value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'flip_coordinates=falso' was detected");
+                    + "-  OK  - 'swap_coordinates=falso' was detected");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'flip_coordinates=falso' was not detected");
+                    + "- FAIL - 'swap_coordinates=falso' was not detected");
             throw e;
         } // try catch
-    } // testConfigureFlipCoordinatesOK
+    } // testConfigureSwapCoordinatesOK
     
     /**
      * [NGSICartoDBSink.configure] -------- Configured 'enable_raw' cannot be different than 'true' or 'false'.
@@ -364,12 +364,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = "falso"; // wrong value
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default value
+        String swapCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -401,12 +401,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -438,12 +438,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default value
         String enableRawSnapshot = "falso"; // wrong value
-        String flipCoordinates = null; // default value
+        String swapCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -475,12 +475,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = null; // empty file
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -526,12 +526,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -579,12 +579,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -633,12 +633,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -674,12 +674,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -695,7 +695,7 @@ public class NGSICartoDBSinkTest {
         sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -741,12 +741,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -795,12 +795,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -850,12 +850,12 @@ public class NGSICartoDBSinkTest {
         String enableGrouping = null;
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -904,12 +904,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -958,12 +958,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -1000,12 +1000,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String service = "someService";
         
         try {
@@ -1050,12 +1050,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1103,12 +1103,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId=someType"; // using the internal concatenator
         String attribute = null; // irrelevant for this test
@@ -1156,12 +1156,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1209,12 +1209,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -1264,12 +1264,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1338,12 +1338,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1431,12 +1431,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1526,12 +1526,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1627,12 +1627,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default one
+        String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1688,14 +1688,14 @@ public class NGSICartoDBSinkTest {
     } // testAggregateValuesStringOK
     
     /**
-     * [CartoDBAggregator.aggregate] -------- When aggregating a single geolocated event, if flip_coordinates=true
+     * [CartoDBAggregator.aggregate] -------- When aggregating a single geolocated event, if swap_coordinates=true
      * then the_geom field contains a point with exchanged latitude and longitude.
      * @throws java.lang.Exception
      */
     @Test
-    public void testAggregateCoordinatesAreFlipped() throws Exception {
+    public void testAggregateCoordinatesAreSwapped() throws Exception {
         System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
-                + "-------- When aggregating a single geolocated event, if flip_coordinates=true then the_geom "
+                + "-------- When aggregating a single geolocated event, if swap_coordinates=true then the_geom "
                 + "field contains a point with exchanged latitude and longitude.");
         
         // Create a NGSICartoDBSink
@@ -1711,12 +1711,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default one
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = "true";
+        String swapCoordinates = "true";
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1748,10 +1748,10 @@ public class NGSICartoDBSinkTest {
             try {
                 assertTrue(rows.contains("40.3833,-3.7167"));
                 System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
-                        + "-  OK  - '" + rows + "' contains the coordinates '-3.7167, 40.3833' flipped");
+                        + "-  OK  - '" + rows + "' contains the coordinates '-3.7167, 40.3833' swapped");
             } catch (AssertionError e) {
                 System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
-                        + "- FAIL - '" + rows + "' done not contain the coordinates '-3.7167, 40.3833' flipped");
+                        + "- FAIL - '" + rows + "' done not contain the coordinates '-3.7167, 40.3833' swapped");
                 throw e;
             } // try catch
         } catch (Exception e) {
@@ -1759,7 +1759,7 @@ public class NGSICartoDBSinkTest {
                     + "- FAIL - There was some problem when aggregating in CartoDBAggregator");
             throw e;
         } // try catch
-    } // testAggregateCoordinatesAreFlipped
+    } // testAggregateCoordinatesAreSwapped
     
     /**
      * [NGSICartoDBSink.buildTableName] -------- When data model is by service path, a table name length greater than 63
@@ -1784,12 +1784,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default
+        String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1828,12 +1828,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default
+        String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/tooLoooooooooooooooooooooooooooongServicePath";
         String entity = "tooLoooooooooooooooooooooooooooongEntity";
         String attribute = null; // irrelevant for this test
@@ -1873,12 +1873,12 @@ public class NGSICartoDBSinkTest {
         String enableLowercase = null; // default
         String enableRaw = null; // default one
         String enableRawSnapshot = null; // defatul one
-        String flipCoordinates = null; // default
+        String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
                 batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                flipCoordinates, keysConfFile));
+                swapCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";
         String attribute = "tooLooooooooooooongAttribute";
@@ -1898,7 +1898,7 @@ public class NGSICartoDBSinkTest {
     private Context createContext(String apiKey, String backendMaxConns, String backendMaxConnsPerRoute,
             String batchSize, String batchTimeout, String batchTTL, String dataModel, String enableDistance,
             String enableGrouping, String enableLowercase, String enableRaw, String enableRawSnapshot,
-            String flipCoordinates, String keysConfFile) {
+            String swapCoordinates, String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
         context.put("backend.max_conns", backendMaxConns);
@@ -1912,7 +1912,7 @@ public class NGSICartoDBSinkTest {
         context.put("enable_lowercase", enableLowercase);
         context.put("enable_raw", enableRaw);
         context.put("enable_raw_snapshot", enableRawSnapshot);
-        context.put("flip_coordinates", flipCoordinates);
+        context.put("swap_coordinates", swapCoordinates);
         context.put("keys_conf_file", keysConfFile);
         return context;
     } // createContext

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSIUtilsTest.java
@@ -51,9 +51,9 @@ public class NGSIUtilsTest {
         String attrMetadataStr = "[]";
         String attrValue = "-3.7167, 40.3833";
         String attrType = "geo:point";
-        boolean flipCoordinates = false; // irrelevant for this test
+        boolean swapCoordinates = false; // irrelevant for this test
         ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
-                attrValue, attrType, attrMetadataStr, flipCoordinates);
+                attrValue, attrType, attrMetadataStr, swapCoordinates);
 
         try {
             assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", geometry.getLeft());
@@ -86,9 +86,9 @@ public class NGSIUtilsTest {
         String attrMetadataStr = metadatasJson.toJSONString();
         String attrValue = "-3.7167, 40.3833";
         String attrType = "coordinates"; // irrelevant for this test
-        boolean flipCoordinates = false; // irrelevant for this test
+        boolean swapCoordinates = false; // irrelevant for this test
         ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
-                attrValue, attrType, attrMetadataStr, flipCoordinates);
+                attrValue, attrType, attrMetadataStr, swapCoordinates);
 
         try {
             assertEquals("ST_SetSRID(ST_MakePoint(-3.7167,40.3833), 4326)", geometry.getLeft());
@@ -115,9 +115,9 @@ public class NGSIUtilsTest {
         String attrMetadataStr = "[]";
         String attrValue = "-3.7167, 40.3833";
         String attrType = "coordinates";
-        boolean flipCoordinates = false; // irrelevant for this test
+        boolean swapCoordinates = false; // irrelevant for this test
         ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
-                attrValue, attrType, attrMetadataStr, flipCoordinates);
+                attrValue, attrType, attrMetadataStr, swapCoordinates);
 
         try {
             assertEquals(attrValue, geometry.getLeft());
@@ -142,9 +142,9 @@ public class NGSIUtilsTest {
         String attrMetadataStr = "[]";
         String attrValue = "{\"coordinates\": [-3.7167, 40.3833], \"type\": \"Point\"}";
         String attrType = "geo:json";
-        boolean flipCoordinates = false; // irrelevant for this test
+        boolean swapCoordinates = false; // irrelevant for this test
         ImmutablePair<String, Boolean> geometry = NGSIUtils.getGeometry(
-                attrValue, attrType, attrMetadataStr, flipCoordinates);
+                attrValue, attrType, attrMetadataStr, swapCoordinates);
 
         try {
             assertEquals("ST_GeomFromGeoJSON('{\"coordinates\": [-3.7167, 40.3833], \"type\": \"Point\"}')", geometry.getLeft());

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -422,6 +422,7 @@ Everything equals to the raw-based storing, but:
 | data\_model | no | dm-by-entity |  <i>dm-by-service-path</i> or <i>dm-by-entity</i>. |
 | keys\_conf\_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/Carto usernames and Carto API Keys. |
 | swap\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
+| flip\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. **Deprecated from release 1.6.0 in favour of `swap_coordinates`**. |
 | enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw based storage is done. |
 | enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance based storage is done. |
 | enable\_raw\_snapshot | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a raw snapshot based storage is done. |

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -421,7 +421,7 @@ Everything equals to the raw-based storing, but:
 | enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
 | data\_model | no | dm-by-entity |  <i>dm-by-service-path</i> or <i>dm-by-entity</i>. |
 | keys\_conf\_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/Carto usernames and Carto API Keys. |
-| flip\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
+| swap\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
 | enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw based storage is done. |
 | enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance based storage is done. |
 | enable\_raw\_snapshot | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a raw snapshot based storage is done. |
@@ -444,7 +444,7 @@ cygnus-ngsi.sinks.cartodb-sink.enable_grouping = false
 cygnus-ngsi.sinks.cartodb-sink.enable_name_mappings = false
 cygnus-ngsi.sinks.cartodb-sink.enable_lowercase = false
 cygnus-ngsi.sinks.cartodb-sink.keys_conf_file = /usr/cygnus/conf/cartodb_keys.conf
-cygnus-ngsi.sinks.cartodb-sink.flip_coordinates = true
+cygnus-ngsi.sinks.cartodb-sink.swap_coordinates = true
 cygnus-ngsi.sinks.cartodb-sink.enable_raw = true
 cygnus-ngsi.sinks.cartodb-sink.enable_distance = false
 cygnus-ngsi.sinks.cartodb-sink.enable_raw_snapshot = false

--- a/doc/cygnus-ngsi/installation_and_administration_guide/deprecated_and_removed.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/deprecated_and_removed.md
@@ -4,6 +4,7 @@ Content:
 * [Functionality deprecation and remove policy](#section1)
 * [Deprecated functionalities](#section2)
     * [Grouping Rules](#section2.1)
+    * [`flip_coordinates` parameter](#section2.2)
 * [Removed functionalities](#section3)
     * [`events_ttl` parameter](#section3.1)
     * [XML notifications support](#section3.2)
@@ -30,12 +31,17 @@ Deprecated features are removed not before 3 developement sprints (usually, a de
 [Top](#top)
 
 ##<a name="section2"></a>Deprecated functionalities
-###<a nanem="section2.1"></a>Grouping Rules
+###<a nane="section2.1"></a>Grouping Rules
 Added at version [0.5](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.5) (issue [107](https://github.com/telefonicaid/fiware-cygnus/issues/107)).
 
 Deprecated after releasing version [1.6.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.6.0) (issue [1182](https://github.com/telefonicaid/fiware-cygnus/issues/1182)).
 
 [Top](#top)
+
+###<a name="section2.2"></a>`flip_coordinates` parameter
+Added at version [1.0.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.0.0) (issue [927](https://github.com/telefonicaid/fiware-cygnus/issues/927)).
+
+Deprecated after releasing version [1.6.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.6.0) (issue [1313](https://github.com/telefonicaid/fiware-cygnus/issues/1313)).
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/ngsi_agent_conf.md
@@ -376,7 +376,7 @@ cygnus-ngsi.sinks.cartodb-sink.channel = cartodb-channel
 # absolute path to the CartoDB file containing the mapping between FIWARE service/CartoDB usernames and CartoDB API Keys
 cygnus-ngsi.sinks.cartodb-sink.keys_conf_file = /usr/cygnus/conf/cartodb_keys.conf
 # if true the latitude and longitude values are exchanged, false otherwise
-#cygnus-ngsi.sinks.cartodb-sink.flip_coordinates = true
+#cygnus-ngsi.sinks.cartodb-sink.swap_coordinates = true
 # if true, a raw based storage is done, false otherwise
 #cygnus-ngsi.sinks.cartodb-sink.enable_raw = true
 # if true, a distance based storage is done, false otherwise


### PR DESCRIPTION
* Implements issue #1313 
* 100% tests passed (`cygnus-ngsi`):
```
Tests run: 266, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[NGSICartoDBSink.configure] ----------------------------------------- Configured 'swap_coordinates' cannot be different than 'true' or 'false'
[NGSICartoDBSink.configure] ----------------------------------  OK  - 'swap_coordinates=falso' was detected
[CartoDBAggregator.aggregate] --------------------------------------- When aggregating a single geolocated event, if swap_coordinates=true then the_geom field contains a point with exchanged latitude and longitude.
[CartoDBAggregator.aggregate] --------------------------------  OK  - '('2016-04-20T07:19:55.801Z','somePath','someId','someType',ST_SetSRID(ST_MakePoint(40.3833,-3.7167), 4326),'someValue2','[]')' contains the coordinates '-3.7167, 40.3833' swapped
```

* (Unofficial) e2e tests passed:

Swapping:

```
Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "78"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.361, -3.4099",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
...
Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-28T15:17:54.561Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(-3.4099,40.361), 4326),'78','[]'))
```
Not swapping:

```
Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "78"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.361, -3.4099",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
...
Persisting data at NGSICartoDBSink. Schema (xxx), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-28T15:19:01.131Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.361,-3.4099), 4326),'78','[]'))
```
"Flipping":

```
Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "78"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.361, -3.4099",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
...
Persisting data at NGSICartoDBSink. Schema (soyunpaquete), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-29T08:48:39.928Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(-3.4099,40.361), 4326),'78','[]'))
```

Not "flipping":

```
Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "speed",            "type" : "float",            "value" : "78"          },          {            "name" : "the_geom",            "type" : "geometry",            "value" : "40.361, -3.4099",            "metadatas": [              {                "name": "location",                "type": "string",                "value": "WGS84"              }            ]          }        ],        "type" : "car",        "isPattern" : "false",        "id" : "car1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
...
Persisting data at NGSICartoDBSink. Schema (soyunpaquete), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-11-29T08:49:10.99Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.361,-3.4099), 4326),'78','[]'))
```