### PR TITLE
feature/1317_data_persistence_policy_instead_truncation

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
@@ -63,6 +63,6 @@ public interface CKANBackend {
      * @param expirationTime
      * @throws Exception
      */
-    void expireRecordsCache(long expirationTime) throws Exception;
+    void expirateRecordsCache(long expirationTime) throws Exception;
     
 } // CKANBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackend.java
@@ -38,30 +38,31 @@ public interface CKANBackend {
         throws Exception;
     
     /**
-     * Trucates the resource within the given package, within the given organization, by size.
+     * Caps the resource within the given package, within the given organization up to the maximum number of records.
      * @param orgName
      * @param pkgName
      * @param resName
-     * @param size
+     * @param maxRecords
      * @throws Exception
      */
-    void truncateBySize(String orgName, String pkgName, String resName, long size) throws Exception;
+    void capRecords(String orgName, String pkgName, String resName, long maxRecords) throws Exception;
     
     /**
-     * Truncates the given resource within the given package, within the given organization, by time.
+     * Expirates records within the given resource within the given package, within the given organization, based on
+     * the expiration time.
      * @param orgName
      * @param pkgName
      * @param resName
-     * @param time
+     * @param expirationTime
      * @throws Exception
      */
-    void truncateByTime(String orgName, String pkgName, String resName, long time) throws Exception;
+    void expirateRecords(String orgName, String pkgName, String resName, long expirationTime) throws Exception;
     
     /**
-     * Trucates all the cached resources by time.
-     * @param time
+     * Expirates records within all the cached resources based on the expiration time.
+     * @param expirationTime
      * @throws Exception
      */
-    void truncateCachedByTime(long time) throws Exception;
+    void expireRecordsCache(long expirationTime) throws Exception;
     
 } // CKANBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -512,7 +512,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
     } // deleteRecords
     
     @Override
