### PR TITLE
hardening/130_add_cache_mysql

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - [cygnus-ngsi][hardening] Replace warnings upon unnecessary header received with debug traces at NGSIRestHandler (#1354)
 - [cygnus-ngsi][hardening] Improve persistence error logs at NGSISink (#1358)
 - [cygnus-ngsi][hardening] Add raw bytes to NGSIEvent (#1345)
+- [cygnus-ngsi][hardening] Add cache to NGSIMySQLSink (#130)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2015-2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCache.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.backends.mysql;
+
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ *
+ * @author frb
+ */
+public class MySQLCache {
+    
+    private static final CygnusLogger LOGGER = new CygnusLogger(MySQLCache.class);
+    private final HashMap<String, ArrayList<String>> hierarchy;
+    
+    /**
+     * Constructor.
+     */
+    public MySQLCache() {
+        hierarchy = new HashMap<>();
+    } // MySQLCache
+    
+    /**
+     * Adds a db name to the cache.
+     * @param dbName
+     * @return True if the db is added, false otherwise. 
+     */
+    public boolean addDb(String dbName) {
+        if (hierarchy.containsKey(dbName)) {
+            LOGGER.debug("'" + dbName + "' not added to the cache, since already existing");
+            return false;
+        } else {
+            hierarchy.put(dbName, new ArrayList<String>());
+            LOGGER.debug("'" + dbName + "' added to the cache");
+            return true;
+        } // if else
+    } // addDb
+    
+    /**
+     * Adds a table name within in a db name to the cache.
+     * @param dbName
+     * @param tableName
+     * @return True if the table is added, false otherwise
+     */
+    public boolean addTable(String dbName, String tableName) {
+        ArrayList<String> tables = hierarchy.get(dbName);
+        
+        if (tables != null) {
+            if (tables.contains(tableName)) {
+                LOGGER.debug("'" + tableName + "' not added to the cache, since already existing");
+                return false;
+            } else {
+                tables.add(tableName);
+                LOGGER.debug("'" + tableName + "' added to the cache");
+                return true;
+            } // if else
+        } else {
+            LOGGER.debug("'" + dbName + "' was not added to the cache, since database did not exist");
+            return false;
+        } // if else
+    } // addTable
+    
+    /**
+     * Gets if a db name is cached.
+     * @param dbName
+     * @return True if the db name is cached, false otherwise.
+     */
+    public boolean isCachedDb(String dbName) {
+        return hierarchy.containsKey(dbName);
+    } // isCachedDb
+    
+    /**
+     * Gets if a table name within a db name is cached.
+     * @param dbName
+     * @param tableName
+     * @return True if the table name is cached, false otherwise.
+     */
+    public boolean isCachedTable(String dbName, String tableName) {
+        ArrayList<String> tables = hierarchy.get(dbName);
+        
+        if (tables == null) {
+            return false;
+        } else {
+            return tables.contains(tableName);
+        } // if else
+    } // isCachedTable
+    
+} // MySQLCache

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCacheTest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FI-WARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.backends.mysql;
+
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class MySQLCacheTest {
+    
+    /**
+     * Constructor.
+     */
+    public MySQLCacheTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // MySQLCacheTest
+    
+    /**
+     * [MySQLCache.addDb] -------- A database is added if not existing in the cache.
+     */
+    @Test
+    public void testAddDbNotExisting() {
+        System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                + "-------- A database is added if not existing in the cache");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        boolean added = cache.addDb(dbName);
+        
+        try {
+            assertTrue(added);
+            System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                    + "-  OK  - The database was added");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                    + "- FAIL - The database was not added");
+            throw e;
+        } // try catch
+    } // testAddDbNotExisting
+    
+    /**
+     * [MySQLCache.addDb] -------- A database is not added if already existing in the cacbe.
+     */
+    @Test
+    public void testAddDbExisting() {
+        System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                + "-------- A database is not added if already existing in the cache");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        boolean added1 = cache.addDb(dbName);
+        boolean added2 = cache.addDb(dbName);
+        
+        try {
+            assertTrue(added1 && !added2);
+            System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                    + "-  OK  - The database was not added");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.addDb]")
+                    + "- FAIL - The database was added");
+            throw e;
+        } // try catch
+    } // testAddDbExisting
+    
+    /**
+     * [MySQLCache.addTable] -------- A table is added if not existing in the cache.
+     */
+    @Test
+    public void testAddTableNotExisting() {
+        System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                + "-------- A table is added if not existing in the cache");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        String tableName = "tablename";
+        boolean added1 = cache.addDb(dbName);
+        boolean added2 = cache.addTable(dbName, tableName);
+        
+        try {
+            assertTrue(added1 && added2);
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "-  OK  - The table was added");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "- FAIL - The table was not added");
+            throw e;
+        } // try catch
+    } // testAddTableNotExisting
+    
+    /**
+     * [MySQLCache.addTable] -------- A table is not added if already existing in the cache.
+     */
+    @Test
+    public void testAddTableExisting() {
+        System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                + "-------- A database is not added if already existing in the cache");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        String tableName = "tablename";
+        boolean added1 = cache.addDb(dbName);
+        boolean added2 = cache.addTable(dbName, tableName);
+        boolean added3 = cache.addTable(dbName, tableName);
+        
+        try {
+            assertTrue(added1 && added2 && !added3);
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "-  OK  - The table was not added");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "- FAIL - The table was added");
+            throw e;
+        } // try catch
+    } // testAddTableExisting
+    
+    /**
+     * [MySQLCache.addTable] -------- A table is not added if the database does not exist in the cache.
+     */
+    @Test
+    public void testAddTableNotExistingDb() {
+        System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                + "-------- A table is not added if the database does not exist in the cache");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        String tableName = "tablename";
+        boolean added1 = cache.addTable(dbName, tableName);
+        
+        try {
+            assertTrue(!added1);
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "-  OK  - The table was not added");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.addTable]")
+                    + "- FAIL - The table was added");
+            throw e;
+        } // try catch
+    } // testAddTableNotExistingDb
+    
+    /**
+     * [MySQLCache.isCachedDb] -------- A cached database is checked.
+     */
+    @Test
+    public void testIsCachedDbExists() {
+        System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                + "-------- A cached database is checked");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        cache.addDb(dbName);
+        
+        try {
+            assertTrue(cache.isCachedDb(dbName));
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                    + "-  OK  - The database was cached");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                    + "- FAIL - The database was not cached");
+            throw e;
+        } // try catch
+    } // testIsCachedDbExists
+    
+    /**
+     * [MySQLCache.isCachedDb] -------- A not cached database is checked.
+     */
+    @Test
+    public void testIsCachedDbNotExists() {
+        System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                + "-------- A not cached database is checked");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        
+        try {
+            assertTrue(!cache.isCachedDb(dbName));
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                    + "-  OK  - The database was not cached");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedDb]")
+                    + "- FAIL - The database was cached");
+            throw e;
+        } // try catch
+    } // testIsCachedDbNotExists
+    
+    /**
+     * [MySQLCache.isCachedTable] -------- A cached table is checked.
+     */
+    @Test
+    public void testIsCachedTableExists() {
+        System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                + "-------- A cached table is checked");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        String tableName = "tablename";
+        cache.addDb(dbName);
+        cache.addTable(dbName, tableName);
+        
+        try {
+            assertTrue(cache.isCachedTable(dbName, tableName));
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                    + "-  OK  - The table was cached");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                    + "- FAIL - The table was not cached");
+            throw e;
+        } // try catch
+    } // testIsCachedTableExists
+    
+    /**
+     * [MySQLCache.isCachedTable] -------- A not cached table is checked.
+     */
+    @Test
+    public void testIsCachedTableNotExists() {
+        System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                + "-------- A not cached table is checked");
+        MySQLCache cache = new MySQLCache();
+        String dbName = "dbname";
+        String tableName = "tablename";
+        cache.addDb(dbName);
+        
+        try {
+            assertTrue(!cache.isCachedTable(dbName, tableName));
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                    + "-  OK  - The table was not cached");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[MySQLCache.isCachedTable]")
+                    + "- FAIL - The table was cached");
+            throw e;
+        } // try catch
+    } // testIsCachedTableNotExists
+    
+} // MySQLCacheTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCacheTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/mysql/MySQLCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FI-WARE project).
  *


