### PR TITLE
hardening/1330_warn_instead_error_when_no_oauth2_token_hdfs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,3 +22,4 @@
 - [cygnus-ngsi][bug] Obtained geometry not properly used in NGSICartoDBSink (#1327)
 - [cygnus-ngsi][hardening] Replace flip_coordinates with swap_coordinates in NGSICartoDBSink (#1313)
 - [cygnus-ngsi][bug] Add event to already existent sub-batches in NGSIBatch (#1331)
+- [cygnus-ngsi][hardening] Warn instead of Error when no OAuth2 token is configured for NGSIHDFSSink (#1330)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
@@ -281,7 +281,7 @@ public class NGSIHDFSSink extends NGSISink {
         if (oauth2Token != null && oauth2Token.length() > 0) {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (oauth2_token=" + this.oauth2Token + ")");
         } else {
-            LOGGER.error("[" + this.getName() + "] No OAuth2 token provided. Cygnus can continue, but HDFS sink may "
+            LOGGER.warn("[" + this.getName() + "] No OAuth2 token provided. Cygnus can continue, but HDFS sink may "
                     + "not properly work if WebHDFS service is protected with such an authentication and "
                     + "authorization mechanism!");
         } // if else


### PR DESCRIPTION
* Implements issue #1330 
* (Unofficial) e2e tests passed:
```
time=2016-12-01T07:56:15.902UTC | lvl=WARN | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=configure | msg=com.telefonica.iot.cygnus.sinks.NGSIHDFSSink[284] : [hdfs-sink] No OAuth2 token provided. Cygnus can continue, but HDFS sink may not properly work if WebHDFS service is protected with such an authentication and authorization mechanism!
```