### PR TITLE
feature/1344_fix_caprecords

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -41,6 +41,7 @@ import org.json.simple.JSONArray;
 public class CKANBackendImpl extends HttpBackend implements CKANBackend {
 
     private static final CygnusLogger LOGGER = new CygnusLogger(CKANBackendImpl.class);
+    private static final RECORDSPERPAGE = 100;
     private final String orionUrl;
     private final String apiKey;
     private final String viewer;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -440,10 +440,11 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         } // try catch
     } // existsView
     
-    private JSONObject getRecords(String resId, String filters) throws Exception {
+    private JSONObject getRecords(String resId, String filters, int offset, int limit) throws Exception {
         try {
             // create the CKAN request JSON
-            String jsonString = "{\"id\": \"" + resId + "\"";
+            String jsonString = "{\"id\": \"" + resId + "\",\"sort\":\"_id\",\"offset\":" + offset
+                    + ",\"limit\":" + limit;
         
             if (filters == null || filters.isEmpty()) {
                 jsonString += "}";
@@ -516,25 +517,46 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         // Get the resource ID by querying the cache
         String resId = cache.getResId(orgName, pkgName, resName);
         
-        // Get certain information about the records within the resource
-        JSONObject result = (JSONObject) getRecords(resId, null).get("result");
-        long total = (Long) result.get("total");
-        JSONArray records = (JSONArray) result.get("records");
-        
         // Create the filters for a datastore deletion
         String filters = "";
         
-        if (total > maxRecords) {
-            for (int i = 0; i < (total - maxRecords); i++) {
+        // Get the record pages, some variables
+        int offset = 0;
+        int limit = 100;
+        long toBeDeleted = 0;
+        long alreadyDeleted = 0;
+        
+        do {
+            // Get the number of records to be deleted
+            JSONObject result = (JSONObject) getRecords(resId, null, offset, limit).get("result");
+            long total = (Long) result.get("total");
+            toBeDeleted = total - maxRecords;
+            
+            if (toBeDeleted < 0) {
+                break;
+            } // if
+            
+            // Get how much records within the current page must be deleted
+            long remaining = toBeDeleted - alreadyDeleted;
+            long toBeDeletedNow = (remaining > limit ? limit : remaining);
+            
+            // Get the records to be deleted from the current page and get their ID
+            JSONArray records = (JSONArray) result.get("records");
+
+            for (int i = 0; i < toBeDeletedNow; i++) {
                 long id = (Long) ((JSONObject) records.get(i)).get("_id");
-                
+
                 if (filters.isEmpty()) {
                     filters += "{\"_id\":[" + id;
                 } else {
                     filters += "," + id;
                 } // if else
             } // for
-        } // if
+            
+            // Updates
+            alreadyDeleted += toBeDeletedNow;
+            offset += limit;
+        } while (alreadyDeleted < toBeDeleted);
         
         if (filters.isEmpty()) {
             LOGGER.debug("No records to be deleted");
@@ -559,27 +581,45 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             // Get the next resource ID
             String resId = cache.getNextResId();
             
-            // Get the records within the resource
-            JSONObject result = (JSONObject) getRecords(resId, null).get("result");
-            JSONArray records = (JSONArray) result.get("records");
-
             // Create the filters for a datastore deletion
             String filters = "";
 
-            for (Object recordObj : records) {
-                JSONObject record = (JSONObject) recordObj;
-                long id = (Long) record.get("_id");
-                long recordTime = (Long) record.get("recvTimeTs");
-                long currentTime = new Date().getTime() / 1000;
+            // Get the record pages, some variables
+            int offset = 0;
+            int limit = 100;
+            boolean morePages = true;
 
-                if (recordTime < (currentTime - expirationTime)) {
-                    if (filters.isEmpty()) {
-                        filters += "{\"_id\":[" + id;
+            do {
+                // Get the records within the current page
+                JSONObject result = (JSONObject) getRecords(resId, null, offset, limit).get("result");
+                JSONArray records = (JSONArray) result.get("records");
+
+                for (Object recordObj : records) {
+                    JSONObject record = (JSONObject) recordObj;
+                    long id = (Long) record.get("_id");
+                    long recordTime = (Long) record.get("recvTimeTs");
+                    long currentTime = new Date().getTime() / 1000;
+
+                    if (recordTime < (currentTime - expirationTime)) {
+                        if (filters.isEmpty()) {
+                            filters += "{\"_id\":[" + id;
+                        } else {
+                            filters += "," + id;
+                        } // if else
                     } else {
-                        filters += "," + id;
+                        // Since records are sorted by _id, once the first not expirated record is found the loop
+                        // can finish
+                        morePages = false;
+                        break;
                     } // if else
-                } // if
-            } // for
+                } // for
+
+                if (records.size() == 0) {
+                    morePages = false;
+                } else {
+                    offset += limit;
+                } // if else
+            } while (morePages);
             
             if (filters.isEmpty()) {
                 LOGGER.debug("No records to be deleted");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -41,7 +41,7 @@ import org.json.simple.JSONArray;
 public class CKANBackendImpl extends HttpBackend implements CKANBackend {
 
     private static final CygnusLogger LOGGER = new CygnusLogger(CKANBackendImpl.class);
-    private static final RECORDSPERPAGE = 100;
+    private static final int RECORDSPERPAGE = 100;
     private final String orionUrl;
     private final String apiKey;
     private final String viewer;
@@ -523,13 +523,12 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
         
         // Get the record pages, some variables
         int offset = 0;
-        int limit = 100;
         long toBeDeleted = 0;
         long alreadyDeleted = 0;
         
         do {
             // Get the number of records to be deleted
-            JSONObject result = (JSONObject) getRecords(resId, null, offset, limit).get("result");
+            JSONObject result = (JSONObject) getRecords(resId, null, offset, RECORDSPERPAGE).get("result");
             long total = (Long) result.get("total");
             toBeDeleted = total - maxRecords;
             
@@ -539,7 +538,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             
             // Get how much records within the current page must be deleted
             long remaining = toBeDeleted - alreadyDeleted;
-            long toBeDeletedNow = (remaining > limit ? limit : remaining);
+            long toBeDeletedNow = (remaining > RECORDSPERPAGE ? RECORDSPERPAGE : remaining);
             
             // Get the records to be deleted from the current page and get their ID
             JSONArray records = (JSONArray) result.get("records");
@@ -556,7 +555,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
             
             // Updates
             alreadyDeleted += toBeDeletedNow;
-            offset += limit;
+            offset += RECORDSPERPAGE;
         } while (alreadyDeleted < toBeDeleted);
         
         if (filters.isEmpty()) {
@@ -587,12 +586,11 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
 
             // Get the record pages, some variables
             int offset = 0;
-            int limit = 100;
             boolean morePages = true;
 
             do {
                 // Get the records within the current page
-                JSONObject result = (JSONObject) getRecords(resId, null, offset, limit).get("result");
+                JSONObject result = (JSONObject) getRecords(resId, null, offset, RECORDSPERPAGE).get("result");
                 JSONArray records = (JSONArray) result.get("records");
 
                 for (Object recordObj : records) {
@@ -618,7 +616,7 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                 if (records.size() == 0) {
                     morePages = false;
                 } else {
-                    offset += limit;
+                    offset += RECORDSPERPAGE;
                 } // if else
             } while (morePages);
             


### PR DESCRIPTION
* Fixes issues related to pagination when capping and expirating records, issue #1344 
* (Unofficial) e2e tests passed:

Capping records (page size=100, records to be deteled within 2 pages, max_records=5):

```
time=2016-12-28T10:09:38.619UTC | lvl=DEBUG | corr=5f8611e1-4021-4b07-95ca-8e3d2814a826 | trans=5f8611e1-4021-4b07-95ca-8e3d2814a826 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=capRecords | msg=com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl[565] : Records must be deleted (resId=234052d9-c736-4172-96f5-252fe2ad604d, filters={"_id":[144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316]})
```

Expirating records (page size=100, records to be deteled within 2 pages):

```
time=2016-12-28T11:13:28.858UTC | lvl=DEBUG | corr= | trans= | srv= | subsrv= | comp=cygnus-ngsi | op=expirateRecordsCache | msg=com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl[629] : Records to be deleted, resId=234052d9-c736-4172-96f5-252fe2ad604d, filters={"_id":[461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,478,479,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,504,505,506,507,508,509,510,511,512,513,514,515,516,517,518,519,520,521,522,523,524,525,526,527,528,529,530,531,532,533,534,535,536,537,538,539,540,541,542,543,544,545,546,547,548,549,550,551,552,553,554,555,556,557,558,559,560,561,562,563,564,565,566,567,568,569,570,571,572,573,574,575,576,577,578,579,580,581,582,583,584,585,586,587,588,589,590,591,592,593,594,595,596,597,598,599,600,601,602,603,604,605,606,607,608,609,610,611]}
```