### PR TITLE
bug/1419_add_support_for_file_channels

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - [cygnus-ngsi][hardening] Pre-aggregate batches in NGSISTHSink (#1359)
 - [cygnus-ngsi][hardening] Change the name of historic-related enabling parameters (#1314)
 - [cygnus-ngsi][bug] Fix NotifyContextRequest.ContextAttribute.toString(), removing double quote for attribute values (#1430)
+- [cygnus-ngsi][bug] Add support for file channels (#1419)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -364,7 +364,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
                     // Headers
                     headers, 
                     // Bytes version of the notified ContextElement
-                    (cer.getContextElement().toString() + "|").getBytes(), 
+                    (cer.getContextElement().toString() + CommonConstants.CONCATENATOR).getBytes(), 
                     // Object version of the notified ContextElement
                     cer.getContextElement(),
                     // Will be set with the mapped object version of the notified ContextElement, by

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -359,8 +359,18 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             LOGGER.debug("[NGSIRestHandler] Header added to NGSI event ("
                     + NGSIConstants.FLUME_HEADER_TRANSACTION_ID + ": " + transId + ")");
             
-            // Create the NGSIEvent and add it to the list
-            NGSIEvent ngsiEvent = new NGSIEvent(headers, cer.toString().getBytes(), cer.getContextElement(), null);
+            // Create the NGSI event and add it to the list
+            NGSIEvent ngsiEvent = new NGSIEvent(
+                    // Headers
+                    headers, 
+                    // Bytes version of the notified ContextElement
+                    (cer.getContextElement().toString() + "|").getBytes(), 
+                    // Object version of the notified ContextElement
+                    cer.getContextElement(),
+                    // Will be set with the mapped object version of the notified ContextElement, by
+                    // NGSINameMappingsInterceptor (if configured). Currently, null
+                    null 
+            );
             ngsiEvents.add(ngsiEvent);
             
             if (ids.isEmpty()) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSIEvent.java
@@ -32,7 +32,7 @@ import org.apache.flume.Event;
 public class NGSIEvent implements Event {
     
     private Map<String, String> headers;
-    private final byte[] body;
+    private byte[] body;
     private ContextElement originalCE;
     private ContextElement mappedCE;
     
@@ -66,7 +66,8 @@ public class NGSIEvent implements Event {
     } // getBody
 
     @Override
-    public void setBody(byte[] bytes) {
+    public void setBody(byte[] body) {
+        this.body = body;
     } // setBody
     
     public ContextElement getOriginalCE() {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -101,6 +101,15 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         // Add the mapped ContextElement to the NGSIEvent
         ngsiEvent.setMappedCE(map.getRight());
         
+        // Add the bytes version of the mapped ContextElement to event's body
+        byte[] originalCEBytes = ngsiEvent.getBody();
+        byte[] mappedCEBytes = map.getRight().toString().getBytes();
+        byte[] newBody = new byte[originalCEBytes.length + mappedCEBytes.length];
+        System.arraycopy(originalCEBytes, 0, newBody, 0, originalCEBytes.length);
+        System.arraycopy(mappedCEBytes, 0, newBody, originalCEBytes.length, mappedCEBytes.length);
+        ngsiEvent.setBody(newBody);
+        LOGGER.debug("[nmi] New body: " + new String(newBody));
+        
         // Add the mapped service and service path to the headers
         headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE, map.getLeft());
         LOGGER.debug("[nmi] Header added to NGSI event ("

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -512,7 +512,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 ngsiEvent = (NGSIEvent)event;
             } else {
                 // Event comes from file... original and mapped context elements must be re-created
-                String[] contextElementsStr = (new String(event.getBody())).split("\\|");
+                String[] contextElementsStr = (new String(event.getBody())).split(CommonConstants.CONCATENATOR);
                 Gson gson = new Gson();
                 ContextElement originalCE = null;
                 ContextElement mappedCE = null;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -18,6 +18,7 @@
 
 package com.telefonica.iot.cygnus.sinks;
 
+import com.google.gson.Gson;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextAttribute;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElement;
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
@@ -41,6 +42,7 @@ import java.util.Arrays;
 import java.util.Date;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
+import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Sink.Status;
 import org.apache.flume.Transaction;
@@ -489,9 +491,9 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 break;
             } // if
 
-            // Get an getRecvTimeTs
-            NGSIEvent event = (NGSIEvent) ch.take();
-
+            // Get an event
+            Event event = ch.take();
+            
             // Check if the event is null
             if (event == null) {
                 accumulator.setAccIndex(currentIndex);
@@ -501,19 +503,46 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 //setMDCToNA();
                 return Status.BACKOFF; // Slow down the sink since no events are available
             } // if
+            
+            // Cast the event to a NGSI event
+            NGSIEvent ngsiEvent;
+            
+            if (event instanceof NGSIEvent) {
+                // Event comes from memory... everything is already in memory
+                ngsiEvent = (NGSIEvent)event;
+            } else {
+                // Event comes from file... original and mapped context elements must be re-created
+                String[] contextElementsStr = (new String(event.getBody())).split("\\|");
+                Gson gson = new Gson();
+                ContextElement originalCE = null;
+                ContextElement mappedCE = null;
+                
+                if (contextElementsStr.length == 1) {
+                    originalCE = gson.fromJson(contextElementsStr[0], ContextElement.class);
+                } else if (contextElementsStr.length == 2) {
+                    originalCE = gson.fromJson(contextElementsStr[0], ContextElement.class);
+                    mappedCE = gson.fromJson(contextElementsStr[1], ContextElement.class);
+                } // if else
+                
+                // Re-create the NGSI event
+                ngsiEvent = new NGSIEvent(event.getHeaders(), event.getBody(), originalCE, mappedCE);
+                LOGGER.debug("Re-creating NGSI event from raw bytes in file channel, original context element: "
+                        + (originalCE == null ? null : originalCE.toString()) + ", mapped context element: "
+                        + (mappedCE == null ? null : mappedCE.toString()));
+            } // if else
 
             // Set the correlation ID, transaction ID, service and service path in MDC
             MDC.put(CommonConstants.LOG4J_CORR,
-                    event.getHeaders().get(CommonConstants.HEADER_CORRELATOR_ID));
+                    ngsiEvent.getHeaders().get(CommonConstants.HEADER_CORRELATOR_ID));
             MDC.put(CommonConstants.LOG4J_TRANS,
-                    event.getHeaders().get(NGSIConstants.FLUME_HEADER_TRANSACTION_ID));
+                    ngsiEvent.getHeaders().get(NGSIConstants.FLUME_HEADER_TRANSACTION_ID));
             MDC.put(CommonConstants.LOG4J_SVC,
-                    event.getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE));
+                    ngsiEvent.getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE));
             MDC.put(CommonConstants.LOG4J_SUBSVC,
-                    event.getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE_PATH));
+                    ngsiEvent.getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE_PATH));
 
             // Accumulate the event
