### PR TITLE
hardening/1358_improve_logs_mysql_backend

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackend.java
@@ -18,6 +18,7 @@
 
 package com.telefonica.iot.cygnus.backends.mysql;
 
+import com.telefonica.iot.cygnus.errors.CygnusBadContextData;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 
@@ -31,18 +32,21 @@ public interface MySQLBackend {
     /**
      * Creates a database, given its name, if not exists.
      * @param dbName
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
-    void createDatabase(String dbName) throws Exception;
+    void createDatabase(String dbName) throws CygnusRuntimeError, CygnusPersistenceError;
     
     /**
      * Creates a table, given its name, if not exists in the given database.
      * @param dbName
      * @param tableName
      * @param fieldNames
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
-    void createTable(String dbName, String tableName, String fieldNames) throws Exception;
+    void createTable(String dbName, String tableName, String fieldNames)
+        throws CygnusRuntimeError, CygnusPersistenceError;
     
     /**
      * Insert already processed context data into the given table within the given database.
@@ -50,25 +54,28 @@ public interface MySQLBackend {
      * @param tableName
      * @param fieldNames
      * @param fieldValues
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusBadContextData
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
-    void insertContextData(String dbName, String tableName, String fieldNames, String fieldValues) throws Exception;
+    void insertContextData(String dbName, String tableName, String fieldNames, String fieldValues)
+        throws CygnusBadContextData, CygnusRuntimeError, CygnusPersistenceError;
     
     /**
      * Caps records from the given table within the given database according to the given maximum number.
      * @param dbName
      * @param tableName
      * @param maxRecords
-     * @throws CygnusRuntimeError
-     * @throws CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
     void capRecords(String dbName, String tableName, long maxRecords) throws CygnusRuntimeError, CygnusPersistenceError;
     
     /**
      * Expirates records within all the cached tables based on the expiration time.
      * @param expirationTime
-     * @throws CygnusRuntimeError
-     * @throws CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
     void expirateRecordsCache(long expirationTime) throws CygnusRuntimeError, CygnusPersistenceError;
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -73,13 +73,8 @@ public class MySQLBackendImpl implements MySQLBackend {
         return driver;
     } // getDriver
     
-    /**
-     * Creates a database, given its name, if not exists.
-     * @param dbName
-     * @throws Exception
-     */
     @Override
-    public void createDatabase(String dbName) throws Exception {
+    public void createDatabase(String dbName) throws CygnusRuntimeError, CygnusPersistenceError {
         if (cache.isCachedDb(dbName)) {
             LOGGER.debug("'" + dbName + "' is cached, thus it is not created");
             return;
@@ -92,16 +87,16 @@ public class MySQLBackendImpl implements MySQLBackend {
         
         try {
             stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
         } // try catch
         
         try {
             String query = "create database if not exists `" + dbName + "`";
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -110,15 +105,9 @@ public class MySQLBackendImpl implements MySQLBackend {
         cache.addDb(dbName);
     } // createDatabase
     
-    /**
-     * Creates a table, given its name, if not exists in the given database.
-     * @param dbName
-     * @param tableName
-     * @param typedFieldNames
-     * @throws Exception
-     */
     @Override
-    public void createTable(String dbName, String tableName, String typedFieldNames) throws Exception {
+    public void createTable(String dbName, String tableName, String typedFieldNames)
+        throws CygnusRuntimeError, CygnusPersistenceError {
         if (cache.isCachedTable(dbName, tableName)) {
             LOGGER.debug("'" + tableName + "' is cached, thus it is not created");
             return;
@@ -131,16 +120,16 @@ public class MySQLBackendImpl implements MySQLBackend {
         
         try {
             stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
         } // try catch
         
         try {
             String query = "create table if not exists `" + tableName + "` " + typedFieldNames;
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -151,7 +140,7 @@ public class MySQLBackendImpl implements MySQLBackend {
     
     @Override
     public void insertContextData(String dbName, String tableName, String fieldNames, String fieldValues)
-        throws Exception {
+        throws CygnusBadContextData, CygnusRuntimeError, CygnusPersistenceError {
         Statement stmt = null;
         
         // get a connection to the given database
@@ -159,8 +148,8 @@ public class MySQLBackendImpl implements MySQLBackend {
             
         try {
             stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
         } // try catch
         
         try {
@@ -168,9 +157,9 @@ public class MySQLBackendImpl implements MySQLBackend {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLTimeoutException e) {
-            throw new CygnusPersistenceError(e.getMessage());
+            throw new CygnusPersistenceError("SQLTimeoutException, " + e.getMessage());
         } catch (SQLException e) {
-            throw new CygnusBadContextData(e.getMessage());
+            throw new CygnusBadContextData("SQLException, " + e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -405,7 +394,7 @@ public class MySQLBackendImpl implements MySQLBackend {
          * @return
          * @throws CygnusPersistenceError
          */
-        public Connection getConnection(String dbName) throws CygnusPersistenceError {
+        public Connection getConnection(String dbName) throws CygnusRuntimeError, CygnusPersistenceError {
             try {
                 // FIXME: the number of cached connections should be limited to a certain number; with such a limit
                 //        number, if a new connection is needed, the oldest one is closed
@@ -422,7 +411,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
                 return con;
             } catch (ClassNotFoundException e) {
-                throw new CygnusPersistenceError("ClassNotFoundException, " + e.getMessage());
+                throw new CygnusRuntimeError("ClassNotFoundException, " + e.getMessage());
             } catch (SQLException e) {
                 throw new CygnusPersistenceError("SQLException, " + e.getMessage());
             } // try catch


### PR DESCRIPTION
* Partially implements issue #1358 (MySQL sink)
* (Unofficial) e2e tests passed:

Eveything goes well:

```
time=2017-01-26T17:01:10.216UTC | lvl=DEBUG | corr=5c66126e-d612-489a-9924-196f72a043d8 | trans=5c66126e-d612-489a-9924-196f72a043d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=insertContextData | msg=com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl[157] : Executing MySQL query 'insert into `gardens_Room1_Room` (recvTimeTs,recvTime,fiwareServicePath,entityId,entityType,attrName,attrType,attrValue,attrMd) values ('1485450062567','2017-01-26T17:01:02.567','/gardens','Room1','Room','temperature','centigrade','26.5','[]')'
time=2017-01-26T17:01:10.267UTC | lvl=INFO | corr=5c66126e-d612-489a-9924-196f72a043d8 | trans=5c66126e-d612-489a-9924-196f72a043d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[549] : Finishing internal transaction (5c66126e-d612-489a-9924-196f72a043d8)
```

Something goes wrong:

```
time=2017-01-26T16:58:02.104UTC | lvl=ERROR | corr=d751d535-dc7e-4d36-b8b4-a2a44ac37ad5 | trans=d751d535-dc7e-4d36-b8b4-a2a44ac37ad5 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=processRollbackedBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[392] : Persistence error. Message: SQLException, Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server., Stack trace: [com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver.getConnection(MySQLBackendImpl.java:416), com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl.createDatabase(MySQLBackendImpl.java:86), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistAggregation(NGSIMySQLSink.java:521), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistBatch(NGSIMySQLSink.java:199), com.telefonica.iot.cygnus.sinks.NGSISink.processRollbackedBatches(NGSISink.java:387), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:370), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:745)]
```