### PR TITLE
bug/1389_remove_subservice_slash_metrics_api

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/metrics/CygnusMetrics.java
@@ -251,10 +251,10 @@ public class CygnusMetrics {
                 Metrics metrics = subserviceMetrics.get(subservice);
                 
                 if (firstSubservice) {
-                    json += "\"" + subservice + "\":" + metrics.toJsonString();
+                    json += "\"" + subservice.substring(1) + "\":" + metrics.toJsonString();
                     firstSubservice = false;
                 } else {
-                    json += ",\"" + subservice + "\":" + metrics.toJsonString();
+                    json += ",\"" + subservice.substring(1) + "\":" + metrics.toJsonString();
                 } // if else
             } // for
             
@@ -268,10 +268,10 @@ public class CygnusMetrics {
             Metrics metrics = perSubserviceAggrMetrics.get(subservice);
             
             if (firstSubservice) {
-                json += "\"" + subservice + "\":" + metrics.toJsonString();
+                json += "\"" + subservice.substring(1) + "\":" + metrics.toJsonString();
                 firstSubservice = false;
             } else {
-                json += ",\"" + subservice + "\":" + metrics.toJsonString();
+                json += ",\"" + subservice.substring(1) + "\":" + metrics.toJsonString();
             } // if else
         } // for
 
@@ -283,7 +283,7 @@ public class CygnusMetrics {
         
         return json;
     } // toJsonString
-    
+
     /**
      * Metrics class.
      */

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface_v1.md
@@ -966,10 +966,10 @@ Response:
     "services": {
         "service1": {
             "subservs": {
-                "/subservice1": {
+                "subservice1": {
                     <metrics for subservice1 within service1>
                 },
-                "/subservice1": {
+                "subservice1": {
                     <metrics for subservice2 within service1>
                 }
             },
@@ -979,10 +979,10 @@ Response:
         },
         "service2": {
             "subservs": {
-                "/subservice1": {
+                "subservice1": {
                     <metrics for subservice1 within service2>
                 },
-                "/subservice2": {
+                "subservice2": {
                     <metrics for subservice2 within service2>
                 }
             },
@@ -993,10 +993,10 @@ Response:
     },
     "sum": {
         "subservs": {
-            "/subservice1": {
+            "subservice1": {
                 <aggregated metrics for subservice1 within all the services>
             },
-            "/subservice2": {
+            "subservice2": {
                 <aggregated metrics for subservice2 within all the services>
             }
         },


### PR DESCRIPTION
* Fixes issue #1389 
* (Unofficial) e2e tests passed:
```
{
    "services": {
        "sc_valencia": {
            "subservs": {
                "gardens": {
                    "incomingTransactionErrors": 0,
                    "incomingTransactionRequestSize": 460,
                    "incomingTransactionResponseSize": 0,
                    "incomingTransactions": 1,
                    "outgoingTransactionErrors": 0,
                    "outgoingTransactionRequestSize": 0,
                    "outgoingTransactionResponseSize": 0,
                    "outgoingTransactions": 0,
                    "serviceTime": 0.0
                }
            },
            "sum": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "outgoingTransactionErrors": 0,
                "outgoingTransactionRequestSize": 0,
                "outgoingTransactionResponseSize": 0,
                "outgoingTransactions": 0,
                "serviceTime": 0.0
            }
        }
    },
    "sum": {
        "subservs": {
            "gardens": {
                "incomingTransactionErrors": 0,
                "incomingTransactionRequestSize": 460,
                "incomingTransactionResponseSize": 0,
                "incomingTransactions": 1,
                "outgoingTransactionErrors": 0,
                "outgoingTransactionRequestSize": 0,
                "outgoingTransactionResponseSize": 0,
                "outgoingTransactions": 0,
                "serviceTime": 0.0
            }
        },
        "sum": {
            "incomingTransactionErrors": 0,
            "incomingTransactionRequestSize": 460,
            "incomingTransactionResponseSize": 0,
            "incomingTransactions": 1,
            "outgoingTransactionErrors": 0,
            "outgoingTransactionRequestSize": 0,
            "outgoingTransactionResponseSize": 0,
            "outgoingTransactions": 0,
            "serviceTime": 0.0
        }
    }
```