-    public void truncateBySize(String orgName, String pkgName, String resName, long size) throws Exception {
+    public void capRecords(String orgName, String pkgName, String resName, long maxRecords) throws Exception {
         // Get the resource ID by querying the cache
         String resId = cache.getResId(orgName, pkgName, resName);
         
@@ -524,8 +524,8 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         // Create the filters for a datastore deletion
         String filters = "";
         
-        if (total > size) {
-            for (int i = 0; i < (total - size); i++) {
+        if (total > maxRecords) {
+            for (int i = 0; i < (total - maxRecords); i++) {
                 long id = (Long) ((JSONObject) records.get(i)).get("_id");
                 
                 if (filters.isEmpty()) {
@@ -543,15 +543,15 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             LOGGER.debug("Records must be deleted (resId=" + resId + ", filters=" + filters + ")");
             deleteRecords(resId, filters);
         } // if else
-    } // truncateBySize
+    } // capRecords
     
     @Override
-    public void truncateByTime(String orgName, String pkgName, String resName, long time) throws Exception {
+    public void expirateRecords(String orgName, String pkgName, String resName, long expirationTime) throws Exception {
         throw new UnsupportedOperationException("Not supported yet.");
-    } // truncateByTime
+    } // expirateRecords
 
     @Override
-    public void truncateCachedByTime(long time) throws Exception {
+    public void expireRecordsCache(long expirationTime) throws Exception {
         // Iterate on the cached resource IDs
         cache.startResIterator();
         
@@ -572,7 +572,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                 long recordTime = (Long) record.get("recvTimeTs");
                 long currentTime = new Date().getTime() / 1000;
 
-                if (recordTime < (currentTime - time)) {
+                if (recordTime < (currentTime - expirationTime)) {
                     if (filters.isEmpty()) {
                         filters += "{\"_id\":[" + id;
                     } else {
@@ -589,7 +589,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                 deleteRecords(resId, filters);
             } // if else
         } // while
-    } // truncateCachedByTime
+    } // expireRecordsCache
     
     /**
      * Sets the CKAN cache. This is protected since it is only used by the tests.

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -551,7 +551,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
     } // expirateRecords
 
     @Override
-    public void expireRecordsCache(long expirationTime) throws Exception {
+    public void expirateRecordsCache(long expirationTime) throws Exception {
         // Iterate on the cached resource IDs
         cache.startResIterator();
         
@@ -589,7 +589,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                 deleteRecords(resId, filters);
             } // if else
         } // while
-    } // expireRecordsCache
+    } // expirateRecordsCache
     
     /**
      * Sets the CKAN cache. This is protected since it is only used by the tests.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -254,7 +254,7 @@ public class NGSICKANSink extends NGSISink {
     } // persistBatch
 
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+    public void capRecords(NGSIBatch batch, long maxRecords) throws EventDeliveryException {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
@@ -270,7 +270,7 @@ public class NGSICKANSink extends NGSISink {
             // Get a representative from the current destination sub-batch
             NGSIEvent event = events.get(0);
             
-            // Do the truncation
+            // Do the capping
             String service = event.getServiceForNaming(enableNameMappings);
             String servicePathForNaming = event.getServicePathForNaming(enableGrouping, enableNameMappings);
             String entityForNaming = event.getEntityForNaming(enableGrouping, enableNameMappings, enableEncoding);
@@ -279,20 +279,20 @@ public class NGSICKANSink extends NGSISink {
                 String orgName = buildOrgName(service);
                 String pkgName = buildPkgName(service, servicePathForNaming);
                 String resName = buildResName(entityForNaming);
-                LOGGER.debug("[" + this.getName() + "] Truncating by size (size=" + size + ",orgName=" + orgName
-                        + ", pkgName=" + pkgName + ", resName=" + resName + ")");
-                persistenceBackend.truncateBySize(orgName, pkgName, resName, size);
+                LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",orgName="
+                        + orgName + ", pkgName=" + pkgName + ", resName=" + resName + ")");
+                persistenceBackend.capRecords(orgName, pkgName, resName, maxRecords);
             } catch (Exception e) {
                 throw new EventDeliveryException(e.getMessage());
             } // try catch
         } // while
-    } // truncateBySize
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-        LOGGER.debug("[" + this.getName() + "] Truncating by time (time=" + time + ")");
-        persistenceBackend.truncateCachedByTime(time);
-    } // truncateByTime
+    public void expirateRecords(long expirationTime) throws Exception {
+        LOGGER.debug("[" + this.getName() + "] Expirating records (time=" + expirationTime + ")");
+        persistenceBackend.expireRecordsCache(expirationTime);
+    } // expirateRecords
 
     /**
      * Class for aggregating fieldValues.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -291,7 +291,7 @@ public class NGSICKANSink extends NGSISink {
     @Override
     public void expirateRecords(long expirationTime) throws Exception {
         LOGGER.debug("[" + this.getName() + "] Expirating records (time=" + expirationTime + ")");
-        persistenceBackend.expireRecordsCache(expirationTime);
+        persistenceBackend.expirateRecordsCache(expirationTime);
     } // expirateRecords
 
     /**

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSink.java
@@ -368,12 +368,12 @@ public class NGSICartoDBSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     /**
      * Convenience class for aggregating data.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSink.java
@@ -167,12 +167,12 @@ public class NGSIDynamoDBSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
 
     /**
      * Class for aggregating data regarding a destination in a servicePath, in a service.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
@@ -508,12 +508,12 @@ public class NGSIHDFSSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
 
     /**
      * Class for aggregating aggregation.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIKafkaSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIKafkaSink.java
@@ -159,12 +159,12 @@ public class NGSIKafkaSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     /**
      * Builds the topic name.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoSink.java
@@ -116,12 +116,12 @@ public class NGSIMongoSink extends NGSIMongoBaseSink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     /**
      * Class for aggregating batches.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -197,12 +197,12 @@ public class NGSIMySQLSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     /**
      * Class for aggregating.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -232,12 +232,12 @@ public class NGSIPostgreSQLSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
 
     /**
      * Class for aggregating fieldValues.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
@@ -96,12 +96,12 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     private void persistOne(NGSIEvent event) throws Exception {
         // get some values from the event

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSITestSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSITestSink.java
@@ -93,12 +93,12 @@ public class NGSITestSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
-    } // truncateBySize
+    public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
+    } // capRecords
 
     @Override
-    public void truncateByTime(long time) throws Exception {
-    } // truncateByTime
+    public void expirateRecords(long time) throws Exception {
+    } // expirateRecords
     
     /**
      * Class for aggregating aggregation.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
@@ -45,13 +45,13 @@ public class NGSIMongoBaseSinkTest {
         } // persistBatch
 
         @Override
-        public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+        public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
             throw new UnsupportedOperationException("Not supported yet.");
-        } // truncateBySize
+        } // capRecords
 
         @Override
-        public void truncateByTime(long time) {
-        } // truncateByTime
+        public void expirateRecords(long time) {
+        } // expirateRecords
         
     } // NGSIMongoBaseSinkImpl
     

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
@@ -93,13 +93,13 @@ public class NGSISinkTest {
         } // persistBatch
 
         @Override
-        public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+        public void capRecords(NGSIBatch batch, long size) throws EventDeliveryException {
             throw new UnsupportedOperationException("Not supported yet.");
-        } // truncateBySize
+        } // capRecords
 
         @Override
-        public void truncateByTime(long time) {
-        } // truncateByTime
+        public void expirateRecords(long time) {
+        } // expirateRecords
         
     } // NGSISinkImpl
     
@@ -241,35 +241,35 @@ public class NGSISinkTest {
         } // try catch
         
         try {
-            assertEquals(-1, sink.getTruncationMaxRecords());
+            assertEquals(-1, sink.getPersistencePolicyMaxRecords());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The default configuration value for 'truncation.max_records' is '-1'");
+                    + "-  OK  - The default configuration value for 'persistence_poilicy.max_records' is '-1'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
                     + "- FAIL - The default configuration value for "
-                    + "'truncation.max_records' is '" + sink.getTruncationMaxRecords() + "'");
+                    + "'persistence_poilicy.max_records' is '" + sink.getPersistencePolicyMaxRecords() + "'");
             throw e;
         } // try catch
         
         try {
-            assertEquals(-1, sink.getTruncationMaxTime());
+            assertEquals(-1, sink.getPersistencePolicyExpirationTime());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The default configuration value for 'truncation.max_time' is '-1'");
+                    + "-  OK  - The default configuration value for 'persistence_poilicy.expiration_time' is '-1'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
                     + "- FAIL - The default configuration value for "
-                    + "'truncation.max_time' is '" + sink.getTruncationMaxTime() + "'");
+                    + "'persistence_poilicy.expiration_time' is '" + sink.getPersistencePolicyExpirationTime() + "'");
             throw e;
         } // try catch
         
         try {
-            assertEquals(3600, sink.getTruncationCheckingTime());
+            assertEquals(3600, sink.getPersistencePolicyCheckingTime());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The default configuration value for 'truncation.checking_time' is '3600000'");
+                    + "-  OK  - The default configuration value for 'persistence_poilicy.checking_time' is '3600000'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
                     + "- FAIL - The default configuration value for "
-                    + "'truncation.checking_time' is '" + sink.getTruncationCheckingTime() + "'");
+                    + "'persistence_poilicy.checking_time' is '" + sink.getPersistencePolicyCheckingTime() + "'");
             throw e;
         } // try catch
     } // testConfigureNotMandatoryParameters
@@ -283,46 +283,46 @@ public class NGSISinkTest {
         System.out.println(getTestTraceHead("[NGSISink.configure]")
                 + "-------- When configured, non mandatory parameters get the appropiate value");
         NGSISinkImpl sink = new NGSISinkImpl();
-        String truncationMaxRecords = "5";
-        sink.configure(createContext(null, null, null, null, null, null, null, null, truncationMaxRecords, null, null));
+        String maxRecords = "5";
+        sink.configure(createContext(null, null, null, null, null, null, null, null, maxRecords, null, null));
         
         try {
-            assertEquals(5, sink.getTruncationMaxRecords());
+            assertEquals(5, sink.getPersistencePolicyMaxRecords());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The configuration value for 'truncation.max_records' is '5'");
+                    + "-  OK  - The configuration value for 'persistence_policy.max_records' is '5'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "- FAIL - The configuration value for 'truncation_max_records' is '"
-                    + sink.getTruncationMaxRecords() + "'");
+                    + "- FAIL - The configuration value for 'persistence_policy.max_records' is '"
+                    + sink.getPersistencePolicyMaxRecords() + "'");
             throw e;
         } // try catch
         
-        String truncationMaxTime = "60";
-        sink.configure(createContext(null, null, null, null, null, null, null, null, null, truncationMaxTime, null));
+        String expirationTime = "60";
+        sink.configure(createContext(null, null, null, null, null, null, null, null, null, expirationTime, null));
         
         try {
-            assertEquals(60, sink.getTruncationMaxTime());
+            assertEquals(60, sink.getPersistencePolicyExpirationTime());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The configuration value for 'truncation.max_time' is '60'");
+                    + "-  OK  - The configuration value for 'persistence_policy.expiration_time' is '60'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "- FAIL - The configuration value for 'truncation.max_time' is '"
-                    + sink.getTruncationMaxTime() + "'");
+                    + "- FAIL - The configuration value for 'persistence_policy.expiration_time' is '"
+                    + sink.getPersistencePolicyExpirationTime() + "'");
             throw e;
         } // try catch
         
-        String truncationCheckingTime = "7200";
+        String checkingTime = "7200";
         sink.configure(createContext(null, null, null, null, null, null, null, null, null, null,
-                truncationCheckingTime));
+                checkingTime));
         
         try {
-            assertEquals(7200, sink.getTruncationCheckingTime());
+            assertEquals(7200, sink.getPersistencePolicyCheckingTime());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - The configuration value for 'truncation.checking_time' is '7200'");
+                    + "-  OK  - The configuration value for 'persistence_policy.checking_time' is '7200'");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "- FAIL - The configuration value for 'truncation.checking_time' is '"
-                    + sink.getTruncationCheckingTime() + "'");
+                    + "- FAIL - The configuration value for 'persistence_policy.checking_time' is '"
+                    + sink.getPersistencePolicyCheckingTime() + "'");
             throw e;
         } // try catch
     } // testConfigureModifyNotMandatoryParameters
@@ -465,21 +465,21 @@ public class NGSISinkTest {
         } // try catch
         
         sink = new NGSISinkImpl();
-        String truncationCheckingTime = "-1000";
+        String checkingTime = "-1000";
         sink.configure(createContext(null, null, null, null, null, null, null, null, null, null,
-                truncationCheckingTime));
+                checkingTime));
         
         try {
             assertTrue(sink.getInvalidConfiguration());
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "-  OK  - A wrong configuration 'truncation.checking_time='"
-                    + truncationCheckingTime + "' has been detected");
+                    + "-  OK  - A wrong configuration 'persistence_policy.checking_time='"
+                    + checkingTime + "' has been detected");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSISink.configure]")
-                    + "- FAIL - A wrong configuration 'truncation.checking_time='"
-                    + truncationCheckingTime + "' has not been detected");
+                    + "- FAIL - A wrong configuration 'persistence_policy.checking_time='"
+                    + checkingTime + "' has not been detected");
             throw e;
-        } // try catch
+        } // try catch // try catch
     } // testConfigureInvalidConfiguration
     
     /**
@@ -1480,7 +1480,8 @@ public class NGSISinkTest {
     
     private Context createContext(String batchRetryIntervals, String batchSize, String batchTimeout, String batchTTL,
             String dataModel, String enableGrouping, String enableLowercase, String enableNameMappings,
-            String truncationMaxRecords, String truncationMaxTime, String truncationCheckingTime) {
+            String perisistencePolicyMaxRecords, String perisistencePolicyExpirationTime,
+            String perisistencePolicyCheckingTime) {
         Context context = new Context();
         context.put("batch_retry_intervals", batchRetryIntervals);
         context.put("batch_size", batchSize);
@@ -1490,9 +1491,9 @@ public class NGSISinkTest {
         context.put("enable_grouping", enableGrouping);
         context.put("enable_lowercase", enableLowercase);
         context.put("enable_name_mappings", enableNameMappings);
-        context.put("truncation.max_records", truncationMaxRecords);
-        context.put("truncation.max_time", truncationMaxTime);
-        context.put("truncation.checking_time", truncationCheckingTime);
+        context.put("persistence_policy.max_records", perisistencePolicyMaxRecords);
+        context.put("persistence_policy.expiration_time", perisistencePolicyExpirationTime);
+        context.put("persistence_policy.checking_time", perisistencePolicyCheckingTime);
         return context;
     } // createContext
     

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink.md
@@ -22,7 +22,7 @@ Content:
         * [About batching](#section2.3.2)
         * [About the encoding](#section2.3.3)
         * [About geolocation attributes](#section2.3.4)
-        * [About truncating resources](#section2.3.5)
+        * [About capping resources/expirating records](#section2.3.5)
 * [Programmers guide](#section3)
     * [`NGSICKANSink` class](#section3.1)
 * [Annexes](#section4)
@@ -339,9 +339,9 @@ NOTE: `curl` is a Unix command allowing for interacting with REST APIs such as t
 | batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 | backend.max\_conns | no | 500 | Maximum number of connections allowed for a Http-based HDFS backend. |
 | backend.max\_conns\_per\_route | no | 100 | Maximum number of connections per route allowed for a Http-based HDFS backend. |
-| truncation.max_records | no | -1 | Maximum number of records allowed for a resource before a size-based truncation is performed. `-1` disables this kind of truncation. |
-| truncation.max_time | no | -1 | Maximum number of seconds a record is maintained in a resource before a time-based truncation is performed. `-1` disables this kind of truncation. |
-| truncation.checking_time | no | 3600 | Frequency (in seconds) at which the sink ckecks for time-based truncations. |
+| persistence\_policy.max_records | no | -1 | Maximum number of records allowed for a resource before it is capped. `-1` disables this policy. |
+| persistence\_policy.expiration_time | no | -1 | Maximum number of seconds a record is maintained in a resource before expiration. `-1` disables this policy. |
+| persistence\_policy.checking_time | no | 3600 | Frequency (in seconds) at which the sink ckecks for record expiration. |
 
 A configuration example could be:
 
@@ -367,9 +367,9 @@ A configuration example could be:
     cygnus-ngsi.sinks.ckan-sink.batch_retry_intervals = 5000
     cygnus-ngsi.sinks.ckan-sink.backend.max_conns = 500
     cygnus-ngsi.sinks.ckan-sink.backend.max_conns_per_route = 100
-    cygnus-ngsi.sinks.ckan-sink.truncation.max_records = 5
-    cygnus-ngsi.sinks.ckan-sink.truncation.max_time = 86400
-    cygnus-ngsi.sinks.ckan-sink.truncation.checking_time = 600
+    cygnus-ngsi.sinks.ckan-sink.persistence_policy.max_records = 5
+    cygnus-ngsi.sinks.ckan-sink.persistence_policy.expiration_time = 86400
+    cygnus-ngsi.sinks.ckan-sink.persistence_policy.checking_time = 600
 
 [Top](#top)
 
@@ -441,11 +441,11 @@ Finally, it must be said this way of mapping geolocated context information into
 
 [Top](#top)
 
-####<a name="section2.3.5"></a>About truncating resources
-Truncation is disabled by default. Nevertheless, if desired, this can be achieved in two ways:
+####<a name="section2.3.5"></a>About capping resources and expirating records
+Capping and expiration are disabled by default. Nevertheless, if desired, this can be enabled:
 
-* Truncating by the number of records. This kind of truncation allows the resource growing up until certain configured maximum number of records is reached (`truncation.max_records`), and then maintains a such a constant number of records.
-* Truncating by time the record was upserted. This kind of truncation allows the resource growing up until records become old, i.e. overcome certain configured maximum time (`truncation.max_time`).
+* Capping by the number of records. This allows the resource growing up until certain configured maximum number of records is reached (`persistence_policy.max_records`), and then maintains a such a constant number of records.
+* Expirating by time the records. This allows the resource growing up until records become old, i.e. overcome certain configured expiration time (`persistence_policy.expiration_time`).
 
 [Top](#top)
 
@@ -457,13 +457,13 @@ As any other NGSI-like sink, `NGSICKANSink` extends the base `NGSISink`. The met
 
 A `NGSIBatch` contains a set of `NGSIEvent` objects, which are the result of parsing the notified context data events. Data within the batch is classified by destination, and in the end, a destination specifies the CKAN resource where the data is going to be persisted. Thus, each destination is iterated in order to compose a per-destination data string to be persisted thanks to any `CKANBackend` implementation.
 
-    void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException;
+    void capRecords(NGSIBatch batch, long maxRecords) throws EventDeliveryException;
     
-This method is always called immediatelly after `persistBacth()`. The same destination resources that were upserted are now checked in terms of number of records: if the configured maximum (`truncation.max_records`) is overcome for any of the updated resources, then as many oldest records are deleted as required until the maximum number of records is reached.
+This method is always called immediatelly after `persistBacth()`. The same destination resources that were upserted are now checked in terms of number of records: if the configured maximum (`persistence_policy.max_records`) is overcome for any of the updated resources, then as many oldest records are deleted as required until the maximum number of records is reached.
     
-    void truncateByTime(long time);
+    void expirateRecords(long expirationTime);
     
-This method is called in a peridocial way (based on `truncation.checking_time`), and if the configured maximum time (`truncation.max_time`) is overcome for any of the records within any of the updated resources, then it is deleted.
+This method is called in a peridocial way (based on `persistence_policy.checking_time`), and if the configured expiration time (`persistence_policy.expiration_time`) is overcome for any of the records within any of the resources, then it is deleted.
 
     public void start();
 


### PR DESCRIPTION
* Implements the replacement of "truncation" with "persistence policy", issue #1317 
* (Unofficial) e2e tests passed:

Capping resources:
```
time=2016-12-22T15:43:24.616UTC | lvl=DEBUG | corr=8e2815e8-b662-490a-bd57-0dda62856376 | trans=8e2815e8-b662-490a-bd57-0dda62856376 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_search", "success": true, "result": {"resource_id": "234052d9-c736-4172-96f5-252fe2ad604d", "fields": [{"type": "int4", "id": "_id"}, {"type": "int4", "id": "recvTimeTs"}, {"type": "timestamp", "id": "recvTime"}, {"type": "text", "id": "fiwareServicePath"}, {"type": "text", "id": "entityId"}, {"type": "text", "id": "entityType"}, {"type": "text", "id": "attrName"}, {"type": "text", "id": "attrType"}, {"type": "json", "id": "attrValue"}, {"type": "json", "id": "attrMd"}], "records": [{"attrType": "centigrade", "recvTime": "2016-12-21T15:36:35.488000", "recvTimeTs": 1482334595, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 46}, {"attrType": "centigrade", "recvTime": "2016-12-21T15:36:35.662000", "recvTimeTs": 1482334595, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 47}, {"attrType": "centigrade", "recvTime": "2016-12-21T15:36:36.121000", "recvTimeTs": 1482334596, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 48}, {"attrType": "centigrade", "recvTime": "2016-12-21T15:36:36.535000", "recvTimeTs": 1482334596, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 49}, {"attrType": "centigrade", "recvTime": "2016-12-21T15:36:36.910000", "recvTimeTs": 1482334596, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 50}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:54.192000", "recvTimeTs": 1482421314, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 52}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:54.457000", "recvTimeTs": 1482421314, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 53}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:55.619000", "recvTimeTs": 1482421315, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 54}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:43:17.244000", "recvTimeTs": 1482421397, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 55}], "_links": {"start": "/api/3/action/datastore_search", "next": "/api/3/action/datastore_search?offset=100"}, "total": 9}}
time=2016-12-22T15:43:24.617UTC | lvl=DEBUG | corr=8e2815e8-b662-490a-bd57-0dda62856376 | trans=8e2815e8-b662-490a-bd57-0dda62856376 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=capRecords | msg=com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl[543] : Records must be deleted (resId=234052d9-c736-4172-96f5-252fe2ad604d, filters={"_id":[46,47,48,49]})
```

Expirating records:
```
time=2016-12-22T15:44:28.779UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=createJsonResponse | msg=com.telefonica.iot.cygnus.backends.http.HttpBackend[307] : Http response payload: {"help": "http://demo.ckan.org/api/3/action/help_show?name=datastore_search", "success": true, "result": {"resource_id": "234052d9-c736-4172-96f5-252fe2ad604d", "fields": [{"type": "int4", "id": "_id"}, {"type": "int4", "id": "recvTimeTs"}, {"type": "timestamp", "id": "recvTime"}, {"type": "text", "id": "fiwareServicePath"}, {"type": "text", "id": "entityId"}, {"type": "text", "id": "entityType"}, {"type": "text", "id": "attrName"}, {"type": "text", "id": "attrType"}, {"type": "json", "id": "attrValue"}, {"type": "json", "id": "attrMd"}], "records": [{"attrType": "centigrade", "recvTime": "2016-12-21T15:36:36.910000", "recvTimeTs": 1482334596, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 50}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:54.192000", "recvTimeTs": 1482421314, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 52}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:54.457000", "recvTimeTs": 1482421314, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 53}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:41:55.619000", "recvTimeTs": 1482421315, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 54}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:43:17.244000", "recvTimeTs": 1482421397, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 55}, {"attrType": "centigrade", "recvTime": "2016-12-22T15:44:21.210000", "recvTimeTs": 1482421461, "attrMd": null, "attrValue": "26.5", "entityType": "Room", "attrName": "temperature", "fiwareServicePath": "/traffic", "entityId": "Room1", "_id": 56}], "_links": {"start": "/api/3/action/datastore_search", "next": "/api/3/action/datastore_search?offset=100"}, "total": 6}}
time=2016-12-22T15:44:28.780UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=expireRecordsCache | msg=com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl[588] : Records to be deleted, resId=234052d9-c736-4172-96f5-252fe2ad604d, filters={"_id":[50,52,53,54]}
```