### PR TITLE
hardening/1314_refactor_carto_historical_mode_names

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@
 - [cygnus-ngsi][feature] Add metadata storing in NGSIMongoSink (#1156)
 - [cygnus-ngsi][hardening] Set transaction and correlation IDs to 'N/A' when there is no activity (#1175)
 - [cygnus-ngsi][hardening] Pre-aggregate batches in NGSISTHSink (#1359)
+- [cygnus-ngsi][hardening] Change the name of historic-related enabling parameters (#1314)

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -22,6 +22,7 @@ import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextMetadata;
+import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.sinks.NGSICartoDBSink.CartoDBAggregator;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
@@ -73,17 +74,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null;
+        String enableDistanceHistoric = null;
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null;
+        String enableRawHistoric = null;
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertEquals(500, sink.getBackendMaxConns());
@@ -146,16 +147,6 @@ public class NGSICartoDBSinkTest {
         } // try catch
         
         try {
-            assertTrue(!sink.getEnableDistance());
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "-  OK  - 'enable_distance=false' configured by default");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
-                    + "- FAIL - 'enable_distance=false' not configured by default");
-            throw e;
-        } // try catch
-        
-        try {
             assertTrue(!sink.getEnableGrouping());
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                     + "-  OK  - 'enable_grouping=false' configured by default");
@@ -176,7 +167,7 @@ public class NGSICartoDBSinkTest {
         } // try catch
 
         try {
-            assertTrue(sink.getEnableRaw());
+            assertTrue(sink.getEnableRawHistoric());
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                     + "-  OK  - 'enable_raw=true' configured by default");
         } catch (AssertionError e) {
@@ -186,12 +177,22 @@ public class NGSICartoDBSinkTest {
         } // try catch
         
         try {
-            assertTrue(!sink.getEnableSnapshotRaw());
+            assertTrue(!sink.getEnableRawSnapshot());
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                     + "-  OK  - 'enable_raw_snapshot=false' configured by default");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                     + "- FAIL - 'enable_raw_snapshot=false' not configured by default");
+            throw e;
+        } // try catch
+        
+        try {
+            assertTrue(!sink.getEnableDistanceHistoric());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - 'enable_distance=false' configured by default");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - 'enable_distance=false' not configured by default");
             throw e;
         } // try catch
     } // testConfigureDefaults
@@ -210,17 +211,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null;
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertEquals(25, sink.getBackendMaxConns());
@@ -247,17 +248,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null;
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertEquals(3, sink.getBackendMaxConnsPerRoute());
@@ -285,17 +286,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = "false";
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -322,17 +323,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = "falso"; // wrong value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.enableLowercase);
@@ -346,10 +347,10 @@ public class NGSICartoDBSinkTest {
     } // testConfigureSwapCoordinatesOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured 'enable_raw' cannot be different than 'true' or 'false'.
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_raw_historic' cannot be different than 'true' or 'false'.
      */
     @Test
-    public void testConfigureEnableRawOK() {
+    public void testConfigureEnableRawHistoricOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'enable_raw' cannot be different than 'true' or 'false'");
         String apiKey = "1234567890abcdef";
@@ -359,17 +360,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = "falso"; // wrong value
+        String enableRawHistoric = "falso"; // wrong value
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -380,13 +381,14 @@ public class NGSICartoDBSinkTest {
                     + "- FAIL - 'enable_raw=falso' was not detected");
             throw e;
         } // try catch
-    } // testConfigureEnableRawOK
+    } // testConfigureEnableRawHistoricOK
     
     /**
-     * [NGSICartoDBSink.configure] -------- Configured 'enable_distance' cannot be different than 'true' or 'false'.
+     * [NGSICartoDBSink.configure] -------- Configured 'enable_distance_historic' cannot be different than 'true' or
+     * 'false'.
      */
     @Test
