### PR TITLE
docs: Erratum

### DIFF
--- a/cygnus-ngsi/README.md
+++ b/cygnus-ngsi/README.md
@@ -80,7 +80,7 @@ So, the starting point is choosing the internal architecture of the cygnus-ngsi 
 +-------------+    +----------------+    +---------------+
 ```
 
-Attending to the above architecture, the content of `/usr/cygnus/conf/cygnus_1.conf` will be:
+Attending to the above architecture, the content of `/usr/cygnus/conf/agent_1.conf` will be:
 
 ```
 cygnusagent.sources = http-source


### PR DESCRIPTION
I believe the intention was to name the configuration file as agent_1.conf rather than cygnus_1.conf, so respective cygnus_instance_1.conf content match with previous setup description.