### PR TITLE
hardening/130_add_cache_mysql_insert

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -102,7 +102,8 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
         
         closeMySQLObjects(con, stmt);
-        LOGGER.debug("Trying to add '" + dbName + "' to the cache");
+        
+        LOGGER.debug("Trying to add '" + dbName + "' to the cache after database creation");
         cache.addDb(dbName);
     } // createDatabase
     
@@ -140,7 +141,8 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
         
         closeMySQLObjects(con, stmt);
-        LOGGER.debug("Trying to add '" + tableName + "' to the cache");
+        
+        LOGGER.debug("Trying to add '" + tableName + "' to the cache after table creation");
         cache.addTable(dbName, tableName);
     } // createTable
     
@@ -169,6 +171,10 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
         
         closeMySQLObjects(con, stmt);
+        
+        LOGGER.debug("Trying to add '" + dbName + "' and '" + tableName + "' to the cache after insertion");
+        cache.addDb(dbName);
+        cache.addTable(dbName, tableName);
     } // insertContextData
     
     private CachedRowSet select(String dbName, String tableName, String selection)


### PR DESCRIPTION
* Partially implements issue #130 
    * No CNR update is required
* (Unofficial) e2e tests passed:

Two insertions:

* The first one adds database and table after insertion.
* The second one does not add anything since already added.

```
time=2017-01-10T10:19:21.251UTC | lvl=INFO | corr=785d115e-519e-49b8-867d-574f603ac347 | trans=785d115e-519e-49b8-867d-574f603ac347 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2017-01-10T10:19:21.831UTC | lvl=DEBUG | corr=785d115e-519e-49b8-867d-574f603ac347 | trans=785d115e-519e-49b8-867d-574f603ac347 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=insertContextData | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[165] : Executing MySQL query 'insert into `another_Room1_Room` (recvTime,fiwareServicePath,entityId,entityType,temperature,temperature_md) values ('2017-01-10T10:19:21.322','/another','Room1','Room','26.5','[]')'
time=2017-01-10T10:19:21.856UTC | lvl=DEBUG | corr=785d115e-519e-49b8-867d-574f603ac347 | trans=785d115e-519e-49b8-867d-574f603ac347 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=insertContextData | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[175] : Trying to add 'sc_madrid' and 'another_Room1_Room' to the cache
time=2017-01-10T10:19:21.856UTC | lvl=DEBUG | corr=785d115e-519e-49b8-867d-574f603ac347 | trans=785d115e-519e-49b8-867d-574f603ac347 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=addDb | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[51] : 'sc_madrid' added to the cache
time=2017-01-10T10:19:21.856UTC | lvl=DEBUG | corr=785d115e-519e-49b8-867d-574f603ac347 | trans=785d115e-519e-49b8-867d-574f603ac347 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=addTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[71] : 'another_Room1_Room' added to the cache
..
..
time=2017-01-10T10:19:51.429UTC | lvl=INFO | corr=f4210039-0201-4d22-abac-c3c8007bee53 | trans=f4210039-0201-4d22-abac-c3c8007bee53 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=getEvents | msg=com.telefonica.iot.cygnus.handlers.NGSIRestHandler[299] : [NGSIRestHandler] Received data ({  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",  "originator" : "localhost",  "contextResponses" : [    {      "contextElement" : {        "attributes" : [          {            "name" : "temperature",            "type" : "centigrade",            "value" : "26.5"          }        ],        "type" : "Room",        "isPattern" : "false",        "id" : "Room1"      },      "statusCode" : {        "code" : "200",        "reasonPhrase" : "OK"      }    }  ]})
time=2017-01-10T10:19:55.465UTC | lvl=DEBUG | corr=f4210039-0201-4d22-abac-c3c8007bee53 | trans=f4210039-0201-4d22-abac-c3c8007bee53 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=insertContextData | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[165] : Executing MySQL query 'insert into `another_Room1_Room` (recvTime,fiwareServicePath,entityId,entityType,temperature,temperature_md) values ('2017-01-10T10:19:51.433','/another','Room1','Room','26.5','[]')'
time=2017-01-10T10:19:55.468UTC | lvl=DEBUG | corr=f4210039-0201-4d22-abac-c3c8007bee53 | trans=f4210039-0201-4d22-abac-c3c8007bee53 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=insertContextData | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[175] : Trying to add 'sc_madrid' and 'another_Room1_Room' to the cache
time=2017-01-10T10:19:55.468UTC | lvl=DEBUG | corr=f4210039-0201-4d22-abac-c3c8007bee53 | trans=f4210039-0201-4d22-abac-c3c8007bee53 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=addDb | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[47] : 'sc_madrid' not added to the cache, since already existing
time=2017-01-10T10:19:55.468UTC | lvl=DEBUG | corr=f4210039-0201-4d22-abac-c3c8007bee53 | trans=f4210039-0201-4d22-abac-c3c8007bee53 | srv=sc_madrid | subsrv=/another | comp=cygnus-ngsi | op=addTable | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLCache[67] : 'another_Room1_Room' not added to the cache, since already existing
```