### PR TITLE
hardening/1358_improve_logs_hdfs_backend

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -12,3 +12,4 @@
 - [cygnus-common, cygnus-ngsi][hardening] Unify test classes (#1332, #1333)
 - [cygnus-common][bug] Allow disabling YAFS in order to avoid crashes upon configuration reloads (#1074)
 - [cygnus-ngsi][hardening] Add a note about optional channels when using Flume's ReplicatingChannelSelector (#510)
+- [cygnus-ngsi][hardening] Improve HDFS sink logs (#1358)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackend.java
@@ -18,6 +18,9 @@
 
 package com.telefonica.iot.cygnus.backends.hdfs;
 
+import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
+
 /**
  * Interface for those backends implementing the persistence in HDFS.
  * 
@@ -35,9 +38,10 @@ public interface HDFSBackend {
      * hdfs:///user/\<hdfsUser\>/\<dirPath\>
      * 
      * @param dirPath Directory to be created
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
      */
-    void createDir(String dirPath) throws Exception;
+    void createDir(String dirPath) throws CygnusPersistenceError, CygnusRuntimeError;
     
     /**
      * Creates a file in HDFS with initial content given its relative path. The absolute path will be build as:
@@ -45,27 +49,30 @@ public interface HDFSBackend {
      * 
      * @param filePath File to be created
      * @param data Data to be written in the created file
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
      */
-    void createFile(String filePath, String data) throws Exception;
+    void createFile(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError;
     
     /**
      * Appends data to an existent file in HDFS.
      * 
      * @param filePath File to be created
      * @param data Data to be appended in the file
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
      */
-    void append(String filePath, String data) throws Exception;
+    void append(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError;
     
     /**
      * Checks if the file exists in HDFS.
      * 
      * @param filePath File that must be checked
      * @return
-     * @throws Exception
+     * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
+     * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
      */
-    boolean exists(String filePath) throws Exception;
+    boolean exists(String filePath) throws CygnusPersistenceError, CygnusRuntimeError;
     
     /**
      * Serializes the backend for pretty printing.

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
@@ -19,6 +19,7 @@
 package com.telefonica.iot.cygnus.backends.hdfs;
 
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -82,31 +83,60 @@ public class HDFSBackendImplBinary implements HDFSBackend {
     } // setFSGetter
 
     @Override
-    public void createDir(String dirPath) throws Exception {
+    public void createDir(String dirPath) throws CygnusPersistenceError, CygnusRuntimeError {
         CreateDirPEA pea = new CreateDirPEA(dirPath);
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser(hdfsUser);
-        ugi.doAs(pea);
+        
+        try {
+            ugi.doAs(pea);
+        } catch (IOException e) {
+            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+        } catch (InterruptedException e) {
+            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+        } // try catch
     } // createDir
 
     @Override
-    public void createFile(String filePath, String data) throws Exception {
+    public void createFile(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError {
         CreateFilePEA pea = new CreateFilePEA(filePath, data);
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser(hdfsUser);
-        ugi.doAs(pea);
+        
+        try {
+            ugi.doAs(pea);
+        } catch (IOException e) {
+            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+        } catch (InterruptedException e) {
+            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+        } // try catch
     } // createFile
 
     @Override
-    public void append(String filePath, String data) throws Exception {
+    public void append(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError {
         AppendPEA pea = new AppendPEA(filePath, data);
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser(hdfsUser);
-        ugi.doAs(pea);
+        
+        try {
+            ugi.doAs(pea);
+        } catch (IOException e) {
+            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+        } catch (InterruptedException e) {
+            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+        } // try catch
     } // append
 
     @Override
-    public boolean exists(String filePath) throws Exception {
+    public boolean exists(String filePath) throws CygnusPersistenceError, CygnusRuntimeError {
         ExistsPEA pea = new ExistsPEA(filePath);
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser(hdfsUser);
-        ugi.doAs(pea);
+        
+        try {
+            ugi.doAs(pea);
+        } catch (IOException e) {
+            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+        } catch (InterruptedException e) {
+            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+        } // try catch
+        
         return pea.exists();
     } // exists
     

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplREST.java
@@ -21,6 +21,7 @@ package com.telefonica.iot.cygnus.backends.hdfs;
 import com.telefonica.iot.cygnus.backends.http.HttpBackend;
 import com.telefonica.iot.cygnus.backends.http.JsonResponse;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import java.util.ArrayList;
 import org.apache.http.Header;
@@ -85,7 +86,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     } // HDFSBackendImplREST
    
     @Override
-    public void createDir(String dirPath) throws Exception {
+    public void createDir(String dirPath) throws CygnusPersistenceError, CygnusRuntimeError {
         String relativeURL = BASE_URL + (serviceAsNamespace ? "" : (hdfsUser + "/")) + dirPath
                 + "?op=mkdirs&user.name=" + hdfsUser;
         JsonResponse response = doRequest("PUT", relativeURL, true, headers, null);
@@ -105,8 +106,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     } // createDir
     
     @Override
-    public void createFile(String filePath, String data)
-        throws Exception {
+    public void createFile(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError {
         String relativeURL = BASE_URL + (serviceAsNamespace ? "" : (hdfsUser + "/")) + filePath
                 + "?op=create&user.name=" + hdfsUser;
         JsonResponse response = doRequest("PUT", relativeURL, true, headers, null);
@@ -151,7 +151,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     } // createFile
     
     @Override
-    public void append(String filePath, String data) throws Exception {
+    public void append(String filePath, String data) throws CygnusPersistenceError, CygnusRuntimeError {
         String relativeURL = BASE_URL + (serviceAsNamespace ? "" : (hdfsUser + "/")) + filePath
                 + "?op=append&user.name=" + hdfsUser;
         JsonResponse response = doRequest("POST", relativeURL, true, headers, null);
@@ -196,7 +196,7 @@ public class HDFSBackendImplREST extends HttpBackend implements HDFSBackend {
     } // append
     
     @Override
-    public boolean exists(String filePath) throws Exception {
+    public boolean exists(String filePath) throws CygnusPersistenceError, CygnusRuntimeError {
         String relativeURL = BASE_URL + (serviceAsNamespace ? "" : (hdfsUser + "/")) + filePath
                 + "?op=getfilestatus&user.name=" + hdfsUser;
         JsonResponse response = doRequest("GET", relativeURL, true, headers, null);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
@@ -1074,7 +1074,7 @@ public class NGSIHDFSSink extends NGSISink {
                 transactionRequestBytes, transactionResponseBytes, 0);
         
         if (!persisted) {
-            throw new CygnusPersistenceError("[" + this.getName() + "] No endpoint was available");
+            throw new CygnusPersistenceError("-, No endpoint was available");
         } // if
     } // persistAggregation
 
@@ -1190,7 +1190,7 @@ public class NGSIHDFSSink extends NGSISink {
         } // if else
         
         if (folderPath.length() > NGSIConstants.HDFS_MAX_NAME_LEN) {
-            throw new CygnusBadConfiguration("Building folder path name '" + folderPath + "' and its length is "
+            throw new CygnusBadConfiguration("-, Building folder path name '" + folderPath + "' and its length is "
                     + "greater than " + NGSIConstants.HDFS_MAX_NAME_LEN);
         } // if
         
@@ -1220,7 +1220,7 @@ public class NGSIHDFSSink extends NGSISink {
         } // if else
         
         if (filePath.length() > NGSIConstants.HDFS_MAX_NAME_LEN) {
-            throw new CygnusBadConfiguration("Building file path name '" + filePath + "' and its length is "
+            throw new CygnusBadConfiguration("-, Building file path name '" + filePath + "' and its length is "
                     + "greater than " + NGSIConstants.HDFS_MAX_NAME_LEN);
         } // if
         

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
@@ -30,6 +30,7 @@ import com.telefonica.iot.cygnus.errors.CygnusBadContextData;
 import com.telefonica.iot.cygnus.errors.CygnusCappingError;
 import com.telefonica.iot.cygnus.errors.CygnusExpiratingError;
 import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
+import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.sinks.Enums.DataModel;
@@ -1056,7 +1057,7 @@ public class NGSIHDFSSink extends NGSISink {
                 } // if
                 
                 break;
-            } catch (Exception e) {
+            } catch (CygnusPersistenceError | CygnusRuntimeError e) {
                 if (persistenceBackend instanceof HDFSBackendImplREST) {
                     ImmutablePair<Long, Long> bytes = ((HDFSBackendImplREST) persistenceBackend).finishTransaction();
                     transactionRequestBytes += bytes.left;
@@ -1104,7 +1105,7 @@ public class NGSIHDFSSink extends NGSISink {
                     } // if
                     
                     break;
-                } catch (Exception e) {
+                } catch (CygnusPersistenceError | CygnusRuntimeError e) {
                     LOGGER.info("[" + this.getName() + "] There was some problem with the current endpoint, "
                             + "trying other one. Details: " + e.getMessage());
                 } // try catch


### PR DESCRIPTION
* Partially implements issue #1358
* (Unofficial) e2e tests passed:
```
time=2017-05-03T07:28:13.164UTC | lvl=ERROR | corr=c0eb14ed-f8c0-4dcd-a9a1-1996255fc96d | trans=c0eb14ed-f8c0-4dcd-a9a1-1996255fc96d | srv=sc_mad | subsrv=/gardens | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[569] : Persistence error. Message: -, No endpoint was available, Stack trace: [com.telefonica.iot.cygnus.sinks.NGSIHDFSSink.persistAggregation(NGSIHDFSSink.java:1077), com.telefonica.iot.cygnus.sinks.NGSIHDFSSink.persistBatch(NGSIHDFSSink.java:495), com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:558), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:370), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:745)]
```