-            accumulator.accumulate(event);
+            accumulator.accumulate(ngsiEvent);
             numProcessedEvents++;
         } // for
 

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
@@ -628,7 +628,7 @@ public class NGSIEventTest {
         ContextElement originalCE = null; // irrelevant for this test
         ContextElement mappedCE = null; // irrelevant for this test
         NGSIEvent event = new NGSIEvent(headers, body, originalCE, mappedCE);
-        event.setBody((originalCEStr + "|" + mappedCEStr).getBytes());
+        event.setBody((originalCEStr + CommonConstants.CONCATENATOR + mappedCEStr).getBytes());
         
         try {
             Assert.assertArrayEquals((originalCEStr + "|" + mappedCEStr).getBytes(), event.getBody());

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
@@ -631,7 +631,8 @@ public class NGSIEventTest {
         event.setBody((originalCEStr + CommonConstants.CONCATENATOR + mappedCEStr).getBytes());
         
         try {
-            Assert.assertArrayEquals((originalCEStr + "|" + mappedCEStr).getBytes(), event.getBody());
+            Assert.assertArrayEquals((originalCEStr + CommonConstants.CONCATENATOR + mappedCEStr).getBytes(),
+                    event.getBody());
             System.out.println(getTestTraceHead("[NGSIEvent.setBody]")
                     + "-  OK  - Bytes regarding the original context element have been returned");
         } catch (AssertionError e) {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSIEventTest.java
@@ -599,21 +599,10 @@ public class NGSIEventTest {
     public void testGetBody() {
         System.out.println(getTestTraceHead("[NGSIEvent.getBody]")
                 + "-------- Bytes regarding the original context element are returned");
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put(NGSIConstants.FLUME_HEADER_TIMESTAMP, timestamp);
+        HashMap<String, String> headers = null; // irrelevant for this test
         byte[] body = originalCEStr.getBytes();
-        ContextElement originalCE;
-        ContextElement mappedCE;
-        
-        try {
-            originalCE = TestUtils.createJsonContextElement(originalCEStr);
-            mappedCE = TestUtils.createJsonContextElement(mappedCEStr);
-        } catch (Exception e) {
-            System.out.println(getTestTraceHead("[NGSIEvent.getBody]")
-                    + "- FAIL - There was some problem when setting up the test");
-            throw new AssertionError(e.getMessage());
-        } // try catch
-        
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
         NGSIEvent event = new NGSIEvent(headers, body, originalCE, mappedCE);
         
         try {
@@ -626,5 +615,30 @@ public class NGSIEventTest {
             throw e;
         } // try catch
     } // testGetBody
+    
+    /**
+     * [NGSIEvent.setBody] -------- Bytes are correctly set.
+     */
+    @Test
+    public void testSetBody() {
+        System.out.println(getTestTraceHead("[NGSIEvent.setBody]")
+                + "-------- Bytes are correctly set");
+        HashMap<String, String> headers = null; // irrelevant for this test
+        byte[] body = originalCEStr.getBytes();
+        ContextElement originalCE = null; // irrelevant for this test
+        ContextElement mappedCE = null; // irrelevant for this test
+        NGSIEvent event = new NGSIEvent(headers, body, originalCE, mappedCE);
+        event.setBody((originalCEStr + "|" + mappedCEStr).getBytes());
+        
+        try {
+            Assert.assertArrayEquals((originalCEStr + "|" + mappedCEStr).getBytes(), event.getBody());
+            System.out.println(getTestTraceHead("[NGSIEvent.setBody]")
+                    + "-  OK  - Bytes regarding the original context element have been returned");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIEvent.setBody]")
+                    + "- FAIL - Bytes regarding the original context element have not been returned");
+            throw e;
+        } // try catch
+    } // testSetBody
     
 } // NGSIEventTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
@@ -315,7 +315,7 @@ public class NGSINameMappingsInterceptorTest {
         NGSIEvent interceptedEvent = (NGSIEvent) nameMappingsInterceptor.intercept(originalEvent);
 
         try {
-            String[] contextElementsStr = new String(interceptedEvent.getBody()).split("\\|");
+            String[] contextElementsStr = new String(interceptedEvent.getBody()).split(CommonConstants.CONCATENATOR);
             assertTrue(contextElementsStr[0] != null && !contextElementsStr[0].isEmpty());
             assertTrue(contextElementsStr[1] != null && !contextElementsStr[1].isEmpty());
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptorTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.flume.Context;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
@@ -249,14 +250,14 @@ public class NGSINameMappingsInterceptorTest {
     } // testGetEventsHeadersInNGSIFlumeEvent
     
     /**
-     * [NGSIGroupingInterceptor.getEvents] -------- When a NGSI getRecvTimeTs is put in the channel, it contains
-     * the original ContextElement and the mapped one.
+     * [NGSIGroupingInterceptor.getEvents] -------- When a NGSI event is put in the channel, it contains
+     * the original ContextElement and the mapped one as objects.
      */
     @Test
-    public void testGetNCRsInNGSIEvent() {
+    public void testGetContextElementsInNGSIEvent() {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
-                + "-------- When a Flume event is put in the channel, it contains the original ContextElement "
-                + "and the mapped one");
+                + "-------- When a NGSI event is put in the channel, it contains the original ContextElement "
+                + "and the mapped one as objects");
         NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
         nameMappingsInterceptor.loadNameMappings(nameMappingsStr);
         NGSIEvent originalEvent;
@@ -273,31 +274,66 @@ public class NGSINameMappingsInterceptorTest {
         try {
             assertTrue(interceptedEvent.getMappedCE() != null);
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
-                    + "-  OK  - The generated NGSI event contains the original ContextElement");
+                    + "-  OK  - The generated NGSI event contains the original ContextElement as object");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
-                    + "- FAIL - The generated NGSI event does not contain the original ContextElement");
+                    + "- FAIL - The generated NGSI event does not contain the original ContextElement as object");
             throw e;
         } // try catch
         
         try {
             assertTrue(interceptedEvent.getOriginalCE() != null);
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
-                    + "-  OK  - The generated NGSI event contains the mapped ContextElement");
+                    + "-  OK  - The generated NGSI event contains the mapped ContextElement as object");
         } catch (AssertionError e) {
             System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
-                    + "- FAIL - The generated NGSI event does not contain the mapped ContextElement");
+                    + "- FAIL - The generated NGSI event does not contain the mapped ContextElement as object");
             throw e;
         } // try catch
