### PR TITLE
bug/1377_mongo_changes_error_string

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [cygnus][hardening] Fix "FIWARE" name in license headers (#1369)
 - [cygnus-common][hardening] Clean and modularize ManagementInterface.java (#1368)
 - [cygnus-common][feature] Add KPIs API (#1339)
+- [cygnus-common][bug] Fix error handling upon MongoDB collection creation (#1377)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -107,7 +107,7 @@ public class MongoBackendImpl implements MongoBackend {
         try {
             db.createCollection(collectionName);
         } catch (Exception e) {
-            if (e.getMessage().contains("collection already exists")) {
+            if (e.getMessage().contains("\"code\" : 48")) {
                 LOGGER.debug("Collection already exists, nothing to create");
             } else {
                 throw e;
@@ -155,7 +155,7 @@ public class MongoBackendImpl implements MongoBackend {
                 db.createCollection(collectionName);
             } // if else
         } catch (Exception e) {
-            if (e.getMessage().contains("collection already exists")) {
+            if (e.getMessage().contains("\"code\" : 48")) {
                 LOGGER.debug("Collection already exists, nothing to create");
             } else {
                 throw e;

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mongo_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mongo_sink.md
@@ -20,6 +20,7 @@ Content:
         * [About batching](#section2.3.1)
         * [About `recvTime` and `TimeInstant` metadata](#section2.3.2)
         * [About the encoding](#section2.3.3)
+        * [About supported versions of MongoDB](#section2.3.4)
 * [Programmers guide](#section3)
     * [`NGSIMongoSink` class](#section3.1)
     * [`NGSIMongoBackend` class](#section3.2)
@@ -381,6 +382,14 @@ From version 1.3.0 (included), Cygnus applies this specific encoding tailored to
 * `xffff` is used as concatenator character.
 
 Despite the old encoding will be deprecated in the future, it is possible to switch the encoding type through the `enable_encoding` parameter as explained in the [configuration](#section2.1) section.
+
+[Top](#top)
+
+####<a name="section2.3.4"></a>About supported versions of MongoDB
+This sink has been tested with the following versions of Mongo:
+
+* 3.2.6
+* 3.4
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md
@@ -18,6 +18,7 @@ Content:
         * [About batching](#section2.3.1)
         * [About `recvTime` and `TimeInstant` metadata](#section2.3.2)
         * [About the encoding](#section2.3.3)
+        * [Aboout supported versions of MongoDB](#section2.3.4)
 * [Implementation details](#section3)
     * [`NGSISTHSink` class](#section3.1)
     * [`MongoBackend` class](#section3.2)
@@ -379,6 +380,14 @@ From version 1.3.0 (included), Cygnus applies this specific encoding tailored to
 * `xffff` is used as concatenator character.
 
 Despite the old encoding will be deprecated in the future, it is possible to switch the encoding type through the `enable_encoding` parameter as explained in the [configuration](#section2.1) section.
+
+[Top](#top)
+
+####<a name="section2.3.4"></a>About supported versions of MongoDB
+This sink has been tested with the following versions of Mongo:
+
+* 3.2.6
+* 3.4
 
 [Top](#top)
 


### PR DESCRIPTION
* Fix issue #1377 
* (Unofficial) e2e tests passed:

Mongo 3.2.6:

```
time=2017-01-27T07:33:11.376UTC | lvl=DEBUG | corr=f09fd10d-0aec-40f6-9a43-8786d19472c0 | trans=f09fd10d-0aec-40f6-9a43-8786d19472c0 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=createCollection | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[154] : Creating Mongo collection=sth_/gardens_Room1_Room at database=sth_sc_valencia
time=2017-01-27T07:33:12.260UTC | lvl=DEBUG | corr=f09fd10d-0aec-40f6-9a43-8786d19472c0 | trans=f09fd10d-0aec-40f6-9a43-8786d19472c0 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=createCollection | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[159] : Collection already exists, nothing to create
```

Mongo 3.4:

```
time=2017-01-27T07:56:49.931Z | lvl=DEBUG | corr=692824a0-8b45-4ce1-8d71-5f4b8771649a | trans=692824a0-8b45-4ce1-8d71-5f4b8771649a | srv=homes | subsrv=/home5 | comp= | op=createCollection | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[155] : Creating Mongo collection=sth_/home5_contador5_smartMeter at database=sth_homes
time=2017-01-27T07:56:49.933Z | lvl=DEBUG | corr=692824a0-8b45-4ce1-8d71-5f4b8771649a | trans=692824a0-8b45-4ce1-8d71-5f4b8771649a | srv=homes | subsrv=/home5 | comp= | op=createCollection | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[160] : Collection already exists, nothing to create
```