### PR DESCRIPTION
* Implements issue #130 
* (Unofficial) e2e tests passed:

Three updates:

* The first one causes a database and a table are created; they are cached as already crated now.
* The second one does not implies any kind of creation nor existence checking through the driver since both database and table are cached as already created.
* The third one is related to the same service than the above ones, but a different service path, thus a new table has to be created (but not the database).

```
time=2017-01-10T08:01:11.123UTC | lvl=INFO | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2017-01-10T08:01:15.976UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createDatabase | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[98] : Executing MySQL query 'create database if not exists `sc_madrid`'
time=2017-01-10T08:01:15.982UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createDatabase | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[105] : Trying to add 'sc_madrid' to the cache
time=2017-01-10T08:01:15.983UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=addDb | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[46] : 'sc_madrid' added to the cache
time=2017-01-10T08:01:16.235UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[136] : Executing MySQL query 'create table if not exists `traffic_Room1_Room` (recvTimeTs text,recvTime text,fiwareServicePath text,entityId text,entityType text,attrName text,attrType text,attrValue text,attrMd text)'
time=2017-01-10T08:01:16.255UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[143] : Trying to add 'traffic_Room1_Room' to the cache
time=2017-01-10T08:01:16.255UTC | lvl=DEBUG | corr=29ea9940-1d46-4899-8c82-3b6669976a85 | trans=29ea9940-1d46-4899-8c82-3b6669976a85 | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=addTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[59] : 'traffic_Room1_Room' added to the cache
..
..
time=2017-01-10T08:02:02.012UTC | lvl=INFO | corr=170c436e-8462-46a8-a146-ba920547a0cc | trans=170c436e-8462-46a8-a146-ba920547a0cc | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2017-01-10T08:02:11.029UTC | lvl=DEBUG | corr=170c436e-8462-46a8-a146-ba920547a0cc | trans=170c436e-8462-46a8-a146-ba920547a0cc | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createDatabase | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[81] : 'sc_madrid' is cached, thus it is not created
time=2017-01-10T08:02:11.029UTC | lvl=DEBUG | corr=170c436e-8462-46a8-a146-ba920547a0cc | trans=170c436e-8462-46a8-a146-ba920547a0cc | srv=sc_madrid | subsrv=/traffic | comp=cygnus-ngsi | op=createTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[119] : 'traffic_Room1_Room' is cached, thus it is not created
..
..
time=2017-01-10T08:11:35.387UTC | lvl=INFO | corr=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | trans=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | srv=sc_madrid | subsrv=/other | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2017-01-10T08:11:40.397UTC | lvl=DEBUG | corr=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | trans=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | srv=sc_madrid | subsrv=/other | comp=cygnus-ngsi | op=createDatabase | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[81] : 'sc_madrid' is cached, thus it is not created
time=2017-01-10T08:11:40.637UTC | lvl=DEBUG | corr=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | trans=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | srv=sc_madrid | subsrv=/other | comp=cygnus-ngsi | op=createTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[136] : Executing MySQL query 'create table if not exists `other_Room1_Room` (recvTimeTs text,recvTime text,fiwareServicePath text,entityId text,entityType text,attrName text,attrType text,attrValue text,attrMd text)'
time=2017-01-10T08:11:40.667UTC | lvl=DEBUG | corr=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | trans=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | srv=sc_madrid | subsrv=/other | comp=cygnus-ngsi | op=createTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[143] : Trying to add 'other_Room1_Room' to the cache
time=2017-01-10T08:11:40.667UTC | lvl=DEBUG | corr=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | trans=3e2666bf-3e39-4ee5-8f66-989c772c9d96 | srv=sc_madrid | subsrv=/other | comp=cygnus-ngsi | op=addTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[59] : 'other_Room1_Room' added to the cache
```