### PR TITLE
bug/1331_add_event_to_existent_subbatches

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -21,3 +21,4 @@
 - [cygnus-ngsi][hardening] Update NGSICKANSink documentation regarding resource name length limit imposed by Cygnus (#1325)
 - [cygnus-ngsi][bug] Obtained geometry not properly used in NGSICartoDBSink (#1327)
 - [cygnus-ngsi][hardening] Replace flip_coordinates with swap_coordinates in NGSICartoDBSink (#1313)
+- [cygnus-ngsi][bug] Add event to already existent sub-batches in NGSIBatch (#1331)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIBatch.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIBatch.java
@@ -64,9 +64,11 @@ public class NGSIBatch {
             ArrayList<NGSIEvent> events = new ArrayList<>();
             events.add(event);
             subBatch = new SubBatch(false, events);
-        } // if
-        
-        subBatches.put(destination, subBatch);
+            subBatches.put(destination, subBatch);
+        } else {
+            subBatch.getEvents().add(event);
+        } // if else
+
         numEvents++;
     } // addEvent
 
@@ -107,6 +109,10 @@ public class NGSIBatch {
         return ((SubBatch) nextEntry.getValue()).getEvents();
     } // getNextEvent
     
+    /**
+     * Sets the next sub-batch as persisted.
+     * @param persisted
+     */
     public void setNextPersisted(boolean persisted) {
         ((SubBatch) nextEntry.getValue()).setPersisted(persisted);
     } // setNextPersisted

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIBatchTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIBatchTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.sinks;
+
+import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import com.telefonica.iot.cygnus.utils.TestUtils;
+import java.util.logging.Logger;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class NGSIBatchTest {
+    
+    /**
+     * Constructor.
+     */
+    public NGSIBatchTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSICKANSinkTest
+    
+    /**
+     * [NGSIBatch.addEvent] -------- An event is added to a not existent subbatch.
+     */
+    @Test
+    public void testAddEventNotExistentSubbatch() {
+        System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                + "-------- An event is added to a not existent subbatch");
+        NGSIBatch batch = new NGSIBatch();
+        String destination = "someDestination";
+        String originalCEStr = ""; // not necessary a real one for this test
+        String mappedCEStr = ""; // not necessary a real one for this test
+        String service = "someService";
+        String servicePath = "/someServicePath";
+        String correlatorId = "12345";
+        NGSIEvent event;
+        
+        try {
+            event = TestUtils.createNGSIEvent(originalCEStr, mappedCEStr, service, servicePath, correlatorId);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - There was some problem when creating the NGSI event");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        batch.addEvent(destination, event);
+        batch.startIterator();
+        
+        try {
+            assertTrue(batch.hasNext());
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "-  OK  - The batch has subbatches");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - The batch has not subbatches");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(event, batch.getNextEvents().get(0));
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "-  OK  - The event within the only subbatch is the added one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - The event within the only subbatch is not the added one");
+            throw e;
+        } // try catch
+    } // testAddEventNotExistentSubbatch
+    
+    /**
+     * [NGSIBatch.addEvent] -------- An event is added to an already existent subbatch.
+     */
+    @Test
+    public void testAddEventExistentSubbatch() {
+        System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                + "-------- An event is added to an already existent subbatch");
+        NGSIBatch batch = new NGSIBatch();
+        String destination = "someDestination";
+        String originalCEStr = ""; // not necessary a real one for this test
+        String mappedCEStr = ""; // not necessary a real one for this test
+        String service = "someService";
+        String servicePath = "/someServicePath";
+        String correlatorId = "12345";
+        NGSIEvent event1;
+        
+        try {
+            event1 = TestUtils.createNGSIEvent(originalCEStr, mappedCEStr, service, servicePath, correlatorId);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - There was some problem when creating the first NGSI event");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        batch.addEvent(destination, event1);
+        NGSIEvent event2;
+        
+        try {
+            event2 = TestUtils.createNGSIEvent(originalCEStr, mappedCEStr, service, servicePath, correlatorId);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - There was some problem when creating the second NGSI event");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        batch.addEvent(destination, event2);
+        batch.startIterator();
+        
+        try {
+            assertTrue(batch.hasNext());
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "-  OK  - The batch has subbatches");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - The batch has not subbatches");
+            throw e;
+        } // try catch
+        
+        try {
+            assertEquals(event2, batch.getNextEvents().get(1));
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "-  OK  - The second event within the only subbatch is the secondly added one");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIBatch.addEvent]")
+                    + "- FAIL - The second event within the only subbatch is not the secondly added one");
+            throw e;
+        } // try catch
+    } // testAddEventExistentSubbatch
+    
+} // NGSIBatchTest


### PR DESCRIPTION
* Fixes issue #1331 
* 100% unit tests passed (cygnus-ngsi):
```
Tests run: 268, Failures: 0, Errors: 0, Skipped: 0
```

Relevant tests for this PR:
```
[NGSIBatch.addEvent] ------------------------------------------------ An event is added to an already existent subbatch
[NGSIBatch.addEvent] -----------------------------------------  OK  - The batch has subbatches
[NGSIBatch.addEvent] -----------------------------------------  OK  - The second event within the only subbatch is the secondly added one
[NGSIBatch.addEvent] ------------------------------------------------ An event is added to a not existent subbatch
[NGSIBatch.addEvent] -----------------------------------------  OK  - The batch has subbatches
[NGSIBatch.addEvent] -----------------------------------------  OK  - The event within the only subbatch is the added one
```

* (Unofficial) e2e tests passed:
```
Persisting data at NGSICartoDBSink. Schema (myschema), Table (x002ftrafficxffffcar1xffffcar), Data (('2016-12-01T07:12:17.477Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.364,-3.4102), 4326),'115','[]'),('2016-12-01T07:12:17.929Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.364,-3.4102), 4326),'115','[]'),('2016-12-01T07:12:18.393Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.364,-3.4102), 4326),'115','[]'),('2016-12-01T07:12:18.855Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.364,-3.4102), 4326),'115','[]'),('2016-12-01T07:12:19.303Z','/traffic','car1','car',ST_SetSRID(ST_MakePoint(40.364,-3.4102), 4326),'115','[]'))
```