-    public void testConfigureEnableDistanceOK() {
+    public void testConfigureEnableDistanceHistoricOK() {
         System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
                 + "-------- Configured 'enable_distance' cannot be different than 'true' or 'false'");
         String apiKey = "1234567890abcdef";
@@ -396,17 +398,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = "falso"; // wrong value
+        String enableDistanceHistoric = "falso"; // wrong value
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -417,7 +419,7 @@ public class NGSICartoDBSinkTest {
                     + "- FAIL - 'enable_distance=falso' was not detected");
             throw e;
         } // try catch
-    } // testConfigureEnableDistanceOK
+    } // testConfigureEnableDistanceHistoricOK
     
     /**
      * [NGSICartoDBSink.configure] -------- Configured 'enable_raw_snapshot' cannot be different than 'true' or 'false'.
@@ -433,17 +435,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default value
+        String enableRawHistoric = null; // default value
         String enableRawSnapshot = "falso"; // wrong value
         String swapCoordinates = null; // default value
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -470,17 +472,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default_one
+        String enableDistanceHistoric = null; // default_one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = null; // empty file
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -522,17 +524,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -575,17 +577,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -629,17 +631,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -670,17 +672,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-service";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -695,8 +697,8 @@ public class NGSICartoDBSinkTest {
         dataModel = "dm-by-attribute";
         sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         try {
             assertTrue(sink.invalidConfiguration);
@@ -738,16 +740,16 @@ public class NGSICartoDBSinkTest {
         String batchTTL = null;
         String dataModel = null; // default one
         String enableLowercase = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -791,17 +793,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -847,16 +849,16 @@ public class NGSICartoDBSinkTest {
         String batchTTL = null;
         String dataModel = null; // default one
         String enableLowercase = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -900,17 +902,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -954,17 +956,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = file.getAbsolutePath();
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         sink.setChannel(new MemoryChannel());
         sink.start();
         
@@ -996,17 +998,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = null; // default one
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String service = "someService";
         
         try {
@@ -1022,7 +1024,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + builtSchemaName + "' is not equals to the encoding of <service>");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildSchemaName]")
                     + "- FAIL - There was some problem when building the schema name");
             throw e;
@@ -1046,17 +1048,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1074,7 +1076,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - There was some problem when building the table name");
             throw e;
@@ -1099,17 +1101,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/somePath";
         String entity = "someId=someType"; // using the internal concatenator
         String attribute = null; // irrelevant for this test
@@ -1128,7 +1130,7 @@ public class NGSICartoDBSinkTest {
                         + "x002f<servicePath>xffff<entityId>xffff<entityType>");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - There was some problem when building the table name");
             throw e;
@@ -1152,17 +1154,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1179,7 +1181,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + builtTableName + "' is not equals to x002f");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - There was some problem when building the table name");
             throw e;
@@ -1205,17 +1207,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/";
         String entity = "someId=someType";
         String attribute = null; // irrelevant for this test
@@ -1235,7 +1237,7 @@ public class NGSICartoDBSinkTest {
                         + "<service-path>, <entityId> and <entityType>");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - There was some problem when building the table name");
             throw e;
@@ -1260,17 +1262,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1306,7 +1308,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - A table name has not been created");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
                     + "- FAIL - There was some problem when initializing CartoDBAggregator");
             throw e;
@@ -1334,17 +1336,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1401,7 +1403,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + NGSIConstants.CARTO_DB_THE_GEOM + "' is not in the fields '" + fields + "'");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
                     + "- FAIL - There was some problem when initializing CartoDBAggregator");
             throw e;
@@ -1427,17 +1429,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1494,7 +1496,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + fields + "' does not end with ')'");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
                     + "- FAIL - There was some problem when initializing CartoDBAggregator");
             throw e;
@@ -1522,17 +1524,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1597,7 +1599,7 @@ public class NGSICartoDBSinkTest {
                         + rows + "'");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.initialize]")
                     + "- FAIL - There was some problem when initializing CartoDBAggregator");
             throw e;
@@ -1623,17 +1625,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default one
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1681,7 +1683,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + rows + "' does not end with ')'");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
                     + "- FAIL - There was some problem when aggregating in CartoDBAggregator");
             throw e;
@@ -1707,17 +1709,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default one
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = "true";
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         
         // Create a CartoDBAggregator
         CartoDBAggregator aggregator = sink.new CartoDBAggregator();
@@ -1755,7 +1757,7 @@ public class NGSICartoDBSinkTest {
                         + "- FAIL - '" + rows + "' done not contain the coordinates '-3.7167, 40.3833' swapped");
                 throw e;
             } // try catch
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             System.out.println(getTestTraceHead("[CartoDBAggregator.aggregate]")
                     + "- FAIL - There was some problem when aggregating in CartoDBAggregator");
             throw e;
@@ -1780,17 +1782,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-service-path";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
         String entity = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
@@ -1800,7 +1802,7 @@ public class NGSICartoDBSinkTest {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - A table name length greater than 63 characters has not been detected");
             assertTrue(false);
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "-  OK  - A table name length greater than 63 characters has been detected");
@@ -1824,17 +1826,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-entity";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/tooLoooooooooooooooooooooooooooongServicePath";
         String entity = "tooLoooooooooooooooooooooooooooongEntity";
         String attribute = null; // irrelevant for this test
@@ -1844,7 +1846,7 @@ public class NGSICartoDBSinkTest {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - A table name length greater than 63 characters has not been detected");
             assertTrue(false);
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "-  OK  - A table name length greater than 63 characters has been detected");
@@ -1869,17 +1871,17 @@ public class NGSICartoDBSinkTest {
         String batchTimeout = null;
         String batchTTL = null;
         String dataModel = "dm-by-attribute";
-        String enableDistance = null; // default one
+        String enableDistanceHistoric = null; // default one
         String enableGrouping = null;
         String enableLowercase = null; // default
-        String enableRaw = null; // default one
+        String enableRawHistoric = null; // default one
         String enableRawSnapshot = null; // defatul one
         String swapCoordinates = null; // default
         String keysConfFile = "/keys.conf";
         NGSICartoDBSink sink = new NGSICartoDBSink();
         sink.configure(createContext(apiKey, backendMaxConns, backendMaxConnsPerRoute, batchSize, batchTimeout,
-                batchTTL, dataModel, enableDistance, enableGrouping, enableLowercase, enableRaw, enableRawSnapshot,
-                swapCoordinates, keysConfFile));
+                batchTTL, dataModel, enableDistanceHistoric, enableGrouping, enableLowercase, enableRawHistoric,
+                enableRawSnapshot, swapCoordinates, keysConfFile));
         String servicePath = "/tooLooooooooooooooongServicePath";
         String entity = "tooLooooooooooooooooooongEntity";
         String attribute = "tooLooooooooooooongAttribute";
@@ -1889,16 +1891,131 @@ public class NGSICartoDBSinkTest {
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "- FAIL - A table name length greater than 63 characters has not been detected");
             assertTrue(false);
-        } catch (Exception e) {
+        } catch (CygnusBadConfiguration e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                     + "-  OK  - A table name length greater than 63 characters has been detected");
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
     
+    /**
+     * [NGSICartoDBSink.configure] -------- When enable_raw and enable_raw_historic are configured, the second one
+     * value is used. This must be removed once enable_raw parameter is removed (currently it is just deprecated).
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testConfigureEnableRawAndEnableRawHistoric() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- When enable_raw and enable_raw_historic are configured, the second one value is used");
+        // Create a NGSICartoDBSink
+        Context context = new Context();
+        context.put("enable_raw", "false");
+        context.put("enable_raw_historic", "true");
+        context.put("keys_conf_file", ""); // any value except for null
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(context);
+        
+        try {
+            assertTrue(sink.getEnableRawHistoric());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - Both 'enable_raw' and 'enable_raw_historic' where configured, but "
+                    + "'enable_raw_historic' value is used");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - Both 'enable_raw' and 'enable_raw_historic' where configured, but "
+                    + "'enable_raw' value is used");
+            throw e;
+        } // try catch
+    } // testConfigureEnableRawAndEnableRawHistoric
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- When enable_distance and enable_distance_historic are configured, the second
+     * one value is used. This must be removed once enable_raw parameter is removed (currently it is just deprecated).
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testConfigureEnableDistanceAndEnableDistanceHistoric() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- When enable_distance and enable_distance_historic are configured, the second one value "
+                + "is used");
+        // Create a NGSICartoDBSink
+        Context context = new Context();
+        context.put("enable_distance", "true");
+        context.put("enable_distance_historic", "false");
+        context.put("keys_conf_file", ""); // any value except for null
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(context);
+        
+        try {
+            assertTrue(!sink.getEnableDistanceHistoric());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - Both 'enable_distance' and 'enable_distance_historic' where configured, but "
+                    + "'enable_distance_historic' value is used");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - Both 'enable_distance' and 'enable_distnace_historic' where configured, but "
+                    + "'enable_distance' value is used");
+            throw e;
+        } // try catch
+    } // testConfigureEnableDistanceAndEnableDistanceHistoric
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Only enable_raw configuration works. This must be removed once
+     * enable_raw parameter is removed (currently it is just deprecated).
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testConfigureEnableRawOnly() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Only enable_raw configuration works");
+        // Create a NGSICartoDBSink
+        Context context = new Context();
+        context.put("enable_raw", "false");
+        context.put("keys_conf_file", ""); // any value except for null
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(context);
+        
+        try {
+            assertTrue(!sink.getEnableRawHistoric());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - Only 'enable_raw' was configured and worked");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - Only 'enable_raw' was configured and did not work");
+            throw e;
+        } // try catch
+    } // testConfigureEnableRawOnly
+    
+    /**
+     * [NGSICartoDBSink.configure] -------- Only enable_distance configuration works. This must be removed
+     * once enable_raw parameter is removed (currently it is just deprecated).
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testConfigureEnableDistanceOnly() throws Exception {
+        System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                + "-------- Only enable_distance configuration works");
+        // Create a NGSICartoDBSink
+        Context context = new Context();
+        context.put("enable_distance", "true");
+        context.put("keys_conf_file", ""); // any value except for null
+        NGSICartoDBSink sink = new NGSICartoDBSink();
+        sink.configure(context);
+        
+        try {
+            assertTrue(sink.getEnableDistanceHistoric());
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "-  OK  - Only 'enable_distance' was configured and worked");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSICartoDBSink.configure]")
+                    + "- FAIL - Only 'enable_distance' was configured and did not work");
+            throw e;
+        } // try catch
+    } // testConfigureEnableDistanceOnly
+    
     private Context createContext(String apiKey, String backendMaxConns, String backendMaxConnsPerRoute,
-            String batchSize, String batchTimeout, String batchTTL, String dataModel, String enableDistance,
-            String enableGrouping, String enableLowercase, String enableRaw, String enableRawSnapshot,
+            String batchSize, String batchTimeout, String batchTTL, String dataModel, String enableDistanceHistoric,
+            String enableGrouping, String enableLowercase, String enableRawHistoric, String enableRawSnapshot,
             String swapCoordinates, String keysConfFile) {
         Context context = new Context();
         context.put("api_key", apiKey);
@@ -1908,10 +2025,10 @@ public class NGSICartoDBSinkTest {
         context.put("batch_timeout", batchTimeout);
         context.put("batch_ttl", batchTTL);
         context.put("data_model", dataModel);
-        context.put("enable_distance", enableDistance);
+        context.put("enable_distance_historic", enableDistanceHistoric);
         context.put("enable_grouping", enableGrouping);
         context.put("enable_lowercase", enableLowercase);
-        context.put("enable_raw", enableRaw);
+        context.put("enable_raw_historic", enableRawHistoric);
         context.put("enable_raw_snapshot", enableRawSnapshot);
         context.put("swap_coordinates", swapCoordinates);
         context.put("keys_conf_file", keysConfFile);
@@ -1924,7 +2041,7 @@ public class NGSICartoDBSinkTest {
         contextMetadata.setName("location");
         contextMetadata.setType("string");
         contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
-        ArrayList<ContextMetadata> metadata = new ArrayList<ContextMetadata>();
+        ArrayList<ContextMetadata> metadata = new ArrayList<>();
         metadata.add(contextMetadata);
         ContextAttribute contextAttribute1 = notifyContextRequest.new ContextAttribute();
         contextAttribute1.setName("someName1");

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink.md
@@ -84,7 +84,7 @@ The following table summarizes the table name composition:
 | `/` | `x002f` | `x002fxffff<entityId>xffff<entityType>[xffffdistance]` |
 | `/<svcPath>` | `x002fxffff<svcPath>[xffffdistance|xffffrawsnapshot]` | `x002fxffff<svcPath>xffff<entityId>xffff<entityType>[xffffdistance]` |
 
-Please observe the concatenation of entity ID and type is already given in the `notified_entities`/`grouped_entities` header values (depending on using or not the grouping rules, see the [Configuration](#section2.1) section for more details) within the `NGSIEvent`. 
+Please observe the concatenation of entity ID and type is already given in the `notified_entities`/`grouped_entities` header values (depending on using or not the grouping rules, see the [Configuration](#section2.1) section for more details) within the `NGSIEvent`.
 
 [Top](#top)
 
@@ -201,8 +201,8 @@ The PostgreSQL table names will be, depending on the configured data model and a
 
 [Top](#top)
 
-#### <a name="section1.3.3"></a>Raw-based storing
-Let's assume a table name `x002f4wheelsxffffcar1xffffcar` (data model by entity, non-root service path, only raw analysis mode). The data stored within this table would be:
+#### <a name="section1.3.3"></a>Raw historic-based storing
+Let's assume a table name `x002f4wheelsxffffcar1xffffcar` (data model by entity, non-root service path, only raw historic analysis mode). The data stored within this table would be:
 
 ```
 curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsxffffcar1xffffcar&api_key=abcdef0123456789"
@@ -264,8 +264,8 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsxfff
 
 [Top](#top)
 
-#### <a name="section1.3.4"></a>Distance-based storing
-Let's assume a table name `x002f4wheelsxffffcar1xffffcarxffffdistance` (data model by entity, non-root service path, only distance analysis mode) with a previous insertion (on the contrary, this would be the first insertion and almost all the aggregated values will be set to 0). The data stored within this table would be:
+#### <a name="section1.3.4"></a>Distance historic-based storing
+Let's assume a table name `x002f4wheelsxffffcar1xffffcarxffffdistance` (data model by entity, non-root service path, only distance historic analysis mode) with a previous insertion (on the contrary, this would be the first insertion and almost all the aggregated values will be set to 0). The data stored within this table would be:
 
 ```
 curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsxffffcar1xffffcarxffffdistance&api_key=abcdef0123456789"
@@ -401,7 +401,7 @@ curl "https://myusername.cartodb.com/api/v2/sql?q=select * from x002f4wheelsxfff
 [Top](#top)
 
 #### <a name="section1.3.5"></a>Raw snapshot-based storing
-Everything equals to the raw-based storing, but:
+Everything equals to the raw historic-based storing, but:
 
 * The table name is `x002f4wheelsxffffcar1xffffcarxffffrawsnapshot`.
 * The data is inserted if the given FIWARE service path, entity ID and entity type are not present in the table; used for update otherwise.
@@ -423,8 +423,10 @@ Everything equals to the raw-based storing, but:
 | keys\_conf\_file | yes | N/A | Absolute path to the CartoDB file containing the mapping between FIWARE service/Carto usernames, endpoints, API Keys and account types. |
 | swap\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. |
 | flip\_coordinates | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, the latitude and longitude values are exchanged. **Deprecated from release 1.6.0 in favour of `swap_coordinates`**. |
-| enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw based storage is done. |
-| enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance based storage is done. |
+| enable\_raw\_historic | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw hiatoric-based storage is done. |
+| enable\_raw | no | true | <i>true</i> or <i>false</i>. If <i>true</i>, a raw-based storage is done. **Deprecated from release 1.8.0 in favour of `enable_raw_historic`**. |
+| enable\_distance\_historic | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance historic-based storage is done. |
+| enable\_distance | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a distance-based storage is done. **Deprecated from release 1.8.0 in favour of `enable_distance_historic`**. |
 | enable\_raw\_snapshot | no | false | <i>true</i> or <i>false</i>. If <i>true</i>, a raw snapshot based storage is done. |
 | batch\_size | no | 1 | Number of events accumulated before persistence. |
 | batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
@@ -446,8 +448,8 @@ cygnus-ngsi.sinks.cartodb-sink.enable_name_mappings = false
 cygnus-ngsi.sinks.cartodb-sink.enable_lowercase = false
 cygnus-ngsi.sinks.cartodb-sink.keys_conf_file = /usr/cygnus/conf/cartodb_keys.conf
 cygnus-ngsi.sinks.cartodb-sink.swap_coordinates = true
-cygnus-ngsi.sinks.cartodb-sink.enable_raw = true
-cygnus-ngsi.sinks.cartodb-sink.enable_distance = false
+cygnus-ngsi.sinks.cartodb-sink.enable_raw_historic = true
+cygnus-ngsi.sinks.cartodb-sink.enable_distance_historic = false
 cygnus-ngsi.sinks.cartodb-sink.enable_raw_snapshot = false
 cygnus-ngsi.sinks.cartodb-sink.data_model = dm-by-entity
 cygnus-ngsi.sinks.cartodb-sink.batch_size = 10

--- a/doc/cygnus-ngsi/installation_and_administration_guide/deprecated_and_removed.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/deprecated_and_removed.md
@@ -12,6 +12,8 @@ Content:
     * [Data model by attribute in `NGSICartoDBSink`](#section3.4)
     * [`matching_table` parameter](#section3.5)
     * [Hash-based collection names in MongoDB/STH](#section3.6)
+    * [`enable_raw` Carto parameter](#section3.7)
+    * [`enable_distance` Carto parameter](#section3.8)
 
 ## <a name="section1"></a>Functionality deprecation and remove policy
 At Cygnus NGSI agent (cygnus-ngsi), functionality lifecycle is:
@@ -19,12 +21,12 @@ At Cygnus NGSI agent (cygnus-ngsi), functionality lifecycle is:
 1. New feature is designed.
 2. New feature is implemented and released.
 3. Existent feature is fixed, when required.
-4. Existent feature is deprecated if a new feature encloses it or becomes unnecesary.
+4. Existent feature is deprecated if a new feature encloses it or becomes unnecessary.
 5. Existent feature is definitely removed after certain period of time.
 
 While a feature is deprecated, it is still available at cygnus-ngsi, i.e. it can be used and it is documented. Nevertheless, it is no longer supported nor fixed nor improved. A disclaimer is added in the documentation, and optionally, in the logs.
 
-Deprecated features are removed not before 3 developement sprints (usually, a development sprint comprises one month).
+Deprecated features are removed not before 3 development sprints (usually, a development sprint comprises one month).
 
 **This policy will be effective from release 1.6.0 (included)**. Before that, this policy has been implemented <i>de facto</i> with more or less success.
 
@@ -51,14 +53,14 @@ Added at version [0.1](https://github.com/telefonicaid/fiware-cygnus/releases/ta
 
 Never deprecated.
 
-Removed in favour of `batch_ttl` parameter after releasing version [0.13.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/0.13.0) (issue [714](https://github.com/telefonicaid/fiware-cygnus/issues/714)).
+Removed in favor of `batch_ttl` parameter after releasing version [0.13.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/0.13.0) (issue [714](https://github.com/telefonicaid/fiware-cygnus/issues/714)).
 
 [Top](#top)
 
 ### <a name="section3.2"></a>XML notifications support
 Added at version [0.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.1).
 
-Deprecated in favour of Json notifications from the very begining of the development.
+Deprecated in favor of Json notifications from the very beginning of the development.
 
 Removed after releasing version [0.13.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.0.0) (issue [448](https://github.com/telefonicaid/fiware-cygnus/issues/448)).
 
@@ -67,7 +69,7 @@ Removed after releasing version [0.13.0](https://github.com/telefonicaid/fiware-
 ### <a name="section3.3"></a>`cosmos_`-like HDFS parameters
 Added at version [0.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.1).
 
-Deprecated in favour of `hdfs_`-like parameters after releasing version [0.8.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.8.1) (issue [374](https://github.com/telefonicaid/fiware-cygnus/issues/374)).
+Deprecated in favor of `hdfs_`-like parameters after releasing version [0.8.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.8.1) (issue [374](https://github.com/telefonicaid/fiware-cygnus/issues/374)).
 
 Removed after releasing version [1.0.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.0.0) (issue [868](https://github.com/telefonicaid/fiware-cygnus/issues/868)).
 
@@ -85,9 +87,9 @@ Removed after releasing version [1.1.0](https://github.com/telefonicaid/fiware-c
 ### <a name="section3.5"></a>`matching_table` parameter
 Added at version [0.5](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.5) (issue [https://github.com/telefonicaid/fiware-cygnus/issues/107](107)).
 
-Deprecated in favour of `grouping_rules_conf_file` after releasing version [0.8.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.8.1) (issue [https://github.com/telefonicaid/fiware-cygnus/issues/387](387)).
+Deprecated in favor of `grouping_rules_conf_file` after releasing version [0.8.1](https://github.com/telefonicaid/fiware-cygnus/releases/tag/release-0.8.1) (issue [https://github.com/telefonicaid/fiware-cygnus/issues/387](387)).
 
-Removed after releaseing version [1.1.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.1.0) (issue [1048](https://github.com/telefonicaid/fiware-cygnus/issues/1048)).
+Removed after releasing version [1.1.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.1.0) (issue [1048](https://github.com/telefonicaid/fiware-cygnus/issues/1048)).
 
 [Top](#top)
 
@@ -97,5 +99,19 @@ Added at version [0.8.1](https://github.com/telefonicaid/fiware-cygnus/releases/
 Never deprecated.
 
 Removed after releasing version [1.4.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.4.0) (issue [1113](https://github.com/telefonicaid/fiware-cygnus/issues/1113)).
+
+[Top](#top)
+
+### <a name="section3.7"></a>`enable_raw` Carto parameter
+Added at version [1.0.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.0.0).
+
+Deprecated in favor of `enable_raw_historic` parameters after releasing version [1.8.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.8.0) (issue [1314](https://github.com/telefonicaid/fiware-cygnus/issues/1314)).
+
+[Top](#top)
+
+### <a name="section3.8"></a>`enable_distance` Carto parameter
+Added at version [1.1.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.1.0).
+
+Deprecated in favor of `enable_distance_historic` parameters after releasing version [1.8.0](https://github.com/telefonicaid/fiware-cygnus/releases/tag/1.8.0) (issue [1314](https://github.com/telefonicaid/fiware-cygnus/issues/1314)).
 
 [Top](#top)


### PR DESCRIPTION
* Implements issue #1314 
* Relevant unit tests:
```
[NGSICartoDBSink.configure] ----------------------------------------- Only enable_raw configuration works
[NGSICartoDBSink.configure] ----------------------------------  OK  - Only 'enable_raw' was configured and worked
[NGSICartoDBSink.configure] ----------------------------------------- Only enable_distance configuration works
[NGSICartoDBSink.configure] ----------------------------------  OK  - Only 'enable_distance' was configured and worked
[NGSICartoDBSink.configure] ----------------------------------------- When enable_raw and enable_raw_historic are configured, the second one value is used
[NGSICartoDBSink.configure] ----------------------------------  OK  - Both 'enable_raw' and 'enable_raw_historic' where configured, but 'enable_raw_historic' value is used
[NGSICartoDBSink.configure] ----------------------------------------- When enable_distance and enable_distance_historic are configured, the second one value is used
[NGSICartoDBSink.configure] ----------------------------------  OK  - Both 'enable_distance' and 'enable_distance_historic' where configured, but 'enable_distance_historic' value is used
```