### PR TITLE
feature/1365_data_capping_mysql

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,6 @@
-- [cygnus-ngsi][feature] Add global data truncation options based on time and size (#1317)
-- [cygnus-ngsi][feature] Add specific data truncation implementation for NGSICKANSink (#1344)
+- [cygnus-ngsi][feature] Add global data capping/expirationn options based on time and size (#1317)
+- [cygnus-ngsi][feature] Add specific data capping/expiration implementation for NGSICKANSink (#1344)
+- [cygnus-ngsi][feature] Add specific data capping/expiration implementation for NGSIMySQLSink (#1365)
 - [cygnus] Add Travis CI (#1347)
 - [cygnus-ngsi][hardening] Force lowercase organization, dataset and resource names in NGSICKANSink (#1352)
 - [cygnus-ngsi][hardening] Replace warnings upon unnecessary header received with debug traces at NGSIRestHandler (#1354)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackend.java
@@ -18,6 +18,10 @@
 
 package com.telefonica.iot.cygnus.backends.mysql;
 
+import com.telefonica.iot.cygnus.errors.CygnusCappingError;
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
+
 /**
  * Interface for those backends implementing the persistence in MySQL.
  * 
@@ -50,5 +54,15 @@ public interface MySQLBackend {
      * @throws Exception
      */
     void insertContextData(String dbName, String tableName, String fieldNames, String fieldValues) throws Exception;
+    
+    /**
+     * Caps records from the given table within the given database according to the given maximum number.
+     * @param dbName
+     * @param tableName
+     * @param maxRecords
+     * @throws CygnusRuntimeError
+     * @throws CygnusPersistenceError
+     */
+    void capRecords(String dbName, String tableName, long maxRecords) throws CygnusRuntimeError, CygnusPersistenceError;
     
 } // MySQLBackend

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -226,6 +226,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
         
         // Get the reception times (they work as IDs) for future deletion
+        // to-do: refactor after implementing https://github.com/telefonicaid/fiware-cygnus/issues/1371
         String filters = "";
         
         try {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -169,6 +169,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
         
         try {
+            // to-do: refactor after implementing https://github.com/telefonicaid/fiware-cygnus/issues/1371
             String query = "select " + selection + " from `" + tableName + "` order by recvTime";
             LOGGER.debug("Executing MySQL query '" + query + "'");
             ResultSet rs = stmt.executeQuery(query);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -18,6 +18,7 @@
 
 package com.telefonica.iot.cygnus.backends.mysql;
 
+import com.sun.rowset.CachedRowSetImpl;
 import com.telefonica.iot.cygnus.errors.CygnusBadContextData;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
@@ -25,9 +26,11 @@ import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.sql.Statement;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.util.HashMap;
+import javax.sql.rowset.CachedRowSet;
 
 /**
  *
@@ -98,6 +101,7 @@ public class MySQLBackendImpl implements MySQLBackend {
      * Creates a table, given its name, if not exists in the given database.
      * @param dbName
      * @param tableName
+     * @param typedFieldNames
      * @throws Exception
      */
     @Override
@@ -147,7 +151,110 @@ public class MySQLBackendImpl implements MySQLBackend {
         } catch (SQLException e) {
             throw new CygnusBadContextData(e.getMessage());
         } // try catch
+        
+        closeMySQLObjects(con, stmt);
     } // insertContextData
+    
+    private CachedRowSet select(String dbName, String tableName, String selection)
+        throws CygnusRuntimeError, CygnusPersistenceError {
+        Statement stmt = null;
+        
+        // get a connection to the given database
+        Connection con = driver.getConnection(dbName);
+            
+        try {
+            stmt = con.createStatement();
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+        } // try catch
+        
+        try {
+            String query = "select " + selection + " from `" + tableName + "` order by recvTime";
+            LOGGER.debug("Executing MySQL query '" + query + "'");
+            ResultSet rs = stmt.executeQuery(query);
+            // A CachedRowSet is "disconnected" from the source, thus can be used once the statement is closed
+            CachedRowSet crs = new CachedRowSetImpl();
+            crs.populate(rs);
+            closeMySQLObjects(con, stmt);
+            return crs;
+        } catch (SQLException e) {
+            closeMySQLObjects(con, stmt);
+            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+        } // try catch
+    } // select
+    
+    private void delete(String dbName, String tableName, String filters)
+        throws CygnusRuntimeError, CygnusPersistenceError {
+        Statement stmt = null;
+        
+        // get a connection to the given database
+        Connection con = driver.getConnection(dbName);
+            
+        try {
+            stmt = con.createStatement();
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+        } // try catch
+        
+        try {
+            String query = "delete from `" + tableName + "` where " + filters;
+            LOGGER.debug("Executing MySQL query '" + query + "'");
+            stmt.executeUpdate(query);
+        } catch (SQLException e) {
+            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+        } // try catch
+        
+        closeMySQLObjects(con, stmt);
+    } // delete
+    
+    @Override
+    public void capRecords(String dbName, String tableName, long maxRecords)
+        throws CygnusRuntimeError, CygnusPersistenceError {
+        // Get the records within the table
+        CachedRowSet records = select(dbName, tableName, "*");
+        
+        // Get the number of records
+        int numRecords = 0;
+        
+        try {
+            if (records.last()) {
+                numRecords = records.getRow();
+                records.beforeFirst();
+            } // if
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+        } // try catch
+        
+        // Get the reception times (they work as IDs) for future deletion
+        String filters = "";
+        
+        try {
+            if (numRecords > maxRecords) {
+                for (int i = 0; i < (numRecords - maxRecords); i++) {
+                    records.next();
+                    String recvTime = records.getString("recvTime");
+
+                    if (filters.isEmpty()) {
+                        filters += "recvTime='" + recvTime + "'";
+                    } else {
+                        filters += " or recvTime='" + recvTime + "'";
+                    } // if else
+                } // for
+            } // if
+            
+            records.close();
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+        } // try catch
+        
+        if (filters.isEmpty()) {
+            LOGGER.debug("No records to be deleted");
+        } else {
+            LOGGER.debug("Records must be deleted (dbName=" + dbName + ",tableName=" + tableName
+                    + ", filters=" + filters + ")");
+            delete(dbName, tableName, filters);
+        } // if else
+    } // capRecords
     
     /**
      * Close all the MySQL objects previously opened by doCreateTable and doQuery.
@@ -155,13 +262,12 @@ public class MySQLBackendImpl implements MySQLBackend {
      * @param stmt
      * @return True if the MySQL objects have been closed, false otherwise.
      */
-    private void closeMySQLObjects(Connection con, Statement stmt) throws Exception {
+    private void closeMySQLObjects(Connection con, Statement stmt) throws CygnusRuntimeError {
         if (con != null) {
             try {
                 con.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("The Hive connection could not be closed. Details="
-                        + e.getMessage());
+                throw new CygnusRuntimeError("SQLException, " + e.getMessage());
             } // try catch
         } // if
 
@@ -169,8 +275,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             try {
                 stmt.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("The Hive statement could not be closed. Details="
-                        + e.getMessage());
+                throw new CygnusRuntimeError("SQLException, " + e.getMessage());
             } // try catch
         } // if
     } // closeMySQLObjects
@@ -195,7 +300,7 @@ public class MySQLBackendImpl implements MySQLBackend {
          * @param mysqlPassword
          */
         public MySQLDriver(String mysqlHost, String mysqlPort, String mysqlUsername, String mysqlPassword) {
-            connections = new HashMap<String, Connection>();
+            connections = new HashMap<>();
             this.mysqlHost = mysqlHost;
             this.mysqlPort = mysqlPort;
             this.mysqlUsername = mysqlUsername;
@@ -206,9 +311,9 @@ public class MySQLBackendImpl implements MySQLBackend {
          * Gets a connection to the MySQL server.
          * @param dbName
          * @return
-         * @throws Exception
+         * @throws CygnusPersistenceError
          */
-        public Connection getConnection(String dbName) throws Exception {
+        public Connection getConnection(String dbName) throws CygnusPersistenceError {
             try {
                 // FIXME: the number of cached connections should be limited to a certain number; with such a limit
                 //        number, if a new connection is needed, the oldest one is closed
@@ -225,9 +330,9 @@ public class MySQLBackendImpl implements MySQLBackend {
 
                 return con;
             } catch (ClassNotFoundException e) {
-                throw new CygnusPersistenceError(e.getMessage());
+                throw new CygnusPersistenceError("ClassNotFoundException, " + e.getMessage());
             } catch (SQLException e) {
-                throw new CygnusPersistenceError(e.getMessage());
+                throw new CygnusPersistenceError("SQLException, " + e.getMessage());
             } // try catch
         } // getConnection
         
@@ -256,10 +361,10 @@ public class MySQLBackendImpl implements MySQLBackend {
          * @param user
          * @param password
          * @return A MySQL connection
-         * @throws Exception
+         * @throws ClassNotFoundException
+         * @throws SQLException
          */
-        private Connection createConnection(String dbName)
-            throws Exception {
+        private Connection createConnection(String dbName) throws ClassNotFoundException, SQLException {
             // dynamically load the MySQL JDBC driver
             Class.forName(DRIVER_NAME);
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
@@ -22,6 +22,7 @@ Content:
         * [About batching](#section2.3.3)
         * [Time zone information](#section2.3.4)
         * [About the encoding](#section2.3.5)
+        * [About capping resources/expirating records](#section2.3.6)
 * [Programmers guide](#section3)
     * [`NGSIMySQLSink` class](#section3.1)
     * [Authentication and authorization](#section3.2)
@@ -214,6 +215,9 @@ If `attr_persistence=colum` then `NGSIMySQLSink` will persist the data within th
 | batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
 | batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
+| persistence\_policy.max_records | no | -1 | Maximum number of records allowed for a table before it is capped. `-1` disables this policy. |
+| persistence\_policy.expiration_time | no | -1 | Maximum number of seconds a record is maintained in a table before expiration. `-1` disables this policy. |
+| persistence\_policy.checking_time | no | 3600 | Frequency (in seconds) at which the sink ckecks for record expiration. |
 
 A configuration example could be:
 
@@ -236,6 +240,9 @@ A configuration example could be:
     cygnus-ngsi.sinks.mysql-sink.batch_timeout = 30
     cygnus-ngsi.sinks.mysql-sink.batch_ttl = 10
     cygnus-ngsi.sinks.mysql-sink.batch_retry_intervals = 5000
+    cygnus-ngsi.sinks.mysql-sink.persistence_policy.max_records = 5
+    cygnus-ngsi.sinks.mysql-sink.persistence_policy.expiration_time = 86400
+    cygnus-ngsi.sinks.mysql-sink.persistence_policy.checking_time = 600
 
 [Top](#top)
 
@@ -301,6 +308,14 @@ Despite the old encoding will be deprecated in the future, it is possible to swi
 
 [Top](#top)
 
+####<a name="section2.3.6"></a>About capping resources and expirating records
+Capping and expiration are disabled by default. Nevertheless, if desired, this can be enabled:
+
+* Capping by the number of records. This allows the resource growing up until certain configured maximum number of records is reached (`persistence_policy.max_records`), and then maintains a such a constant number of records.
+* Expirating by time the records. This allows the resource growing up until records become old, i.e. overcome certain configured expiration time (`persistence_policy.expiration_time`).
+
+[Top](#top)
+
 ##<a name="section3"></a>Programmers guide
 ###<a name="section3.1"></a>`NGSIMySQLSink` class
 As any other NGSI-like sink, `NGSIMySQLSink` extends the base `NGSISink`. The methods that are extended are:
@@ -308,6 +323,14 @@ As any other NGSI-like sink, `NGSIMySQLSink` extends the base `NGSISink`. The me
     void persistBatch(Batch batch) throws Exception;
 
 A `Batch` contains a set of `NGSIEvent` objects, which are the result of parsing the notified context data events. Data within the batch is classified by destination, and in the end, a destination specifies the MySQL table where the data is going to be persisted. Thus, each destination is iterated in order to compose a per-destination data string to be persisted thanks to any `MySQLBackend` implementation.
+
+    void capRecords(NGSIBatch batch, long maxRecords) throws EventDeliveryException;
+    
+This method is always called immediatelly after `persistBacth()`. The same destination tables that were upserted are now checked in terms of number of records: if the configured maximum (`persistence_policy.max_records`) is overcome for any of the updated tables, then as many oldest records are deleted as required until the maximum number of records is reached.
+    
+    void expirateRecords(long expirationTime);
+    
+This method is called in a periodical way (based on `persistence_policy.checking_time`), and if the configured expiration time (`persistence_policy.expiration_time`) is overcome for any of the records within any of the tables, then it is deleted.
 
     public void start();
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
@@ -217,7 +217,7 @@ If `attr_persistence=colum` then `NGSIMySQLSink` will persist the data within th
 | batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
 | persistence\_policy.max_records | no | -1 | Maximum number of records allowed for a table before it is capped. `-1` disables this policy. |
 | persistence\_policy.expiration_time | no | -1 | Maximum number of seconds a record is maintained in a table before expiration. `-1` disables this policy. |
-| persistence\_policy.checking_time | no | 3600 | Frequency (in seconds) at which the sink ckecks for record expiration. |
+| persistence\_policy.checking_time | no | 3600 | Frequency (in seconds) at which the sink checks for record expiration. |
 
 A configuration example could be:
 
@@ -311,8 +311,8 @@ Despite the old encoding will be deprecated in the future, it is possible to swi
 ####<a name="section2.3.6"></a>About capping resources and expirating records
 Capping and expiration are disabled by default. Nevertheless, if desired, this can be enabled:
 
-* Capping by the number of records. This allows the resource growing up until certain configured maximum number of records is reached (`persistence_policy.max_records`), and then maintains a such a constant number of records.
-* Expirating by time the records. This allows the resource growing up until records become old, i.e. overcome certain configured expiration time (`persistence_policy.expiration_time`).
+* Capping by the number of records. This allows the resource growing up until certain configured maximum number of records is reached (`persistence_policy.max_records`), and then maintains such a constant number of records.
+* Expirating by time the records. This allows the resource growing up until records become old, i.e. exceed certain configured expiration time (`persistence_policy.expiration_time`).
 
 [Top](#top)
 
@@ -326,11 +326,11 @@ A `Batch` contains a set of `NGSIEvent` objects, which are the result of parsing
 
     void capRecords(NGSIBatch batch, long maxRecords) throws EventDeliveryException;
     
-This method is always called immediatelly after `persistBacth()`. The same destination tables that were upserted are now checked in terms of number of records: if the configured maximum (`persistence_policy.max_records`) is overcome for any of the updated tables, then as many oldest records are deleted as required until the maximum number of records is reached.
+This method is always called immediatelly after `persistBacth()`. The same destination tables that were upserted are now checked in terms of number of records: if the configured maximum (`persistence_policy.max_records`) is exceeded for any of the updated tables, then as many oldest records are deleted as required until the maximum number of records is reached.
     
     void expirateRecords(long expirationTime);
     
-This method is called in a periodical way (based on `persistence_policy.checking_time`), and if the configured expiration time (`persistence_policy.expiration_time`) is overcome for any of the records within any of the tables, then it is deleted.
+This method is called in a periodical way (based on `persistence_policy.checking_time`), and if the configured expiration time (`persistence_policy.expiration_time`) is exceeded for any of the records within any of the tables, then it is deleted.
 
     public void start();
 


### PR DESCRIPTION
* Implements issue #1365 (capping part)
* PR https://github.com/telefonicaid/fiware-cygnus/pull/1360 must be merged before this one.
* (Unofficial) e2e tests passed:
```
mysql> select * from traffic_Room1_Room order by recvTime;
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
| recvTimeTs    | recvTime                | fiwareServicePath | entityId | entityType | attrName    | attrType   | attrValue | attrMd |
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
| 1483021054473 | 2016-12-29T14:17:34.473 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021120977 | 2016-12-29T14:18:40.977 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021121407 | 2016-12-29T14:18:41.407 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021518722 | 2016-12-29T14:25:18.722 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021531954 | 2016-12-29T14:25:31.954 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
5 rows in set (0.00 sec)
..
..
time=2016-12-29T14:26:05.270UTC | lvl=DEBUG | corr=59f5554d-20fe-428b-b78c-07cf556decfc | trans=59f5554d-20fe-428b-b78c-07cf556decfc | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=delete | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[200] : Executing MySQL query 'delete from `traffic_Room1_Room` where recvTime='2016-12-29T14:17:34.473' or recvTime='2016-12-29T14:18:40.977' or recvTime='2016-12-29T14:18:41.407''
..
..
mysql> select * from traffic_Room1_Room order by recvTime;
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
| recvTimeTs    | recvTime                | fiwareServicePath | entityId | entityType | attrName    | attrType   | attrValue | attrMd |
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
| 1483021518722 | 2016-12-29T14:25:18.722 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021531954 | 2016-12-29T14:25:31.954 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021556434 | 2016-12-29T14:25:56.434 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021557044 | 2016-12-29T14:25:57.44  | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
| 1483021557529 | 2016-12-29T14:25:57.529 | /traffic          | Room1    | Room       | temperature | centigrade | 26.5      | []     |
+---------------+-------------------------+-------------------+----------+------------+-------------+------------+-----------+--------+
5 rows in set (0.00 sec)
```