-    } // testGetNCRsInNGSIEvent
+    } // testGetContextElementsInNGSIEvent
     
     /**
-     * [NGSIGroupingInterceptor.doMap] -------- A mapped NotifyContextRequest can be obtained from the Name Mappings.
+     * [NGSIGroupingInterceptor.getEvents] -------- When a NGSI event is put in the channel, it contains
+     * the original ContextElement and the mapped one as bytes in the body.
+     */
+    @Test
+    public void testGetBodyInNGSIEvent() {
+        System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
+                + "-------- When a NGSI event is put in the channel, it contains the original ContextElement and "
+                + "the mapped one as bytes in the body");
+        NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
+        nameMappingsInterceptor.loadNameMappings(nameMappingsStr);
+        NGSIEvent originalEvent;
+        
+        try {
+            originalEvent = TestUtils.createNGSIEvent(originalCEStr, null, originalService, originalServicePath,
+                    "12345");
+        } catch (Exception e) {
+            throw new AssertionError(e.getMessage());
+        } // try catch
+        
+        NGSIEvent interceptedEvent = (NGSIEvent) nameMappingsInterceptor.intercept(originalEvent);
+
+        try {
+            String[] contextElementsStr = new String(interceptedEvent.getBody()).split("\\|");
+            assertTrue(contextElementsStr[0] != null && !contextElementsStr[0].isEmpty());
+            assertTrue(contextElementsStr[1] != null && !contextElementsStr[1].isEmpty());
+            System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
+                    + "-  OK  - The generated NGSI event contains the original ContextElement as bytes");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.intercept]")
+                    + "- FAIL - The generated NGSI event does not contain the original ContextElement as bytes");
+            throw e;
+        } // try catch
+    } // testGetBodyInNGSIEvent
+    
+    /**
+     * [NGSIGroupingInterceptor.doMap] -------- A mapped ContextElement can be obtained from the Name Mappings.
      */
     @Test
     public void testDoMap() {
         System.out.println(getTestTraceHead("[NGSIGroupingInterceptor.doMap]")
-                + "-------- A mapped NotifyContextRequest can be obtained from the Name Mappings");
+                + "-------- A mapped ContextElement can be obtained from the Name Mappings");
         NGSINameMappingsInterceptor nameMappingsInterceptor = new NGSINameMappingsInterceptor(null, false);
         nameMappingsInterceptor.loadNameMappings(nameMappingsStr);
         ContextElement originalCE;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
