### PR TITLE
feature/1339_kpis_api_common ops

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -9,3 +9,4 @@
 - [cygnus-ngsi][hardening] Add cache to NGSIMySQLSink (#130)
 - [cygnus][hardening] Fix "FIWARE" name in license headers (#1369)
 - [cygnus-common][hardening] Clean and modularize ManagementInterface.java (#1368)
+- [cygnus-common][feature] Add KPIs API (#1339)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/handlers/CygnusHandler.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/handlers/CygnusHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2017 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2016-2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FIWARE project).
  *
@@ -17,6 +17,7 @@
  */
 package com.telefonica.iot.cygnus.handlers;
 
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics;
 import java.util.Date;
 
 /**
@@ -28,10 +29,11 @@ public abstract class CygnusHandler {
     protected static final long BOOTTIME = new Date().getTime();
     protected static long numReceivedEvents = 0;
     protected static long numProcessedEvents = 0;
+    protected CygnusMetrics serviceMetrics = new CygnusMetrics();
     
     /**
      * Gets the number of received events.
-     * @return The number of received events
+     * @return The number of received eventsObje
      */
     public long getNumReceivedEvents() {
         return numReceivedEvents;
@@ -68,5 +70,21 @@ public abstract class CygnusHandler {
     public long getBootTime() {
         return BOOTTIME;
     } // getBootTime
+    
+    /**
+     * Gets serviceMetrics.
+     * @return serviceMetrics
+     */
+    public CygnusMetrics getServiceMetrics() {
+        return serviceMetrics;
+    } // getServiceSubserviceMetrics
+    
+    /**
+     * Sets serviceMetrics.
+     * @param serviceMetrics
+     */
+    public void setServiceMetrics(CygnusMetrics serviceMetrics) {
+        this.serviceMetrics = serviceMetrics;
+    } // setServiceMetrics
     
 } // CygnusHandler

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/ManagementInterface.java
@@ -122,6 +122,8 @@ public class ManagementInterface extends AbstractHandler {
                         LogHandlers.getLoggers(request, response, configurationPath);
                     } else if (uri.startsWith("/v1/admin/log/appenders")) {
                         LogHandlers.getAppenders(request, response, configurationPath);
+                    } else if (uri.startsWith("/v1/admin/metrics") || uri.startsWith("/admin/metrics")) {
+                        MetricsHandlers.get(request, response, sources, sinks);
                     } else {
                         response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
                         response.getWriter().println(method + " " + uri + " not implemented");
@@ -193,6 +195,8 @@ public class ManagementInterface extends AbstractHandler {
                         LogHandlers.deleteLoggers(request, response, configurationPath);
                     } else if (uri.startsWith("/v1/admin/log/appenders")) {
                         LogHandlers.deleteAppenders(request, response, configurationPath);
+                    } else if (uri.startsWith("/v1/admin/metrics") || uri.startsWith("/admin/metrics")) {
+                        MetricsHandlers.delete(response, sources, sinks);
                     } else {
                         response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
                         response.getWriter().println(method + " " + uri + " not implemented");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/MetricsHandlers.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/MetricsHandlers.java
@@ -48,7 +48,8 @@ public final class MetricsHandlers {
     } // MetricsHandlers
     
     /**
-     * Handles GET /v1/admin/mergeMetrics and /admin/mergeMetrics.
+     * Handles GET /v1/admin/metrics and /admin/metrics. It is synchronized in order to ensure atomic modifications
+     * on the metrics.
      * @param request
      * @param response
      * @param sources
@@ -78,10 +79,11 @@ public final class MetricsHandlers {
             response.getWriter().println(metrics.toJsonString());
             response.setContentType("application/json; charset=utf-8");
         } // else
-    } // getServiceSubserviceMetrics
+    } // get
     
     /**
-     * Handles DELETE /v1/admin/mergeMetrics and /admin/mergeMetrics.
+     * Handles DELETE /v1/admin/metrics and /admin/metrics. It is synchronized in order to ensure atomic modifications
+     * on the metrics.
      * @param response
      * @param sources
      * @param sinks
@@ -101,7 +103,7 @@ public final class MetricsHandlers {
      */
     protected static CygnusMetrics mergeMetrics(ImmutableMap<String, SourceRunner> sources,
             ImmutableMap<String, SinkRunner> sinks) {
-        CygnusMetrics mergeServices = new CygnusMetrics();
+        CygnusMetrics mergedMetrics = new CygnusMetrics();
     
         if (sources != null) {
             for (String key : sources.keySet()) {
@@ -122,8 +124,8 @@ public final class MetricsHandlers {
 
                 if (handler instanceof CygnusHandler) {
                     CygnusHandler ch = (CygnusHandler) handler;
-                    CygnusMetrics sourceServices = ch.getServiceMetrics();
-                    mergeServices.merge(sourceServices);
+                    CygnusMetrics sourceMetrics = ch.getServiceMetrics();
+                    mergedMetrics.merge(sourceMetrics);
                 } // if
             } // for
         } // if
@@ -146,14 +148,14 @@ public final class MetricsHandlers {
 
                 if (sink instanceof CygnusSink) {
                     CygnusSink cs = (CygnusSink) sink;
-                    CygnusMetrics sinkServices = cs.getServiceMetrics();
-                    mergeServices.merge(sinkServices);
+                    CygnusMetrics sinkMetrics = cs.getServiceMetrics();
+                    mergedMetrics.merge(sinkMetrics);
                 } // if
             } // for
         } // if
 
-        return mergeServices;
-    } // mergeServices
+        return mergedMetrics;
+    } // mergeMetrics
     
     /**
      * Deletes metrics from all the given sources and sinks.

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/MetricsHandlers.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/management/MetricsHandlers.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.management;
+
+import com.google.common.collect.ImmutableMap;
+import com.telefonica.iot.cygnus.handlers.CygnusHandler;
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics;
+import com.telefonica.iot.cygnus.log.CygnusLogger;
+import com.telefonica.iot.cygnus.sinks.CygnusSink;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.flume.Sink;
+import org.apache.flume.SinkProcessor;
+import org.apache.flume.SinkRunner;
+import org.apache.flume.Source;
+import org.apache.flume.SourceRunner;
+import org.apache.flume.source.http.HTTPSourceHandler;
+
+/**
+ *
+ * @author frb
+ */
+public final class MetricsHandlers {
+    
+    private static final CygnusLogger LOGGER = new CygnusLogger(MetricsHandlers.class);
+    
+    /**
+     * Constructor. Utility classes should not have a public or default constructor.
+     */
+    private MetricsHandlers() {
+    } // MetricsHandlers
+    
+    /**
+     * Handles GET /v1/admin/mergeMetrics and /admin/mergeMetrics.
+     * @param request
+     * @param response
+     * @param sources
+     * @param sinks
+     * @throws IOException
+     */
+    public static synchronized void get(HttpServletRequest request, HttpServletResponse response,
+            ImmutableMap<String, SourceRunner> sources, ImmutableMap<String, SinkRunner> sinks) throws IOException {
+        // Let's assume everything goes well
+        response.setStatus(HttpServletResponse.SC_OK);
+        
+        // Get the reset parameter
+        String reset = request.getParameter("reset");
+        
+        if (reset != null && !reset.equals("true") && !reset.equals("false")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        } // if
+        
+        if (reset != null && reset.equals("true")) {
+            CygnusMetrics metrics = mergeMetrics(sources, sinks);
+            response.getWriter().println(metrics.toJsonString());
+            deleteMetrics(sources, sinks);
+            response.setContentType("application/json; charset=utf-8");
+        } else {
+            CygnusMetrics metrics = mergeMetrics(sources, sinks);
+            response.getWriter().println(metrics.toJsonString());
+            response.setContentType("application/json; charset=utf-8");
+        } // else
+    } // getServiceSubserviceMetrics
+    
+    /**
+     * Handles DELETE /v1/admin/mergeMetrics and /admin/mergeMetrics.
+     * @param response
+     * @param sources
+     * @param sinks
+     * @throws java.io.IOException
+     */
+    public static synchronized void delete(HttpServletResponse response, ImmutableMap<String, SourceRunner> sources,
+            ImmutableMap<String, SinkRunner> sinks) throws IOException {
+        deleteMetrics(sources, sinks);
+        response.setStatus(HttpServletResponse.SC_OK);
+    } // delete
+    
+    /**
+     * Merges metrics from all the given sources and sinks. It is protected in order it can be tested.
+     * @param sources
+     * @param sinks
+     * @return
+     */
+    protected static CygnusMetrics mergeMetrics(ImmutableMap<String, SourceRunner> sources,
+            ImmutableMap<String, SinkRunner> sinks) {
+        CygnusMetrics mergeServices = new CygnusMetrics();
+    
+        if (sources != null) {
+            for (String key : sources.keySet()) {
+                Source source;
+                HTTPSourceHandler handler;
+
+                try {
+                    SourceRunner sr = sources.get(key);
+                    source = sr.getSource();
+                    Field f = source.getClass().getDeclaredField("handler");
+                    f.setAccessible(true);
+                    handler = (HTTPSourceHandler) f.get(source);
+                } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                        | SecurityException e) {
+                    LOGGER.error("There was a problem when getting a sink. Details: " + e.getMessage());
+                    continue;
+                } // try catch
+
+                if (handler instanceof CygnusHandler) {
+                    CygnusHandler ch = (CygnusHandler) handler;
+                    CygnusMetrics sourceServices = ch.getServiceMetrics();
+                    mergeServices.merge(sourceServices);
+                } // if
+            } // for
+        } // if
+        
+        if (sinks != null) {
+            for (String key : sinks.keySet()) {
+                Sink sink;
+
+                try {
+                    SinkRunner sr = sinks.get(key);
+                    SinkProcessor sp = sr.getPolicy();
+                    Field f = sp.getClass().getDeclaredField("sink");
+                    f.setAccessible(true);
+                    sink = (Sink) f.get(sp);
+                } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                        | SecurityException e) {
+                    LOGGER.error("There was a problem when getting a sink. Details: " + e.getMessage());
+                    continue;
+                } // try catch
+
+                if (sink instanceof CygnusSink) {
+                    CygnusSink cs = (CygnusSink) sink;
+                    CygnusMetrics sinkServices = cs.getServiceMetrics();
+                    mergeServices.merge(sinkServices);
+                } // if
+            } // for
+        } // if
+
+        return mergeServices;
+    } // mergeServices
+    
+    /**
+     * Deletes metrics from all the given sources and sinks.
+     * @param sources
+     * @param sinks
+     */
+    private static void deleteMetrics(ImmutableMap<String, SourceRunner> sources,
+            ImmutableMap<String, SinkRunner> sinks) {
+        if (sources != null) {
+            for (String key : sources.keySet()) {
+                Source source;
+                HTTPSourceHandler handler;
+
+                try {
+                    SourceRunner sr = sources.get(key);
+                    source = sr.getSource();
+                    Field f = source.getClass().getDeclaredField("handler");
+                    f.setAccessible(true);
+                    handler = (HTTPSourceHandler) f.get(source);
+                } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                        | SecurityException e) {
+                    LOGGER.error("There was a problem when getting a sink. Details: " + e.getMessage());
+                    continue;
+                } // try catch
+
+                if (handler instanceof CygnusHandler) {
+                    CygnusHandler ch = (CygnusHandler) handler;
+                    ch.setServiceMetrics(new CygnusMetrics());
+                } // if
+            } // for
+        } // if
+        
+        if (sinks != null) {
+            for (String key : sinks.keySet()) {
+                Sink sink;
+
+                try {
+                    SinkRunner sr = sinks.get(key);
+                    SinkProcessor sp = sr.getPolicy();
+                    Field f = sp.getClass().getDeclaredField("sink");
+                    f.setAccessible(true);
+                    sink = (Sink) f.get(sp);
+                } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                        | SecurityException e) {
+                    LOGGER.error("There was a problem when getting a sink. Details: " + e.getMessage());
+                    continue;
+                } // try catch
+
+                if (sink instanceof CygnusSink) {
+                    CygnusSink cs = (CygnusSink) sink;
+                    cs.setServiceMetrics(new CygnusMetrics());
+                } // if
+            } // for
+        } // if
+    } // deleteMetrics
+    
+} // MetricsHandlers

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.metrics;
+
+import java.util.HashMap;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusMetrics {
+    
+    private final HashMap<String, HashMap<String, Metrics>> perServiceSubserviceMetrics;
+    private final HashMap<String, Metrics> perServiceAggrMetrics;
+    private final HashMap<String, Metrics> perSubserviceAggrMetrics;
+    private final Metrics allAggrMetrics;
+    
+    /**
+     * Constructor.
+     */
+    public CygnusMetrics() {
+        perServiceSubserviceMetrics = new HashMap<>();
+        perServiceAggrMetrics = new HashMap<>();
+        perSubserviceAggrMetrics = new HashMap<>();
+        allAggrMetrics = new Metrics();
+    } // CygnusMetrics
+    
+    /**
+     * Adds metrics to the given entity within the given service path within the given service.
+     * @param service
+     * @param subservice
+     * @param incomingTransaction
+     * @param incomingTransactionRequestSize
+     * @param incomingTransactionResponseSize
+     * @param incomingTransactionErrors
+     * @param serviceTime
+     */
+    public void add(String service, String subservice, long incomingTransaction, long incomingTransactionRequestSize,
+            long incomingTransactionResponseSize, long incomingTransactionErrors, long serviceTime) {
+        // Add to per-service metrics
+        HashMap<String, Metrics> subserviceMetrics = perServiceSubserviceMetrics.get(service);
+        
+        if (subserviceMetrics == null) {
+            subserviceMetrics = new HashMap<>();
+            perServiceSubserviceMetrics.put(service, subserviceMetrics);
+        } // if
+        
+        Metrics metrics = subserviceMetrics.get(subservice);
+        
+        if (metrics == null) {
+            metrics = new Metrics();
+            subserviceMetrics.put(subservice, metrics);
+        } // if
+        
+        metrics.addIncomingTransactions(incomingTransaction);
+        metrics.addIncomingTransactionRequestSize(incomingTransactionRequestSize);
+        metrics.addIncomingTransactionResponseSize(incomingTransactionResponseSize);
+        metrics.addIncomingTransactionErrors(incomingTransactionErrors);
+        metrics.addServiceTime(serviceTime);
+        
+        // Add to per-service aggregated metrics
+        Metrics allsubserviceMetrics = perServiceAggrMetrics.get(service);
+        
+        if (allsubserviceMetrics == null) {
+            allsubserviceMetrics = new Metrics();
+            perServiceAggrMetrics.put(service, allsubserviceMetrics);
+        } // if
+        
+        allsubserviceMetrics.addIncomingTransactions(incomingTransaction);
+        allsubserviceMetrics.addIncomingTransactionRequestSize(incomingTransactionRequestSize);
+        allsubserviceMetrics.addIncomingTransactionResponseSize(incomingTransactionResponseSize);
+        allsubserviceMetrics.addIncomingTransactionErrors(incomingTransactionErrors);
+        allsubserviceMetrics.addServiceTime(serviceTime);
+        
+        // Add to per-subservice metrics
+        Metrics subsvcMetrics = perSubserviceAggrMetrics.get(subservice);
+        
+        if (subsvcMetrics == null) {
+            subsvcMetrics = new Metrics();
+            perSubserviceAggrMetrics.put(subservice, subsvcMetrics);
+        } // if
+        
+        subsvcMetrics.addIncomingTransactions(incomingTransaction);
+        subsvcMetrics.addIncomingTransactionRequestSize(incomingTransactionRequestSize);
+        subsvcMetrics.addIncomingTransactionResponseSize(incomingTransactionResponseSize);
+        subsvcMetrics.addIncomingTransactionErrors(incomingTransactionErrors);
+        subsvcMetrics.addServiceTime(serviceTime);
+        
+        // Add to per-subservice aggregated metrics
+        allAggrMetrics.addIncomingTransactions(incomingTransaction);
+        allAggrMetrics.addIncomingTransactionRequestSize(incomingTransactionRequestSize);
+        allAggrMetrics.addIncomingTransactionResponseSize(incomingTransactionResponseSize);
+        allAggrMetrics.addIncomingTransactionErrors(incomingTransactionErrors);
+        allAggrMetrics.addServiceTime(serviceTime);
+    } // add
+    
+    /**
+     * Gets metrics related to given service and service path.
+     * @param service
+     * @param servicePath
+     * @return Metrics related to given service and ervice path
+     */
+    public Metrics getServiceSubserviceMetrics(String service, String servicePath) {
+        return perServiceSubserviceMetrics.get(service).get(servicePath);
+    } // getServiceSubserviceMetrics
+    
+    /**
+     * Gets metrics related to given service.
+     * @param service
+     * @return Metrics related to given service
+     */
+    public Metrics getServiceAggrMetrics(String service) {
+        return perServiceAggrMetrics.get(service);
+    } // getServiceSubserviceMetrics
+    
+    /**
+     * Gets metrics related to given service and service path.
+     * @param servicePath
+     * @return Metrics related to given service and ervice path
+     */
+    public Metrics getSubserviceAggrMetrics(String servicePath) {
+        return perSubserviceAggrMetrics.get(servicePath);
+    } // getSubserviceAggrMetrics
+    
+    /**
+     * Gets metrics related to given service.
+     * @return Metrics related to given service
+     */
+    public Metrics getAllAggrMetrics() {
+        return this.allAggrMetrics;
+    } // getAllAggrMetrics
+   
+    /**
+     * Merges given source handler metrics into these ones.
+     * @param other
+     */
+    public void merge(CygnusMetrics other) {
+        HashMap<String, HashMap<String, Metrics>> otherServiceMetrics = other.perServiceSubserviceMetrics;
+                
+        for (String service : otherServiceMetrics.keySet()) {
+            HashMap<String, Metrics> thisSubservices = this.perServiceSubserviceMetrics.get(service);
+
+            if (thisSubservices == null) {
+                thisSubservices = new HashMap<>();
+                this.perServiceSubserviceMetrics.put(service, thisSubservices);
+            } // if
+
+            HashMap<String, Metrics> otherSubservices = otherServiceMetrics.get(service);
+
+            for (String subservice : otherSubservices.keySet()) {
+                Metrics thisMetrics = thisSubservices.get(subservice);
+
+                if (thisMetrics == null) {
+                    thisMetrics = new Metrics();
+                    thisSubservices.put(subservice, thisMetrics);
+                } // if
+                
+                Metrics otherMetrics = otherSubservices.get(subservice);
+                thisMetrics.merge(otherMetrics);
+            } // for
+        } // for
+        
+        HashMap<String, Metrics> otherServiceSumMetrics = other.perServiceAggrMetrics;
+        
+        for (String service : otherServiceSumMetrics.keySet()) {
+            Metrics thisMetrics = this.perServiceAggrMetrics.get(service);
+            
+            if (thisMetrics == null) {
+                thisMetrics = new Metrics();
+                this.perServiceAggrMetrics.put(service, thisMetrics);
+            } // if
+            
+            Metrics otherMetrics = otherServiceSumMetrics.get(service);
+            thisMetrics.merge(otherMetrics);
+        } // for
+        
+        HashMap<String, Metrics> otherSuberviceMetrics = other.perSubserviceAggrMetrics;
+        
+        for (String subservice : otherSuberviceMetrics.keySet()) {
+            Metrics thisMetrics = this.perSubserviceAggrMetrics.get(subservice);
+            
+            if (thisMetrics == null) {
+                thisMetrics = new Metrics();
+                this.perSubserviceAggrMetrics.put(subservice, thisMetrics);
+            } // if
+            
+            Metrics otherMetrics = otherSuberviceMetrics.get(subservice);
+            thisMetrics.merge(otherMetrics);
+        } // for
+        
+        this.allAggrMetrics.merge(other.allAggrMetrics);
+    } // merge
+    
+    /**
+     * Gets the Json string for this metrics.
+     * @return The Json string for this metrics
+     */
+    public String toJsonString() {
+        String json = "{\"services\":{";
+        boolean firstService = true;
+        
+        for (String service : perServiceSubserviceMetrics.keySet()) {
+            if (firstService) {
+                json += "\"" + service + "\":{\"subservs\":{";
+                firstService = false;
+            } else {
+                json += ",\"" + service + "\":{\"subservs\":{";
+            } // if else
+            
+            HashMap<String, Metrics> subserviceMetrics = perServiceSubserviceMetrics.get(service);
+            boolean firstSubservice = true;
+            
+            for (String subservice : subserviceMetrics.keySet()) {
+                Metrics metrics = subserviceMetrics.get(subservice);
+                
+                if (firstSubservice) {
+                    json += "\"" + subservice + "\":" + metrics.toJsonString();
+                    firstSubservice = false;
+                } else {
+                    json += ",\"" + subservice + "\":" + metrics.toJsonString();
+                } // if else
+            } // for
+            
+            json += "},\"sum\":" + perServiceAggrMetrics.get(service).toJsonString() + "}";
+        } // for
+        
+        json += "},\"sum\": {\"subservs\":{";
+        boolean firstSubservice = true;
+        
+        for (String subservice : perSubserviceAggrMetrics.keySet()) {
+            Metrics metrics = perSubserviceAggrMetrics.get(subservice);
+            
+            if (firstSubservice) {
+                json += "\"" + subservice + "\":" + metrics.toJsonString();
+                firstSubservice = false;
+            } else {
+                json += ",\"" + subservice + "\":" + metrics.toJsonString();
+            } // if else
+        } // for
+
+        if (perSubserviceAggrMetrics.isEmpty()) {
+            json += "},\"sum\":{}}}";
+        } else {
+            json += "},\"sum\":" + allAggrMetrics.toJsonString() + "}}";
+        } // if else
+        
+        return json;
+    } // toJsonString
+    
+    /**
+     * Metrics class.
+     */
+    public class Metrics {
+        
+        private long incomingTransactions;
+        private long incomingTransactionRequestSize;
+        private long incomingTransactionResponseSize;
+        private long incomingTransactionErrors;
+        private double serviceTime;
+
+        /**
+         * Constructor.
+         */
+        public Metrics() {
+            incomingTransactions = 0;
+            incomingTransactionRequestSize = 0;
+            incomingTransactionResponseSize = 0;
+            incomingTransactionErrors = 0;
+            serviceTime = 0;
+        } // Metrics
+
+        public long getIncomingTransactions() {
+            return incomingTransactions;
+        } // getIncomingTransactions
+
+        public long getIncomingTransactionRequestSize() {
+            return incomingTransactionRequestSize;
+        } // getIncomingTransactionRequestSize
+
+        public long getIncomingTransactionResponseSize() {
+            return incomingTransactionResponseSize;
+        } // getIncomingTransactionResponseSize
+
+        public long getIncomingTransactionErrors() {
+            return incomingTransactionErrors;
+        } // getIncomingTransactionErrors
+        
+        public double getServiceTime() {
+            return serviceTime;
+        } // getServiceTime
+
+        /**
+         * Adds as many incoming transactions as given.
+         * @param incomingTransactions
+         */
+        public void addIncomingTransactions(long incomingTransactions) {
+            this.incomingTransactions += incomingTransactions;
+        } // addIncomingTransactions
+
+        /**
+         * Adds as many bytes for incoming transaction requests as given.
+         * @param incomingTransactionRequestSize
+         */
+        public void addIncomingTransactionRequestSize(long incomingTransactionRequestSize) {
+            this.incomingTransactionRequestSize += incomingTransactionRequestSize;
+        } // addIncomingTransactionRequestSize
+
+        /**
+         * Adds as many bytes for incoming transaction responses as given.
+         * @param incomingTransactionResponseSize
+         */
+        public void addIncomingTransactionResponseSize(long incomingTransactionResponseSize) {
+            this.incomingTransactionResponseSize += incomingTransactionResponseSize;
+        } // addIncomingTransactionResponseSize
+
+        /**
+         * Adds as many incoming transaction errors as given.
+         * @param incomingTransactionErrors
+         */
+        public void addIncomingTransactionErrors(long incomingTransactionErrors) {
+            this.incomingTransactionErrors += incomingTransactionErrors;
+        } // addIncomingTransactionErrors
+        
+        /**
+         * Adds as many service milliseconds as given.
+         * @param serviceTime
+         */
+        public void addServiceTime(double serviceTime) {
+            this.serviceTime += serviceTime;
+        } // addIncomingTransactionErrors
+
+        /**
+         * Merges given metrics with these ones.
+         * @param metrics
+         */
+        public void merge(Metrics metrics) {
+            incomingTransactions += metrics.incomingTransactions;
+            incomingTransactionRequestSize += metrics.incomingTransactionRequestSize;
+            incomingTransactionResponseSize += metrics.incomingTransactionResponseSize;
+            incomingTransactionErrors += metrics.incomingTransactionErrors;
+            serviceTime += metrics.serviceTime;
+        } // merge
+        
+        /**
+         * Gets the Json string for this metrics.
+         * @return The Json string for this metrics
+         */
+        public String toJsonString() {
+            double avg = (incomingTransactions == 0 ? 0 : serviceTime / incomingTransactions);
+            
+            return "{\"incomingTransactions\":" + incomingTransactions + ","
+                    + "\"incomingTransactionRequestSize\":" + incomingTransactionRequestSize + ","
+                    + "\"incomingTransactionResponseSize\":" + incomingTransactionResponseSize + ","
+                    + "\"incomingTransactionErrors\":" + incomingTransactionErrors + ","
+                    + "\"serviceTime\":" + avg + "}";
+        } // toJsonString
+        
+    } // Metrics
+    
+} // CygnusMetrics

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
@@ -271,7 +271,7 @@ public class CygnusMetrics {
         private long incomingTransactionRequestSize;
         private long incomingTransactionResponseSize;
         private long incomingTransactionErrors;
-        private long outgoingTransactions; // Hidden metric just for service time compautations
+        private long outgoingTransactions; // Hidden metric just for service time computations
         private double serviceTime;
 
         /**
@@ -365,7 +365,7 @@ public class CygnusMetrics {
          * @return The Json string for this metrics
          */
         public String toJsonString() {
-            double avg = (incomingTransactions == 0 ? 0 : serviceTime / outgoingTransactions);
+            double avg = (outgoingTransactions == 0 ? 0 : serviceTime / outgoingTransactions);
             
             return "{\"incomingTransactions\":" + incomingTransactions + ","
                     + "\"incomingTransactionRequestSize\":" + incomingTransactionRequestSize + ","

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
@@ -271,6 +271,7 @@ public class CygnusMetrics {
         private long incomingTransactionRequestSize;
         private long incomingTransactionResponseSize;
         private long incomingTransactionErrors;
+        private long outgoingTransactions; // Hidden metric just for service time compautations
         private double serviceTime;
 
         /**
@@ -281,6 +282,7 @@ public class CygnusMetrics {
             incomingTransactionRequestSize = 0;
             incomingTransactionResponseSize = 0;
             incomingTransactionErrors = 0;
+            outgoingTransactions = 0;
             serviceTime = 0;
         } // Metrics
 
@@ -341,6 +343,7 @@ public class CygnusMetrics {
          * @param serviceTime
          */
         public void addServiceTime(double serviceTime) {
+            this.outgoingTransactions++;
             this.serviceTime += serviceTime;
         } // addIncomingTransactionErrors
 
@@ -353,6 +356,7 @@ public class CygnusMetrics {
             incomingTransactionRequestSize += metrics.incomingTransactionRequestSize;
             incomingTransactionResponseSize += metrics.incomingTransactionResponseSize;
             incomingTransactionErrors += metrics.incomingTransactionErrors;
+            outgoingTransactions += metrics.outgoingTransactions;
             serviceTime += metrics.serviceTime;
         } // merge
         
@@ -361,7 +365,7 @@ public class CygnusMetrics {
          * @return The Json string for this metrics
          */
         public String toJsonString() {
-            double avg = (incomingTransactions == 0 ? 0 : serviceTime / incomingTransactions);
+            double avg = (incomingTransactions == 0 ? 0 : serviceTime / outgoingTransactions);
             
             return "{\"incomingTransactions\":" + incomingTransactions + ","
                     + "\"incomingTransactionRequestSize\":" + incomingTransactionRequestSize + ","

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/sinks/CygnusSink.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/sinks/CygnusSink.java
@@ -17,6 +17,7 @@
  */
 package com.telefonica.iot.cygnus.sinks;
 
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics;
 import java.util.Date;
 import org.apache.flume.sink.AbstractSink;
 
@@ -30,6 +31,7 @@ public abstract class CygnusSink extends AbstractSink {
     protected final long setupTime = new Date().getTime();
     protected long numProcessedEvents = 0;
     protected long numPersistedEvents = 0;
+    protected CygnusMetrics serviceMetrics = new CygnusMetrics();
     
     /**
      * Gets the setup time.
@@ -70,5 +72,21 @@ public abstract class CygnusSink extends AbstractSink {
     public void setNumPersistedEvents(long n) {
         numPersistedEvents = n;
     } // setNumPersistedEvents
+    
+    /**
+     * Gets serviceMetrics.
+     * @return serviceMetrics
+     */
+    public CygnusMetrics getServiceMetrics() {
+        return serviceMetrics;
+    } // getServiceSubserviceMetrics
+    
+    /**
+     * Sets serviceMetrics.
+     * @param serviceMetrics
+     */
+    public void setServiceMetrics(CygnusMetrics serviceMetrics) {
+        this.serviceMetrics = serviceMetrics;
+    } // setServiceMetrics
     
 } // CygnusSink

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/handlers/CygnusHandlerTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/handlers/CygnusHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.handlers;
+
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusHandlerTest {
+    
+    /**
+     * Constructor.
+     */
+    public CygnusHandlerTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // CygnusHandlerTest
+    
+    /**
+     * Dummy class for testing purposes.
+     */
+    private class CygnusHandlerImpl extends CygnusHandler {
+    } // CygnusHandlerImpl
+    
+    /**
+     * [CygnusHandler.getServiceMetrics] -------- Not null metrics are retrieved.
+     */
+    @Test
+    public void testGetServiceMetrics() {
+        System.out.println(getTestTraceHead("[CygnusHandler.getServiceMetrics]")
+                + " - Not null metrics are retrieved");
+        
+        CygnusHandlerImpl ch = new CygnusHandlerImpl();
+        CygnusMetrics metrics = ch.getServiceMetrics();
+        
+        try {
+            assertTrue(metrics != null);
+            System.out.println(getTestTraceHead("[CygnusMetrics.getServiceMetrics]")
+                    + " -  OK  - Not null metrics were retrieved");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.getServiceMetrics]")
+                    + " - FAIL - Null metrics were retrieved");
+            throw e;
+        } // try catch
+    } // testGetServiceMetrics
+    
+    /**
+     * [CygnusHandler.setServiceMetrics] -------- Given metrics are set.
+     */
+    @Test
+    public void testSetServiceMetrics() {
+        System.out.println(getTestTraceHead("[CygnusHandler.setServiceMetrics]")
+                + " - Given metrics are set");
+        
+        CygnusHandlerImpl ch = new CygnusHandlerImpl();
+        CygnusMetrics metrics = new CygnusMetrics();
+        ch.setServiceMetrics(metrics);
+        
+        try {
+            assertEquals(metrics, ch.getServiceMetrics());
+            System.out.println(getTestTraceHead("[CygnusMetrics.setServiceMetrics]")
+                    + " -  OK  - Metrics were set");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.setServiceMetrics]")
+                    + " - FAIL - Metrics were not set");
+            throw e;
+        } // try catch
+    } // testGetServiceMetrics
+    
+} // CygnusHandlerTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/MetricsHandlersTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/management/MetricsHandlersTest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.management;
+
+import com.google.common.collect.ImmutableMap;
+import com.telefonica.iot.cygnus.handlers.CygnusHandler;
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import java.lang.reflect.Field;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.Source;
+import org.apache.flume.SourceRunner;
+import org.apache.flume.source.EventDrivenSourceRunner;
+import org.apache.flume.source.http.HTTPSource;
+import org.apache.flume.source.http.HTTPSourceHandler;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class MetricsHandlersTest {
+    
+    /**
+     * Constructor.
+     */
+    public MetricsHandlersTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // MetricsHandlersTest
+    
+    /**
+     * Dummy class for testing purposes.
+     */
+    private class CygnusHandlerImpl extends CygnusHandler implements HTTPSourceHandler {
+
+        @Override
+        public List<Event> getEvents(HttpServletRequest hsr) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        } // getEvents
+
+        @Override
+        public void configure(Context cntxt) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        } // configure
+        
+    } // CygnusHandlerImpl
+
+    /**
+     * [MetricsHandlers.mergeMetrics] -------- Metrics from two sources are merged.
+     */
+    @Test
+    public void testMerge() {
+        System.out.println(getTestTraceHead("[MetricsHandlers.mergeMetrics]")
+                + " - Metrics from two sources are merged");
+        
+        // Names
+        String service1 = "service1";
+        String subservice11 = "subservice11";
+        String service2 = "service2";
+        String subservice21 = "subservice21";
+        String subservice22 = "subservice22";
+        
+        // Sources
+        String source1 = "source1";
+        String source2 = "source2";
+        
+        // Source 1 organization and metrics
+        // service1
+        //    subservice11 -> 1000, 12000, 500, 5
+        // service2
+        //    subservice21 -> 8000, 340000, 3700, 90
+        //    subservice22 -> 1500, 10000, 1000, 10
+        CygnusMetrics source1Metrics = new CygnusMetrics();
+        source1Metrics.add(service1, subservice11, 1000, 12000, 500, 5, 0);
+        source1Metrics.add(service2, subservice21, 8000, 340000, 3700, 90, 0);
+        source1Metrics.add(service2, subservice22, 1500, 10000, 1000, 10, 0);
+        
+        // Source 2 organization and metrics
+        // service1
+        //    subservice11 -> 12500, 256700, 10500, 215
+        // service2
+        //    subservice22 -> 10, 100, 30, 0
+        CygnusMetrics source2Metrics = new CygnusMetrics();
+        source2Metrics.add(service1, subservice11, 12500, 256700, 10500, 215, 0);
+        source2Metrics.add(service2, subservice22, 10, 100, 30, 0, 0);
+
+        // Assign to all the sources a Cygnus handler containing metrics
+        // Use Java reflection to hack SourceRunner class
+        SourceRunner sr1;
+        SourceRunner sr2;
+
+        try {
+            CygnusHandler ch1 = new CygnusHandlerImpl();
+            ch1.setServiceMetrics(source1Metrics);
+            sr1 = new EventDrivenSourceRunner();
+            Source s1 = new HTTPSource();
+            sr1.setSource(s1);
+            Field f = s1.getClass().getDeclaredField("handler");
+            f.setAccessible(true);
+            f.set(s1, ch1);
+            CygnusHandler ch2 = new CygnusHandlerImpl();
+            ch2.setServiceMetrics(source2Metrics);
+            sr2 = new EventDrivenSourceRunner();
+            Source s2 = new HTTPSource();
+            sr2.setSource(s2);
+            f = s2.getClass().getDeclaredField("handler");
+            f.setAccessible(true);
+            f.set(s2, ch2);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+            System.out.println(getTestTraceHead("[MetricsHandlers.mergeMetrics]")
+                    + " - FAIL - Metrics merge was not correct ");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        // Create the list of sources
+        ImmutableMap<String, SourceRunner> sources = ImmutableMap.of(source1, sr1, source2, sr2);
+        
+        // Do the merge for source's metrics
+        CygnusMetrics mergedServiceMetrics = MetricsHandlers.mergeMetrics(sources, null);
+        
+        // Check the merge for subservice 11 within service 1
+        CygnusMetrics.Metrics subservice11metrics =
+                mergedServiceMetrics.getServiceSubserviceMetrics(service1, subservice11);
+        
+        try {
+            assertEquals(13500, subservice11metrics.getIncomingTransactions());
+            assertEquals(268700, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 within service 2
+        CygnusMetrics.Metrics subservice21metrics =
+                mergedServiceMetrics.getServiceSubserviceMetrics(service2, subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 within service 2
+        CygnusMetrics.Metrics subservice22metrics =
+                mergedServiceMetrics.getServiceSubserviceMetrics(service2, subservice22);
+        
+        try {
+            assertEquals(1510, subservice22metrics.getIncomingTransactions());
+            assertEquals(10100, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1030, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 1 aggregated
+        CygnusMetrics.Metrics service1metrics =
+                mergedServiceMetrics.getServiceAggrMetrics(service1);
+        
+        try {
+            assertEquals(13500, service1metrics.getIncomingTransactions());
+            assertEquals(268700, service1metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, service1metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, service1metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 2 aggregated
+        CygnusMetrics.Metrics service2metrics =
+                mergedServiceMetrics.getServiceAggrMetrics(service2);
+        
+        try {
+            assertEquals(9510, service2metrics.getIncomingTransactions());
+            assertEquals(350100, service2metrics.getIncomingTransactionRequestSize());
+            assertEquals(4730, service2metrics.getIncomingTransactionResponseSize());
+            assertEquals(100, service2metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 11 aggregated
+        subservice11metrics =
+                mergedServiceMetrics.getSubserviceAggrMetrics(subservice11);
+        
+        try {
+            assertEquals(13500, subservice11metrics.getIncomingTransactions());
+            assertEquals(268700, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 aggregated
+        subservice21metrics = mergedServiceMetrics.getSubserviceAggrMetrics(subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 aggregated
+        subservice22metrics = mergedServiceMetrics.getSubserviceAggrMetrics(subservice22);
+        
+        try {
+            assertEquals(1510, subservice22metrics.getIncomingTransactions());
+            assertEquals(10100, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1030, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for all metrics
+        CygnusMetrics.Metrics allMetrics = mergedServiceMetrics.getAllAggrMetrics();
+        
+        try {
+            assertEquals(23010, allMetrics.getIncomingTransactions());
+            assertEquals(618800, allMetrics.getIncomingTransactionRequestSize());
+            assertEquals(15730, allMetrics.getIncomingTransactionResponseSize());
+            assertEquals(320, allMetrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+    } // testMergeMetrics
+
+    
+} // MetricsHandlersTest

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/metrics/CygnusMetricsTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/metrics/CygnusMetricsTest.java
@@ -1,0 +1,480 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.telefonica.iot.cygnus.metrics;
+
+import com.telefonica.iot.cygnus.metrics.CygnusMetrics.Metrics;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusMetricsTest {
+    
+    /**
+     * Constructor.
+     */
+    public CygnusMetricsTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // CygnusMetricsTest
+
+    /**
+     * [CygnusMetrics.add] -------- Values are added to the metrics.
+     */
+    @Test
+    public void testAdd() {
+        System.out.println(getTestTraceHead("[CygnusMetrics.add]") + " - Values are added to the metrics");
+        
+        // Names
+        String service1 = "service1";
+        String subservice11 = "subservice11";
+        String service2 = "service2";
+        String subservice21 = "subservice21";
+        String subservice22 = "subservice22";
+        
+        // Metrics
+        // service1
+        //    subservice11 -> 1000, 12000, 500, 5
+        // service2
+        //    subservice21 -> 8000, 340000, 3700, 90
+        //    subservice22 -> 1500, 10000, 1000, 10
+        CygnusMetrics metrics = new CygnusMetrics();
+        metrics.add(service1, subservice11, 1000, 12000, 500, 5, 0);
+        metrics.add(service2, subservice21, 8000, 340000, 3700, 90, 0);
+        metrics.add(service2, subservice22, 1500, 10000, 1000, 10, 0);
+        
+        // Check the merge for subservice 11 within service 1
+        Metrics subservice11metrics = metrics.getServiceSubserviceMetrics(service1, subservice11);
+        
+        try {
+            assertEquals(1000, subservice11metrics.getIncomingTransactions());
+            assertEquals(12000, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(500, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(5, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 within service 2
+        Metrics subservice21metrics = metrics.getServiceSubserviceMetrics(service2, subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 within service 2
+        Metrics subservice22metrics = metrics.getServiceSubserviceMetrics(service2, subservice22);
+        
+        try {
+            assertEquals(1500, subservice22metrics.getIncomingTransactions());
+            assertEquals(10000, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1000, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 1 aggregated
+        Metrics service1metrics = metrics.getServiceAggrMetrics(service1);
+        
+        try {
+            assertEquals(1000, service1metrics.getIncomingTransactions());
+            assertEquals(12000, service1metrics.getIncomingTransactionRequestSize());
+            assertEquals(500, service1metrics.getIncomingTransactionResponseSize());
+            assertEquals(5, service1metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 2 aggregated
+        Metrics service2metrics = metrics.getServiceAggrMetrics(service2);
+        
+        try {
+            assertEquals(9500, service2metrics.getIncomingTransactions());
+            assertEquals(350000, service2metrics.getIncomingTransactionRequestSize());
+            assertEquals(4700, service2metrics.getIncomingTransactionResponseSize());
+            assertEquals(100, service2metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 11 aggregated
+        subservice11metrics =
+                metrics.getSubserviceAggrMetrics(subservice11);
+        
+        try {
+            assertEquals(1000, subservice11metrics.getIncomingTransactions());
+            assertEquals(12000, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(500, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(5, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 aggregated
+        subservice21metrics = metrics.getSubserviceAggrMetrics(subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 aggregated
+        subservice22metrics = metrics.getSubserviceAggrMetrics(subservice22);
+        
+        try {
+            assertEquals(1500, subservice22metrics.getIncomingTransactions());
+            assertEquals(10000, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1000, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for all metrics
+        Metrics allMetrics = metrics.getAllAggrMetrics();
+        
+        try {
+            assertEquals(10500, allMetrics.getIncomingTransactions());
+            assertEquals(362000, allMetrics.getIncomingTransactionRequestSize());
+            assertEquals(5200, allMetrics.getIncomingTransactionResponseSize());
+            assertEquals(105, allMetrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.add]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+    } // testAdd
+    
+    /**
+     * [CygnusMetrics.merge] -------- Two metrics are merged.
+     */
+    @Test
+    public void testMerge() {
+        System.out.println(getTestTraceHead("[CygnusMetrics.merge]") + " - Two metrics are merged");
+        
+        // Names
+        String service1 = "service1";
+        String subservice11 = "subservice11";
+        String service2 = "service2";
+        String subservice21 = "subservice21";
+        String subservice22 = "subservice22";
+        
+        // First metrics
+        // service1
+        //    subservice11 -> 1000, 12000, 500, 5
+        // service2
+        //    subservice21 -> 8000, 340000, 3700, 90
+        //    subservice22 -> 1500, 10000, 1000, 10
+        CygnusMetrics metrics1 = new CygnusMetrics();
+        metrics1.add(service1, subservice11, 1000, 12000, 500, 5, 0);
+        metrics1.add(service2, subservice21, 8000, 340000, 3700, 90, 0);
+        metrics1.add(service2, subservice22, 1500, 10000, 1000, 10, 0);
+        
+        // Second metrics
+        // service1
+        //    subservice11 -> 12500, 256700, 10500, 215
+        // service2
+        //    subservice22 -> 10, 100, 30, 0
+        CygnusMetrics metrics2 = new CygnusMetrics();
+        metrics2.add(service1, subservice11, 12500, 256700, 10500, 215, 0);
+        metrics2.add(service2, subservice22, 10, 100, 30, 0, 0);
+
+        // Merge second metrics in first one
+        metrics1.merge(metrics2);
+        
+        // Check the merge for subservice 11 within service 1
+        Metrics subservice11metrics = metrics1.getServiceSubserviceMetrics(service1, subservice11);
+        
+        try {
+            assertEquals(13500, subservice11metrics.getIncomingTransactions());
+            assertEquals(268700, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 within service 2
+        Metrics subservice21metrics = metrics1.getServiceSubserviceMetrics(service2, subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 within service 2
+        Metrics subservice22metrics = metrics1.getServiceSubserviceMetrics(service2, subservice22);
+        
+        try {
+            assertEquals(1510, subservice22metrics.getIncomingTransactions());
+            assertEquals(10100, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1030, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 1 aggregated
+        Metrics service1metrics = metrics1.getServiceAggrMetrics(service1);
+        
+        try {
+            assertEquals(13500, service1metrics.getIncomingTransactions());
+            assertEquals(268700, service1metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, service1metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, service1metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for service 2 aggregated
+        Metrics service2metrics = metrics1.getServiceAggrMetrics(service2);
+        
+        try {
+            assertEquals(9510, service2metrics.getIncomingTransactions());
+            assertEquals(350100, service2metrics.getIncomingTransactionRequestSize());
+            assertEquals(4730, service2metrics.getIncomingTransactionResponseSize());
+            assertEquals(100, service2metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 11 aggregated
+        subservice11metrics =
+                metrics1.getSubserviceAggrMetrics(subservice11);
+        
+        try {
+            assertEquals(13500, subservice11metrics.getIncomingTransactions());
+            assertEquals(268700, subservice11metrics.getIncomingTransactionRequestSize());
+            assertEquals(11000, subservice11metrics.getIncomingTransactionResponseSize());
+            assertEquals(220, subservice11metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 21 aggregated
+        subservice21metrics = metrics1.getSubserviceAggrMetrics(subservice21);
+        
+        try {
+            assertEquals(8000, subservice21metrics.getIncomingTransactions());
+            assertEquals(340000, subservice21metrics.getIncomingTransactionRequestSize());
+            assertEquals(3700, subservice21metrics.getIncomingTransactionResponseSize());
+            assertEquals(90, subservice21metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for subservice 22 aggregated
+        subservice22metrics = metrics1.getSubserviceAggrMetrics(subservice22);
+        
+        try {
+            assertEquals(1510, subservice22metrics.getIncomingTransactions());
+            assertEquals(10100, subservice22metrics.getIncomingTransactionRequestSize());
+            assertEquals(1030, subservice22metrics.getIncomingTransactionResponseSize());
+            assertEquals(10, subservice22metrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+        
+        // Check the merge for all metrics
+        Metrics allMetrics = metrics1.getAllAggrMetrics();
+        
+        try {
+            assertEquals(23010, allMetrics.getIncomingTransactions());
+            assertEquals(618800, allMetrics.getIncomingTransactionRequestSize());
+            assertEquals(15730, allMetrics.getIncomingTransactionResponseSize());
+            assertEquals(320, allMetrics.getIncomingTransactionErrors());
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " -  OK  - Metrics merge was correct");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.merge]")
+                    + " - FAIL - Metrics merge was not corect ");
+            throw e;
+        } // try catch
+    } // testMergeMetrics
+    
+    /**
+     * [CygnusMetrics.toJsonString] -------- Metrics are printed as Json string.
+     */
+    @Test
+    public void testToJsonString() {
+        System.out.println(getTestTraceHead("[CygnusMetrics.toJsonString]")
+                + " - Metrics are printed as Json string");
+        
+        // Names
+        String service1 = "service1";
+        String subservice11 = "subservice11";
+        String service2 = "service2";
+        String subservice21 = "subservice21";
+        String subservice22 = "subservice22";
+        
+        // Source 1 organization and metrics
+        // service1
+        //    subservice11 -> 1000, 12000, 500, 5
+        // service2
+        //    subservice21 -> 8000, 340000, 3700, 90
+        //    subservice22 -> 1500, 10000, 1000, 10
+        CygnusMetrics source1Metrics = new CygnusMetrics();
+        source1Metrics.add(service1, subservice11, 1000, 12000, 500, 5, 0);
+        source1Metrics.add(service2, subservice21, 8000, 340000, 3700, 90, 0);
+        source1Metrics.add(service2, subservice22, 1500, 10000, 1000, 10, 0);
+        
+        // To Json string
+        String jsonStr = source1Metrics.toJsonString();
+        String expectedJsonStr = "{\"services\":{\"service2\":{\"subservs\":{"
+                + "\"subservice22\":{"
+                + "\"incomingTransactions\":1500,"
+                + "\"incomingTransactionRequestSize\":10000,"
+                + "\"incomingTransactionResponseSize\":1000,"
+                + "\"incomingTransactionErrors\":10,"
+                + "\"serviceTime\":0.0},"
+                + "\"subservice21\":{"
+                + "\"incomingTransactions\":8000,"
+                + "\"incomingTransactionRequestSize\":340000,"
+                + "\"incomingTransactionResponseSize\":3700,"
+                + "\"incomingTransactionErrors\":90,"
+                + "\"serviceTime\":0.0}},"
+                + "\"sum\":{"
+                + "\"incomingTransactions\":9500,"
+                + "\"incomingTransactionRequestSize\":350000,"
+                + "\"incomingTransactionResponseSize\":4700,"
+                + "\"incomingTransactionErrors\":100,"
+                + "\"serviceTime\":0.0}},"
+                + "\"service1\":{\"subservs\":{"
+                + "\"subservice11\":{"
+                + "\"incomingTransactions\":1000,"
+                + "\"incomingTransactionRequestSize\":12000,"
+                + "\"incomingTransactionResponseSize\":500,"
+                + "\"incomingTransactionErrors\":5,"
+                + "\"serviceTime\":0.0}},"
+                + "\"sum\":{"
+                + "\"incomingTransactions\":1000,"
+                + "\"incomingTransactionRequestSize\":12000,"
+                + "\"incomingTransactionResponseSize\":500,"
+                + "\"incomingTransactionErrors\":5,"
+                + "\"serviceTime\":0.0}}},"
+                + "\"sum\": {"
+                + "\"subservs\":{"
+                + "\"subservice11\":{"
+                + "\"incomingTransactions\":1000,"
+                + "\"incomingTransactionRequestSize\":12000,"
+                + "\"incomingTransactionResponseSize\":500,"
+                + "\"incomingTransactionErrors\":5,"
+                + "\"serviceTime\":0.0},"
+                + "\"subservice22\":{"
+                + "\"incomingTransactions\":1500,"
+                + "\"incomingTransactionRequestSize\":10000,"
+                + "\"incomingTransactionResponseSize\":1000,"
+                + "\"incomingTransactionErrors\":10,"
+                + "\"serviceTime\":0.0},"
+                + "\"subservice21\":{"
+                + "\"incomingTransactions\":8000,"
+                + "\"incomingTransactionRequestSize\":340000,"
+                + "\"incomingTransactionResponseSize\":3700,"
+                + "\"incomingTransactionErrors\":90,"
+                + "\"serviceTime\":0.0}},"
+                + "\"sum\":{"
+                + "\"incomingTransactions\":10500,"
+                + "\"incomingTransactionRequestSize\":362000,"
+                + "\"incomingTransactionResponseSize\":5200,"
+                + "\"incomingTransactionErrors\":105,"
+                + "\"serviceTime\":0.0}}}";
+        
+        try {
+            assertEquals(expectedJsonStr, jsonStr);
+            System.out.println(getTestTraceHead("[CygnusMetrics.toJsonString]")
+                    + " -  OK  - Metrics were successfully printed as Json string");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CygnusMetrics.toJsonString]")
+                    + " - FAIL - Metrics were not successfully printed as Json string");
+            throw e;
+        } // try catch
+    } // testToJsonString
+    
+} // CygnusMetricsTest

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -161,30 +161,8 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         // Result
         ArrayList<Event> ngsiEvents = new ArrayList<>();
         
-        // If the configuration is invalid, nothing has to be done but to return null
-        if (invalidConfiguration) {
-            LOGGER.debug("[NGSIRestHandler] Invalid configuration, thus returning an empty list of Flume events");
-            return new ArrayList<>();
-        } // if
-        
         // Update the counters
         numReceivedEvents++;
-        
-        // Check the method
-        String method = request.getMethod().toUpperCase(Locale.ENGLISH);
-        
-        if (!method.equals("POST")) {
-            LOGGER.warn("[NGSIRestHandler] Bad HTTP notification (" + method + " method not supported)");
-            throw new MethodNotSupportedException(method + " method not supported");
-        } // if
-
-        // Check the notificationTarget
-        String target = request.getRequestURI();
-        
-        if (!target.equals(notificationTarget)) {
-            LOGGER.warn("[NGSIRestHandler] Bad HTTP notification (" + target + " target not supported)");
-            throw new HTTPBadRequestException(target + " target not supported");
-        } // if
         
         // Check the headers looking for not supported content type and/or invalid FIWARE service and service path
         Enumeration headerNames = request.getHeaderNames();
@@ -258,15 +236,41 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             } // switch
         } // while
         
-        // Check if received content type is null
-        if (contentType == null) {
-            LOGGER.warn("[NGSIRestHandler] Missing content type. Required 'application/json; charset=utf-8'");
-            throw new HTTPBadRequestException("Missing content type. Required 'application/json; charset=utf-8'");
-        } // if
-        
         // Get a service and servicePath and store it in the log4j Mapped Diagnostic Context (MDC)
         MDC.put(CommonConstants.LOG4J_SVC, service == null ? defaultService : service);
         MDC.put(CommonConstants.LOG4J_SUBSVC, servicePath == null ? defaultServicePath : servicePath);
+
+        // If the configuration is invalid, nothing has to be done but to return null
+        if (invalidConfiguration) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 0, 0);
+            LOGGER.debug("[NGSIRestHandler] Invalid configuration, thus returning an empty list of Flume events");
+            return new ArrayList<>();
+        } // if
+        
+        // Check the method
+        String method = request.getMethod().toUpperCase(Locale.ENGLISH);
+        
+        if (!method.equals("POST")) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
+            LOGGER.warn("[NGSIRestHandler] Bad HTTP notification (" + method + " method not supported)");
+            throw new MethodNotSupportedException(method + " method not supported");
+        } // if
+
+        // Check the notificationTarget
+        String target = request.getRequestURI();
+        
+        if (!target.equals(notificationTarget)) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
+            LOGGER.warn("[NGSIRestHandler] Bad HTTP notification (" + target + " target not supported)");
+            throw new HTTPBadRequestException(target + " target not supported");
+        } // if
+
+        // Check if received content type is null
+        if (contentType == null) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
+            LOGGER.warn("[NGSIRestHandler] Missing content type. Required 'application/json; charset=utf-8'");
+            throw new HTTPBadRequestException("Missing content type. Required 'application/json; charset=utf-8'");
+        } // if
         
         // Get an internal transaction ID.
         String transId = CommonUtils.generateUniqueId(null, null);
@@ -292,6 +296,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         } // try
                 
         if (data.length() == 0) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
             LOGGER.warn("[NGSIRestHandler] Bad HTTP notification (No content in the request)");
             throw new HTTPBadRequestException("No content in the request");
         } // if
@@ -306,6 +311,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             ncr = gson.fromJson(data, NotifyContextRequest.class);
             LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest: " + ncr.toString());
         } catch (Exception e) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
             LOGGER.error("[NGSIRestHandler] Runtime error (" + e.getMessage() + ")");
             return null;
         } // try catch
@@ -314,6 +320,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         String[] servicePaths = servicePath.split(",");
         
         if (servicePaths.length != ncr.getContextResponses().size()) {
+            serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 1, 0);
             LOGGER.warn("[NGSIRestHandler] Bad HTTP notification ('"
                     + CommonConstants.HEADER_FIWARE_SERVICE_PATH
                     + "' header value does not match the number of notified context responses");
@@ -356,6 +363,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         } // for
 
         // Return the NGSIEvent list
+        serviceMetrics.add(service, servicePath, 1, request.getContentLength(), 0, 0, 0);
         LOGGER.debug("[NGSIRestHandler] NGSI events put in the channel, ids=" + ids);
         numProcessedEvents++;
         return ngsiEvents;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
@@ -93,6 +93,10 @@ public class NGSIEvent implements Event {
         return new Long(headers.get(NGSIConstants.FLUME_HEADER_TIMESTAMP));
     } // getRecvTimeTs
     
+    public String getServiceForData() {
+        return headers.get(CommonConstants.HEADER_FIWARE_SERVICE);
+    } // getServiceForData
+    
     /**
      * Gets the service both for data and for naming.
      * @param enableMappings

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
@@ -121,6 +121,31 @@ public class NGSIEventTest {
     } // testGetRecvTimeTs
     
     /**
+     * [NGSIEvent.getServiceForData] -------- The original service is returned.
+     */
+    @Test
+    public void testGetServiceForData() {
+        System.out.println(getTestTraceHead("[NGSIEvent.getServiceForData]")
+                + "-------- The original service is returned");
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE, originalService);
+        byte[] body = null; // irrelevant for this test
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, body, originalCE, mappedCE);
+        
+        try {
+            assertEquals(originalService, event.getServiceForData());
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForData]")
+                    + "-  OK  - The original service has been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.getServiceForData]")
+                    + "- FAIL - The original service has not been returned");
+            throw e;
+        } // try catch
+    } // testGetServiceForData
+    
+    /**
      * [NGSIEvent.getServiceForNaming] -------- When name mappings are not enabled, the original service is returned.
      */
     @Test

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
@@ -39,7 +39,7 @@ Content:
         * [DELETE all loggers](#section6.5.2)
 * [Metrics](#section7)
     * [GET `/v1/admin/metrics`](#section7.1)
-    * [DELTE `/v1/admin/metrics`](#section7.2)
+    * [DELETE `/v1/admin/metrics`](#section7.2)
 * [Available aliases](#section8)
 
 ##<a name="section1"></a>Apiary version of this document
@@ -938,11 +938,11 @@ When an invalid `transient` parameter is given:
 ###<a name="section7.1"></a>`GET /v1/admin/metrics`
 Gets metrics for a whole Cygnus agent. Specifically:
 
-* Number of <b>incoming transactions</b> (a transaction involves a request and a response).
-* Total <b>size of the requests</b>, in bytes.
-* Total <b>size of the responses</b>, in bytes.
-* Number of <b>transactions causing an error</b>.
-* <b>Average time</b> between transaction requests reception and transaction responses sending.
+* `incomingTransactions`. Number of incoming transactions (a transaction involves a request and a response).
+* `incomingTransactionRequestSize`. Total size of the requests, in bytes.
+* `incomingTransactionResponseSize`. Total size of the responses, in bytes.
+* `incomingTransactionError`. Number of transactions causing an error.
+* `serviceTime`. Average time between transaction requests reception and transaction responses sending.
 
 Metrics are only gathered if the following custom Cygnus components are used:
 

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
@@ -1005,6 +1005,12 @@ Response:
 
 If `reset=true` then metrics and returned and immediatelly after they are deleted (gathering the metrics and deleting them is an atomic operation, i.e. another interleaved GET operation will wait until the deletion is done).
 
+Additionally, because Cygnus distributes event processing among sources (responsible for event reception) and sinks (responsible for event persistence; an event may be processed by 2 or more sinks in parallel), some considerations when retrieving metrics must be had into account:
+
+* The number of incoming transactions may be inconsistent with regards to the service time, because certain events may be in a reception state, but not in a processed state.
+* The service time is computed as the total sum of processing times divided by the number of times the same incoming event is persisted (in other words, it is not divided by the number of incoming transactions). Thus, it could occur N events are persisted M times (M > N), and that impacts in the average service time.
+* The same occurs with the number of transaction errors. Thus, it could be this number is greater than the number of incoming transactions because the events are being processed by 2 or more sinks, and all of them are failing.
+
 [Top](#top)
 
 ###<a name="section7.2"></a>`DELETE /v1/admin/metrics`

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
@@ -37,6 +37,10 @@ Content:
     * [DELETE `/v1/admin/log/loggers`](#section6.5)
         * [DELETE logger by name](#section6.5.1)
         * [DELETE all loggers](#section6.5.2)
+* [Metrics](#section7)
+    * [GET `/v1/admin/metrics`](#section7.1)
+    * [DELTE `/v1/admin/metrics`](#section7.2)
+* [Available aliases](#section8)
 
 ##<a name="section1"></a>Apiary version of this document
 This API specification can be checked at [Apiary](http://telefonicaid.github.io/fiware-cygnus/api/latests) as well.
@@ -927,5 +931,101 @@ When an invalid `transient` parameter is given:
 ```
 {"success":"false","result":"Invalid 'transient' parameter"}
 ```
+
+[Top](#top)
+
+##<a name="section7"></a>Metrics
+###<a name="section7.1"></a>`GET /v1/admin/metrics`
+Gets metrics for a whole Cygnus agent. Specifically:
+
+* Number of <b>incoming transactions</b> (a transaction involves a request and a response).
+* Total <b>size of the requests</b>, in bytes.
+* Total <b>size of the responses</b>, in bytes.
+* Number of <b>transactions causing an error</b>.
+* <b>Average time</b> between transaction requests reception and transaction responses sending.
+
+Metrics are only gathered if the following custom Cygnus components are used:
+
+* `NGISRestHandler`
+* Any sink extending `NGSISink`.
+
+```
+GET http://<cygnus_host>:<management_port>/v1/admin/metrics[?reset=true|false]
+```
+
+Response:
+
+```
+200 OK
+
+{
+    "services": {
+        "service1": {
+            "subservs": {
+                "/subservice1": {
+                    <metrics for subservice1 within service1>
+                },
+                "/subservice1": {
+                    <metrics for subservice2 within service1>
+                }
+            },
+            "sum": {
+                <aggregated metrics for all subservices within service1>
+            }
+        },
+        "service2": {
+            "subservs": {
+                "/subservice1": {
+                    <metrics for subservice1 within service2>
+                },
+                "/subservice2": {
+                    <metrics for subservice2 within service2>
+                }
+            },
+            "sum": {
+                <aggregated metrics for all subservices within service2>
+            }
+        }
+    },
+    "sum": {
+        "subservs": {
+            "/subservice1": {
+                <aggregated metrics for subservice1 within all the services>
+            },
+            "/subservice2": {
+                <aggregated metrics for subservice2 within all the services>
+            }
+        },
+        "sum": {
+            <aggregated metrics for all subservices within all the services>
+        }
+    }
+}
+```
+
+If `reset=true` then metrics and returned and immediatelly after they are deleted (gathering the metrics and deleting them is an atomic operation, i.e. another interleaved GET operation will wait until the deletion is done).
+
+[Top](#top)
+
+###<a name="section7.2"></a>`DELETE /v1/admin/metrics`
+Deletes metrics, putting counters to zero.
+
+```
+DELETE http://<cygnus_host>:<management_port>/v1/admin/metrics
+```
+
+Response:
+
+```
+200 OK
+```
+
+[Top](#top)
+
+##<a name="section8"></a>Available aliases
+|Alias|Operation|
+|---|---|
+|GET /admin/metrics|GET /v1/admin/metrics|
+|DELETE /admin/metrics|DELETE /v1/admin/metrics|
 
 [Top](#top)

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
@@ -1007,8 +1007,8 @@ If `reset=true` then metrics and returned and immediatelly after they are delete
 
 Additionally, because Cygnus distributes event processing among sources (responsible for event reception) and sinks (responsible for event persistence; an event may be processed by 2 or more sinks in parallel), some considerations when retrieving metrics must be had into account:
 
-* The number of incoming transactions may be inconsistent with regards to the service time, because certain events may be in a reception state, but not in a processed state.
-* The service time is computed as the total sum of processing times divided by the number of times the same incoming event is persisted (in other words, it is not divided by the number of incoming transactions). Thus, it could occur N events are persisted M times (M > N), and that impacts in the average service time.
+* The number of incoming transactions may be eventually inconsistent with regards to the service time, because certain events may be in a reception state, but not in a processed state.
+* The service time is computed as the total sum of processing times (understanding processing time in this context as the time between even reception in the source and processing in one of the invidual sinks) divided by the number of times the same incoming event is persisted (in other words, it is not divided by the number of incoming transactions). Thus, it could occur N events are persisted M times (M > N), and that impacts in the average service time.
 * The same occurs with the number of transaction errors. Thus, it could be this number is greater than the number of incoming transactions because the events are being processed by 2 or more sinks, and all of them are failing.
 
 [Top](#top)


### PR DESCRIPTION
* Implements issue #1339 
* (Unofficial) e2e tests passed:
```
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {},
    "sum": {
        "subservs": {},
        "sum": {}
    }
}
$ ./notification-json-simple.sh http://localhost:5050/notify sc_madrid /gardens
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {
        "sc_madrid": {
            "subservs": {
                "/gardens": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 1258.0
                }
            },
            "sum": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 1258.0
            }
        }
    },
    "sum": {
        "subservs": {
            "/gardens": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 1258.0
            }
        },
        "sum": {
            "incomingTransactionErrors": 0,
            "incomingTransactionRequestSize": 460,
            "incomingTransactionResponseSize": 0,
            "incomingTransactions": 1,
            "serviceTime": 1258.0
        }
    }
}
$ ./notification-json-simple.sh http://localhost:5050/notify sc_madrid /traffic
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {
        "sc_madrid": {
            "subservs": {
                "/gardens": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 1258.0
                },
                "/traffic": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 804.0
                }
            },
            "sum": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 920,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 2,
                "serviceTime": 1031.0
            }
        }
    },
    "sum": {
        "subservs": {
            "/gardens": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 1258.0
            },
            "/traffic": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 804.0
            }
        },
        "sum": {
            "incomingTransactionErrors": 0,
            "incomingTransactionRequestSize": 920,
            "incomingTransactionResponseSize": 0,
            "incomingTransactions": 2,
            "serviceTime": 1031.0
        }
    }
}
$ curl -X GET "http://localhost:8081/v1/admin/metrics?reset=true" | python -m json.tool
{
    "services": {
        "sc_madrid": {
            "subservs": {
                "/gardens": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 1258.0
                },
                "/traffic": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 804.0
                }
            },
            "sum": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 920,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 2,
                "serviceTime": 1031.0
            }
        }
    },
    "sum": {
        "subservs": {
            "/gardens": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 1258.0
            },
            "/traffic": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 804.0
            }
        },
        "sum": {
            "incomingTransactionErrors": 0,
            "incomingTransactionRequestSize": 920,
            "incomingTransactionResponseSize": 0,
            "incomingTransactions": 2,
            "serviceTime": 1031.0
        }
    }
}
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {},
    "sum": {
        "subservs": {},
        "sum": {}
    }
}
$ ./notification-json-simple.sh http://localhost:5050/notify sc_madrid /traffic
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {
        "sc_madrid": {
            "subservs": {
                "/traffic": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "serviceTime": 416.0
                }
            },
            "sum": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 416.0
            }
        }
    },
    "sum": {
        "subservs": {
            "/traffic": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "serviceTime": 416.0
            }
        },
        "sum": {
            "incomingTransactionErrors": 0,
            "incomingTransactionRequestSize": 460,
            "incomingTransactionResponseSize": 0,
            "incomingTransactions": 1,
            "serviceTime": 416.0
        }
    }
}
$ curl -X DELETE "http://localhost:8081/v1/admin/metrics"
$ curl -X GET "http://localhost:8081/v1/admin/metrics" | python -m json.tool
{
    "services": {},
    "sum": {
        "subservs": {},
        "sum": {}
    }
}
```