### PR TITLE
hardening/1358_improve_logs_ngsisink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - [cygnus] Add Travis CI (#1347)
 - [cygnus-ngsi][hardening] Force lowercase organization, dataset and resource names in NGSICKANSink (#1352)
 - [cygnus-ngsi][hardening] Replace warnings upon unnecessary header received with debug traces at NGSIRestHandler (#1354)
+- [cygnus-ngsi][hardening] Improve persistence error logs at NGSISink (#1358)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -29,7 +29,7 @@ public class CygnusBadConfiguration extends Exception {
      * @param message
      */
     public CygnusBadConfiguration(String message) {
-        super("Bad configuration (" + message + ")");
+        super("Bad configuration. Message: " + message);
     } // CygnusBadConfiguration
     
 } // CygnusBadConfiguration

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -29,7 +29,7 @@ public class CygnusBadContextData extends Exception {
      * @param message
      */
     public CygnusBadContextData(String message) {
-        super("Bad context data (" + message + ")");
+        super("Bad context data. Message: " + message);
     } // CygnusBadContextData
     
 } // CygnusBadContextData

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.errors;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusCappingError extends Exception {
+    
+    /**
+     * Constructor.
+     * @param message
+     */
+    public CygnusCappingError(String message) {
+        super("Error while capping persistence elements. Message: " + message);
+    } // CygnusCappingError
+    
+} // CygnusCappingError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.errors;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusExpiratingError extends Exception {
+    
+    /**
+     * Constructor.
+     * @param message
+     */
+    public CygnusExpiratingError(String message) {
+        super("Error while expirating records. Message: " + message);
+    } // CygnusExpiratingError
+    
+} // CygnusExpiratingError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -29,7 +29,7 @@ public class CygnusPersistenceError extends Exception {
      * @param message
      */
     public CygnusPersistenceError(String message) {
-        super("Persistence error (" + message + ")");
+        super("Persistence error. Message: " + message);
     } // CygnusPersistenceError
     
 } // CygnusPersistenceError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *
@@ -29,7 +29,7 @@ public class CygnusRuntimeError extends Exception {
      * @param message
      */
     public CygnusRuntimeError(String message) {
-        super("Runtime error (" + message + ")");
+        super("Runtime error. Message: " + message);
     } // CygnusRuntimeError
     
 } // CygnusRuntimeError

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -248,7 +248,7 @@ public class NGSICKANSink extends NGSISink {
             for (NGSIEvent event : events) {
                 aggregator.aggregate(event);
             } // for
-            
+
             // Persist the aggregation
             persistAggregation(aggregator);
             batch.setNextPersisted(true);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIDynamoDBSink.java
@@ -23,6 +23,9 @@ import com.telefonica.iot.cygnus.backends.dynamo.DynamoDBBackend;
 import com.telefonica.iot.cygnus.backends.dynamo.DynamoDBBackendImpl;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
@@ -35,7 +38,6 @@ import com.telefonica.iot.cygnus.utils.NGSIConstants;
 import java.util.ArrayList;
 import java.util.Date;
 import org.apache.flume.Context;
-import org.apache.flume.EventDeliveryException;
 
 /**
  *
@@ -135,7 +137,7 @@ public class NGSIDynamoDBSink extends NGSISink {
     } // start
 
     @Override
-    void persistBatch(NGSIBatch batch) throws Exception {
+    void persistBatch(NGSIBatch batch) throws CygnusBadConfiguration, CygnusPersistenceError {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
@@ -167,11 +169,11 @@ public class NGSIDynamoDBSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+    public void truncateBySize(NGSIBatch batch, long size) throws CygnusCappingError {
     } // truncateBySize
 
     @Override
-    public void truncateByTime(long time) throws Exception {
+    public void truncateByTime(long time) throws CygnusExpiratingError {
     } // truncateByTime
 
     /**
@@ -199,7 +201,7 @@ public class NGSIDynamoDBSink extends NGSISink {
             } // if else
         } // getTableName
 
-        public void initialize(NGSIEvent event) throws Exception {
+        public void initialize(NGSIEvent event) throws CygnusBadConfiguration {
             service = event.getServiceForNaming(enableNameMappings);
             servicePathForData = event.getServicePathForData();
             servicePathForNaming = event.getServicePathForNaming(enableGrouping, enableNameMappings);
@@ -208,7 +210,7 @@ public class NGSIDynamoDBSink extends NGSISink {
             aggregation = new ArrayList<>();
         } // initialize
 
-        public abstract void aggregate(NGSIEvent cygnusEvent) throws Exception;
+        public abstract void aggregate(NGSIEvent cygnusEvent);
 
     } // DynamoDBAggregator
 
@@ -218,12 +220,12 @@ public class NGSIDynamoDBSink extends NGSISink {
     private class DynamoDBRowAggregator extends DynamoDBAggregator {
 
         @Override
-        public void initialize(NGSIEvent cygnusEvent) throws Exception {
+        public void initialize(NGSIEvent cygnusEvent) throws CygnusBadConfiguration {
             super.initialize(cygnusEvent);
         } // initialize
 
         @Override
-        public void aggregate(NGSIEvent event) throws Exception {
+        public void aggregate(NGSIEvent event) {
             // get the getRecvTimeTs headers
             long recvTimeTs = event.getRecvTimeTs();
             String recvTime = CommonUtils.getHumanReadable(recvTimeTs, true);
@@ -279,12 +281,12 @@ public class NGSIDynamoDBSink extends NGSISink {
     private class DynamoDBColumnAggregator extends DynamoDBAggregator {
 
         @Override
-        public void initialize(NGSIEvent event) throws Exception {
+        public void initialize(NGSIEvent event) throws CygnusBadConfiguration {
             super.initialize(event);
         } // initialize
 
         @Override
-        public void aggregate(NGSIEvent event) throws Exception {
+        public void aggregate(NGSIEvent event) {
             // get the getRecvTimeTs headers
             long recvTimeTs = event.getRecvTimeTs();
             String recvTime = CommonUtils.getHumanReadable(recvTimeTs, true);
@@ -342,7 +344,7 @@ public class NGSIDynamoDBSink extends NGSISink {
         } // if else
     } // getAggregator
 
-    private void persistAggregation(DynamoDBAggregator aggregator) throws Exception {
+    private void persistAggregation(DynamoDBAggregator aggregator) throws CygnusPersistenceError {
         ArrayList aggregation = aggregator.getAggregation();
         String tableName = aggregator.getTableName(enableLowercase);
 
@@ -351,12 +353,17 @@ public class NGSIDynamoDBSink extends NGSISink {
 
         // tables can be always created in DynamoDB, independedntly of the attribute persistence mode,
         // since it is NoSQL and there is no fixed structure
-        persistenceBackend.createTable(tableName, NGSIConstants.DYNAMO_DB_PRIMARY_KEY);
-        persistenceBackend.putItems(tableName, aggregation);
+        
+        try {
+            persistenceBackend.createTable(tableName, NGSIConstants.DYNAMO_DB_PRIMARY_KEY);
+            persistenceBackend.putItems(tableName, aggregation);
+        } catch (Exception e) {
+            throw new CygnusPersistenceError("-, " + e.getMessage());
+        } // try catch
     } // persistAggregation
 
     private String buildTableName(String service, String servicePath, String destination, DataModel dataModel)
-        throws Exception {
+        throws CygnusBadConfiguration {
         String tableName;
 
         switch (dataModel) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSink.java
@@ -166,9 +166,9 @@ public abstract class NGSIMongoBaseSink extends NGSISink {
      * Builds a database name given a fiwareService. It throws an exception if the naming conventions are violated.
      * @param fiwareService
      * @return
-     * @throws Exception
+     * @throws CygnusBadConfiguration
      */
-    protected String buildDbName(String fiwareService) throws Exception {
+    protected String buildDbName(String fiwareService) throws CygnusBadConfiguration {
         String dbName;
         
         if (enableEncoding) {
@@ -192,10 +192,10 @@ public abstract class NGSIMongoBaseSink extends NGSISink {
      * @param entity
      * @param attribute
      * @return
-     * @throws Exception
+     * @throws CygnusBadConfiguration
      */
     protected String buildCollectionName(String fiwareServicePath, String entity, String attribute)
-        throws Exception {
+        throws CygnusBadConfiguration {
         String collectionName;
 
         if (enableEncoding) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISTHSink.java
@@ -19,13 +19,19 @@ package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import static com.telefonica.iot.cygnus.sinks.NGSIMongoBaseSink.LOGGER;
 import com.telefonica.iot.cygnus.utils.CommonUtils;
 import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.flume.Context;
-import org.apache.flume.EventDeliveryException;
 
 /**
  *
@@ -68,7 +74,7 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
     } // configure
     
     @Override
-    public void persistBatch(NGSIBatch batch) throws Exception {
+    public void persistBatch(NGSIBatch batch) throws CygnusBadConfiguration, CygnusPersistenceError {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
@@ -96,14 +102,14 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+    public void truncateBySize(NGSIBatch batch, long size) throws CygnusCappingError {
     } // truncateBySize
 
     @Override
-    public void truncateByTime(long time) throws Exception {
+    public void truncateByTime(long time) throws CygnusExpiratingError {
     } // truncateByTime
     
-    private void persistOne(NGSIEvent event) throws Exception {
+    private void persistOne(NGSIEvent event) throws CygnusBadConfiguration, CygnusPersistenceError {
         // get some values from the event
         Long notifiedRecvTimeTs = event.getRecvTimeTs();
         String service = event.getServiceForNaming(enableNameMappings);
@@ -115,7 +121,12 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
         // create the database for this service if not yet existing... the cost of trying to create it is the same
         // than checking if it exits and then creating it
         String dbName = enableLowercase ? buildDbName(service).toLowerCase() : buildDbName(service);
-        backend.createDatabase(dbName);
+        
+        try {
+            backend.createDatabase(dbName);
+        } catch (Exception e) {
+            throw new CygnusPersistenceError("-, " + e.getMessage());
+        } // try catch
         
         // collection name container
         String collectionName = null;
@@ -125,7 +136,12 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
             collectionName = enableLowercase
                     ? (buildCollectionName(servicePathForNaming, null, null) + ".aggr").toLowerCase()
                     : buildCollectionName(servicePathForNaming, null, null) + ".aggr";
-            backend.createCollection(dbName, collectionName, dataExpiration);
+            
+            try {
+                backend.createCollection(dbName, collectionName, dataExpiration);
+            } catch (Exception e) {
+                throw new CygnusPersistenceError("-, " + e.getMessage());
+            } // try catch
         } // if
         
         String entityId = contextElement.getId();
@@ -138,7 +154,12 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
             collectionName = enableLowercase
                     ? (buildCollectionName(servicePathForNaming, entityForNaming, null) + ".aggr").toLowerCase()
                     : buildCollectionName(servicePathForNaming, entityForNaming, null) + ".aggr";
-            backend.createCollection(dbName, collectionName, dataExpiration);
+            
+            try {
+                backend.createCollection(dbName, collectionName, dataExpiration);
+            } catch (Exception e) {
+                throw new CygnusPersistenceError("-, " + e.getMessage());
+            } // try catch
         } // if
 
         // iterate on all this entity's attributes, if there are attributes
@@ -180,7 +201,12 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
                 collectionName = enableLowercase
                         ? (buildCollectionName(servicePathForNaming, entityForNaming, attrName) + ".aggr").toLowerCase()
                         : buildCollectionName(servicePathForNaming, entityForNaming, attrName) + ".aggr";
-                backend.createCollection(dbName, collectionName, dataExpiration);
+                
+                try {
+                    backend.createCollection(dbName, collectionName, dataExpiration);
+                } catch (Exception e) {
+                    throw new CygnusPersistenceError("-, " + e.getMessage());
+                } // try catch
             } // if
 
             // insert the data
@@ -188,8 +214,13 @@ public class NGSISTHSink extends NGSIMongoBaseSink {
                     + ", Collection: " + collectionName + ", Data: " + recvTimeTs + ","
                     + entityId + "," + entityType + "," + attrName + "," + attrType + "," + attrValue + ","
                     + attrMetadata);
-            backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs,
-                    entityId, entityType, attrName, attrType, attrValue, attrMetadata, resolutions);
+            
+            try {
+                backend.insertContextDataAggregated(dbName, collectionName, recvTimeTs,
+                        entityId, entityType, attrName, attrType, attrValue, attrMetadata, resolutions);
+            } catch (Exception e) {
+                throw new CygnusPersistenceError("-, " + e.getMessage());
+            } // try catch
         } // for
     } // persistOne
     

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSITestSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSITestSink.java
@@ -21,6 +21,10 @@ package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
@@ -28,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.flume.Context;
-import org.apache.flume.EventDeliveryException;
 
 /**
  * Sink for testing purposes. It does not persistOne the notified context data but
@@ -61,7 +64,7 @@ public class NGSITestSink extends NGSISink {
     } // start
     
     @Override
-    void persistBatch(NGSIBatch batch) throws Exception {
+    void persistBatch(NGSIBatch batch) {
         if (batch == null) {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
@@ -93,11 +96,11 @@ public class NGSITestSink extends NGSISink {
     } // persistBatch
     
     @Override
-    public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+    public void truncateBySize(NGSIBatch batch, long size) throws CygnusCappingError {
     } // truncateBySize
 
     @Override
-    public void truncateByTime(long time) throws Exception {
+    public void truncateByTime(long time) throws CygnusExpiratingError {
     } // truncateByTime
     
     /**
@@ -116,10 +119,10 @@ public class NGSITestSink extends NGSISink {
             return aggregation;
         } // getAggregation
         
-        public void initialize(NGSIEvent event) throws Exception {
+        public void initialize(NGSIEvent event) {
         } // initialize
         
-        public void aggregate(NGSIEvent event) throws Exception {
+        public void aggregate(NGSIEvent event) {
             String line = "Processing event={";
             
             // get the getRecvTimeTs headers
@@ -174,7 +177,7 @@ public class NGSITestSink extends NGSISink {
         
     } // TestAggregator
     
-    private void persistAggregation(TestAggregator aggregator) throws Exception {
+    private void persistAggregation(TestAggregator aggregator) {
         String aggregation = aggregator.getAggregation();
         
         LOGGER.info("[" + this.getName() + "] Persisting data at NGSITestSink. Data (" + aggregation + ")");

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIMongoBaseSinkTest.java
@@ -17,11 +17,13 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
 import com.telefonica.iot.cygnus.utils.NGSICharsets;
 import com.telefonica.iot.cygnus.utils.NGSIUtils;
 import com.telefonica.iot.cygnus.utils.NGSIUtilsForTests;
-import org.apache.flume.EventDeliveryException;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import static org.junit.Assert.assertEquals;
@@ -40,17 +42,17 @@ public class NGSIMongoBaseSinkTest {
     private class NGSIMongoBaseSinkImpl extends NGSIMongoBaseSink {
 
         @Override
-        void persistBatch(NGSIBatch batch) throws Exception {
+        void persistBatch(NGSIBatch batch) throws CygnusPersistenceError {
             throw new UnsupportedOperationException("Not supported yet.");
         } // persistBatch
 
         @Override
-        public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+        public void truncateBySize(NGSIBatch batch, long size) throws CygnusCappingError {
             throw new UnsupportedOperationException("Not supported yet.");
         } // truncateBySize
 
         @Override
-        public void truncateByTime(long time) {
+        public void truncateByTime(long time) throws CygnusExpiratingError {
         } // truncateByTime
         
     } // NGSIMongoBaseSinkImpl

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSISinkTest.java
@@ -18,6 +18,9 @@
 package com.telefonica.iot.cygnus.sinks;
 
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
 import com.telefonica.iot.cygnus.sinks.NGSISink.Accumulator;
@@ -30,7 +33,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flume.Context;
-import org.apache.flume.EventDeliveryException;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.log4j.Level;
@@ -88,17 +90,17 @@ public class NGSISinkTest {
     private class NGSISinkImpl extends NGSISink {
 
         @Override
-        void persistBatch(NGSIBatch batch) throws Exception {
+        void persistBatch(NGSIBatch batch) throws CygnusPersistenceError {
             throw new UnsupportedOperationException("Not supported yet.");
         } // persistBatch
 
         @Override
-        public void truncateBySize(NGSIBatch batch, long size) throws EventDeliveryException {
+        public void truncateBySize(NGSIBatch batch, long size) throws CygnusCappingError {
             throw new UnsupportedOperationException("Not supported yet.");
         } // truncateBySize
 
         @Override
-        public void truncateByTime(long time) {
+        public void truncateByTime(long time) throws CygnusExpiratingError {
         } // truncateByTime
         
     } // NGSISinkImpl


### PR DESCRIPTION
* Implements issue #1358 
* Basically, the work done was:
    * `CygnusCappingError` and `CygnusExpiratingError` were added.
    * All the other Cygnus errors were updated.
    * `NGISSink` expception handling was refactored in order to make it more clean and Cygnus errors-specific.
    * All the sinks were refactored according to `NGSISink` base class. Nevetheless, calls to specific backend classes were not refactored, and currenty `Exception`s are catched and "translated" into `CygnusPersistenceError`s. Next PRs will refactor the backend classes themselves in order to directly throw `CygnusPersistenceError`s instead of simple `Exception`s.