@@ -101,8 +101,7 @@ public final class TestUtils {
         headers.put(NGSIConstants.FLUME_HEADER_TRANSACTION_ID, correlatorID);
         ContextElement originalCE = createJsonContextElement(originalCEStr);
         ContextElement mappedCE = createJsonContextElement(mappedCEStr);
-        return new NGSIEvent(headers, (originalCE == null ? null : originalCE.toString().getBytes()),
-                originalCE, mappedCE);
+        return new NGSIEvent(headers, (originalCEStr + "|").getBytes(), originalCE, mappedCE);
     } // createNGSIEvent
     
     /**

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/TestUtils.java
@@ -101,7 +101,7 @@ public final class TestUtils {
         headers.put(NGSIConstants.FLUME_HEADER_TRANSACTION_ID, correlatorID);
         ContextElement originalCE = createJsonContextElement(originalCEStr);
         ContextElement mappedCE = createJsonContextElement(mappedCEStr);
-        return new NGSIEvent(headers, (originalCEStr + "|").getBytes(), originalCE, mappedCE);
+        return new NGSIEvent(headers, (originalCEStr + CommonConstants.CONCATENATOR).getBytes(), originalCE, mappedCE);
     } // createNGSIEvent
     
     /**


### PR DESCRIPTION
* Fixes issue #1419 
* Relevant unit tests:
```
[NGSIGroupingInterceptor.intercept] --------------------------------- When a NGSI event is put in the channel, it contains the original ContextElement and the mapped one as bytes in the body
[NGSIGroupingInterceptor.intercept] --------------------------  OK  - The generated NGSI event contains the original ContextElement as bytes
[NGSIEvent.setBody] ------------------------------------------------- Bytes are correctly set
[NGSIEvent.setBody] ------------------------------------------  OK  - Bytes regarding the original context element have been returned
```
* (unofficial) e2e tests passed:

Name mappings enabled, memory channel:
```
time=2017-04-19T15:15:01.680UTC | lvl=INFO | corr=f649d45e-b0f8-4c94-89e4-733f30e629d8 | trans=f649d45e-b0f8-4c94-89e4-733f30e629d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614870110,Room1,Room,pressure,pascal,[78.1,78.1,78.1,6099.609999999999,1]
time=2017-04-19T15:15:01.984UTC | lvl=INFO | corr=f649d45e-b0f8-4c94-89e4-733f30e629d8 | trans=f649d45e-b0f8-4c94-89e4-733f30e629d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614870110,Room1,Room,temperature,centigrade,[26.5,26.5,26.5,702.25,1]
time=2017-04-19T15:15:02.147UTC | lvl=INFO | corr=f649d45e-b0f8-4c94-89e4-733f30e629d8 | trans=f649d45e-b0f8-4c94-89e4-733f30e629d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614870110,Room1,Room,message,string,[{correct=1},1]
time=2017-04-19T15:15:02.319UTC | lvl=INFO | corr=f649d45e-b0f8-4c94-89e4-733f30e629d8 | trans=f649d45e-b0f8-4c94-89e4-733f30e629d8 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614870110,Room1,Room,status,string,[{ok=1},1]
```

Name mappings disabled, memory channel:
```
time=2017-04-19T15:13:42.887UTC | lvl=INFO | corr=41de0afc-f170-42a1-8de9-9e892d7c49b4 | trans=41de0afc-f170-42a1-8de9-9e892d7c49b4 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614791371,Room1,Room,pressure,pascal,[78.1,78.1,78.1,6099.609999999999,1]
time=2017-04-19T15:13:43.095UTC | lvl=INFO | corr=41de0afc-f170-42a1-8de9-9e892d7c49b4 | trans=41de0afc-f170-42a1-8de9-9e892d7c49b4 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614791371,Room1,Room,temperature,centigrade,[26.5,26.5,26.5,702.25,1]
time=2017-04-19T15:13:43.273UTC | lvl=INFO | corr=41de0afc-f170-42a1-8de9-9e892d7c49b4 | trans=41de0afc-f170-42a1-8de9-9e892d7c49b4 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614791371,Room1,Room,message,string,[{correct=1},1]
time=2017-04-19T15:13:43.499UTC | lvl=INFO | corr=41de0afc-f170-42a1-8de9-9e892d7c49b4 | trans=41de0afc-f170-42a1-8de9-9e892d7c49b4 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614791371,Room1,Room,status,string,[{ok=1},1]
```

Name mappings disabled, file channel:
```
time=2017-04-19T15:11:32.400UTC | lvl=INFO | corr=151f5468-7ae6-46b6-8409-91403cead442 | trans=151f5468-7ae6-46b6-8409-91403cead442 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614659878,Room1,Room,pressure,pascal,[78.1,78.1,78.1,6099.609999999999,1]
time=2017-04-19T15:11:32.718UTC | lvl=INFO | corr=151f5468-7ae6-46b6-8409-91403cead442 | trans=151f5468-7ae6-46b6-8409-91403cead442 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614659878,Room1,Room,temperature,centigrade,[26.5,26.5,26.5,702.25,1]
time=2017-04-19T15:11:33.101UTC | lvl=INFO | corr=151f5468-7ae6-46b6-8409-91403cead442 | trans=151f5468-7ae6-46b6-8409-91403cead442 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614659878,Room1,Room,message,string,[{correct=1},1]
time=2017-04-19T15:11:33.589UTC | lvl=INFO | corr=151f5468-7ae6-46b6-8409-91403cead442 | trans=151f5468-7ae6-46b6-8409-91403cead442 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_valencia, Collection: sth_/gardens_Room1_Room.aggr, Data: 1492614659878,Room1,Room,status,string,[{ok=1},1]
```

Name mappings enabled, file channel:
```
time=2017-04-19T15:10:00.356UTC | lvl=INFO | corr=1f9337ba-3924-4eeb-8cee-737f7076ca91 | trans=1f9337ba-3924-4eeb-8cee-737f7076ca91 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614560543,Room1,Room,pressure,pascal,[78.1,78.1,78.1,6099.609999999999,1]
time=2017-04-19T15:10:00.729UTC | lvl=INFO | corr=1f9337ba-3924-4eeb-8cee-737f7076ca91 | trans=1f9337ba-3924-4eeb-8cee-737f7076ca91 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[380] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614560543,Room1,Room,temperature,centigrade,[26.5,26.5,26.5,702.25,1]
time=2017-04-19T15:10:00.909UTC | lvl=INFO | corr=1f9337ba-3924-4eeb-8cee-737f7076ca91 | trans=1f9337ba-3924-4eeb-8cee-737f7076ca91 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614560543,Room1,Room,message,string,[{correct=1},1]
time=2017-04-19T15:10:01.069UTC | lvl=INFO | corr=1f9337ba-3924-4eeb-8cee-737f7076ca91 | trans=1f9337ba-3924-4eeb-8cee-737f7076ca91 | srv=sc_valencia | subsrv=/gardens | comp=cygnus-ngsi | op=persist | msg=com.telefonica.iot.cygnus.sinks.NGSISTHSink$STHAggregator[400] : [sth-sink] Persisting data at NGSISTHSink. Database: sth_sc_val, Collection: sth_/all_Room1_Room.aggr, Data: 1492614560543,Room1,Room,status,string,[{ok=1},1]
```