### PR TITLE
hardening/1441_add_cygnus_error_base_class

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -13,3 +13,4 @@
 - [cygnus-common][bug] Allow disabling YAFS in order to avoid crashes upon configuration reloads (#1074)
 - [cygnus-ngsi][hardening] Add a note about optional channels when using Flume's ReplicatingChannelSelector (#510)
 - [cygnus-ngsi][hardening] Improve HDFS sink logs (#1358)
+- [cygnus-ngsi][hardening] Add CygnusError base class (#1441)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANBackendImpl.java
@@ -530,10 +530,10 @@ public class CKANBackendImpl extends HttpBackend implements CKANBackend {
                         } // if else
                     } // for
                 } catch (ParseException e) {
-                    throw new CygnusRuntimeError("ParseException, " + e.getMessage());
+                    throw new CygnusRuntimeError("Data expiration error", "ParseException", e.getMessage());
                 } // try catch
 
-                if (records.size() == 0) {
+                if (records.isEmpty()) {
                     morePages = false;
                 } else {
                     offset += RECORDSPERPAGE;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/ckan/CKANCache.java
@@ -179,35 +179,36 @@ public class CKANCache extends HttpBackend {
         headers.add(new BasicHeader("Authorization", apiKey));
         JsonResponse res = doRequest("GET", ckanURL, true, headers, null);
 
-        if (res.getStatusCode() == 200) {
-            // the organization exists in CKAN
-            JSONObject result = (JSONObject) res.getJsonObject().get("result");
-                        
-            // check if the organization is in "deleted" state
-            String orgState = result.get("state").toString();
-            
-            if (orgState.equals("deleted")) {
-                throw new CygnusBadConfiguration("The organization exists but it is in a deleted state (orgName="
-                        + orgName + ")");
-            } // if
-
-            // put the organization in the tree and in the organization map
-            String orgId = result.get("id").toString();
-            tree.put(orgName, new HashMap<String, ArrayList<String>>());
-            orgMap.put(orgName, orgId);
-            LOGGER.debug("Organization found in CKAN, now cached (orgName/orgId=" + orgName + "/" + orgId + ")");
-
-            // get the packages and populate the packages map
-            JSONArray packages = (JSONArray) result.get("packages");
-            LOGGER.debug("Going to populate the packages cache (orgName=" + orgName + ")");
-            populatePackagesMap(packages, orgName);
-            return true;
-        } else if (res.getStatusCode() == 404) {
-            return false;
-        } else {
-            throw new CygnusPersistenceError("Could not check if the organization exists ("
-                    + "orgName=" + orgName + ", statusCode=" + res.getStatusCode() + ")");
-        } // if else
+        switch (res.getStatusCode()) {
+            case 200:
+                // the organization exists in CKAN
+                JSONObject result = (JSONObject) res.getJsonObject().get("result");
+                
+                // check if the organization is in "deleted" state
+                String orgState = result.get("state").toString();
+                
+                if (orgState.equals("deleted")) {
+                    throw new CygnusBadConfiguration("The organization '" + orgName + "' exists but it is in a "
+                            + "deleted state");
+                } // if
+                
+                // put the organization in the tree and in the organization map
+                String orgId = result.get("id").toString();
+                tree.put(orgName, new HashMap<String, ArrayList<String>>());
+                orgMap.put(orgName, orgId);
+                LOGGER.debug("Organization found in CKAN, now cached (orgName/orgId=" + orgName + "/" + orgId + ")");
+                
+                // get the packages and populate the packages map
+                JSONArray packages = (JSONArray) result.get("packages");
+                LOGGER.debug("Going to populate the packages cache (orgName=" + orgName + ")");
+                populatePackagesMap(packages, orgName);
+                return true;
+            case 404:
+                return false;
+            default:
+                throw new CygnusPersistenceError("Could not check if the organization exists ("
+                        + "orgName=" + orgName + ", statusCode=" + res.getStatusCode() + ")");
+        } // switch
     } // isCachedOrg
     
     /**
@@ -237,37 +238,38 @@ public class CKANCache extends HttpBackend {
         headers.add(new BasicHeader("Authorization", apiKey));
         JsonResponse res = doRequest("GET", ckanURL, true, headers, null);
 
-        if (res.getStatusCode() == 200) {
-            // the package exists in CKAN
-            JSONObject result = (JSONObject) res.getJsonObject().get("result");
-                        
-            // check if the package is in "deleted" state
-            String pkgState = result.get("state").toString();
-            
-            if (pkgState.equals("deleted")) {
-                throw new CygnusBadConfiguration("The package exists but it is in a deleted state (orgName=" + orgName
-                        + ", pkgName=" + pkgName + ")");
-            } // if
-
-            // put the package in the tree and in the package map
-            String pkgId = result.get("id").toString();
-            tree.get(orgName).put(pkgName, new ArrayList<String>());
-            orgMap.put(pkgName, pkgId);
-            LOGGER.debug("Package found in CKAN, now cached (orgName=" + orgName + ", pkgName/pkgId=" + pkgName
-                    + "/" + pkgId + ")");
-
-            // get the resource and populate the resource map
-            JSONArray resources = (JSONArray) result.get("resources");
-            LOGGER.debug("Going to populate the resources cache (orgName=" + orgName + ", pkgName=" + pkgName
-                    + ")");
-            populateResourcesMap(resources, orgName, pkgName, false);
-            return true;
-        } else if (res.getStatusCode() == 404) {
-            return false;
-        } else {
-            throw new CygnusPersistenceError("Could not check if the package exists ("
-                    + "orgName=" + orgName + ", pkgName=" + pkgName + ", statusCode=" + res.getStatusCode() + ")");
-        } // if else
+        switch (res.getStatusCode()) {
+            case 200:
+                // the package exists in CKAN
+                JSONObject result = (JSONObject) res.getJsonObject().get("result");
+                
+                // check if the package is in "deleted" state
+                String pkgState = result.get("state").toString();
+                
+                if (pkgState.equals("deleted")) {
+                    throw new CygnusBadConfiguration("The package '" + pkgName + "' exists but it is in a "
+                            + "deleted state");
+                } // if
+                
+                // put the package in the tree and in the package map
+                String pkgId = result.get("id").toString();
+                tree.get(orgName).put(pkgName, new ArrayList<String>());
+                orgMap.put(pkgName, pkgId);
+                LOGGER.debug("Package found in CKAN, now cached (orgName=" + orgName + ", pkgName/pkgId=" + pkgName
+                        + "/" + pkgId + ")");
+                
+                // get the resource and populate the resource map
+                JSONArray resources = (JSONArray) result.get("resources");
+                LOGGER.debug("Going to populate the resources cache (orgName=" + orgName + ", pkgName=" + pkgName
+                        + ")");
+                populateResourcesMap(resources, orgName, pkgName, false);
+                return true;
+            case 404:
+                return false;
+            default:
+                throw new CygnusPersistenceError("Could not check if the package exists ("
+                        + "orgName=" + orgName + ", pkgName=" + pkgName + ", statusCode=" + res.getStatusCode() + ")");
+        } // switch
     } // isCachedPkg
     
     /**
@@ -303,44 +305,45 @@ public class CKANCache extends HttpBackend {
         headers.add(new BasicHeader("Authorization", apiKey));
         JsonResponse res = doRequest("GET", ckanURL, true, headers, null);
 
-        if (res.getStatusCode() == 200) {
-            // the package exists in CKAN
-            LOGGER.debug("Package found in CKAN, going to update the cached resources (orgName=" + orgName
-                    + ", pkgName=" + pkgName + ")");
-
-            // there is no need to check if the package is in "deleted" state...
-
-            // there is no need to put the package in the tree nor put it in the package map...
-
-            // get the resource and populate the resource map
-            JSONObject result = (JSONObject) res.getJsonObject().get("result");
-            JSONArray resources = (JSONArray) result.get("resources");
-            
-            if (resources.size() == 0) {
-                return false;
-            } else {
-                LOGGER.debug("Going to populate the resources cache (orgName=" + orgName + ", pkgName=" + pkgName
-                        + ")");
-                populateResourcesMap(resources, orgName, pkgName, true);
+        switch (res.getStatusCode()) {
+            case 200:
+                // the package exists in CKAN
+                LOGGER.debug("Package found in CKAN, going to update the cached resources (orgName=" + orgName
+                        + ", pkgName=" + pkgName + ")");
                 
-                // check if the resource is within the resources cache, once populated
-                if (tree.get(orgName).get(pkgName).contains(resName)) {
-                    LOGGER.debug("Resource found in the cache, once queried CKAN " + "(orgName=" + orgName
-                            + ", pkgName=" + pkgName + ", resName=" + resName + ")");
-                    return true;
-                } else {
-                    LOGGER.debug("Resource not found in the cache, once queried CKAN " + "(orgName=" + orgName
-                            + ", pkgName=" + pkgName + ", resName=" + resName + ")");
+                // there is no need to check if the package is in "deleted" state...
+                
+                // there is no need to put the package in the tree nor put it in the package map...
+                
+                // get the resource and populate the resource map
+                JSONObject result = (JSONObject) res.getJsonObject().get("result");
+                JSONArray resources = (JSONArray) result.get("resources");
+                
+                if (resources.isEmpty()) {
                     return false;
+                } else {
+                    LOGGER.debug("Going to populate the resources cache (orgName=" + orgName + ", pkgName=" + pkgName
+                            + ")");
+                    populateResourcesMap(resources, orgName, pkgName, true);
+                    
+                    // check if the resource is within the resources cache, once populated
+                    if (tree.get(orgName).get(pkgName).contains(resName)) {
+                        LOGGER.debug("Resource found in the cache, once queried CKAN " + "(orgName=" + orgName
+                                + ", pkgName=" + pkgName + ", resName=" + resName + ")");
+                        return true;
+                    } else {
+                        LOGGER.debug("Resource not found in the cache, once queried CKAN " + "(orgName=" + orgName
+                                + ", pkgName=" + pkgName + ", resName=" + resName + ")");
+                        return false;
+                    } // if else
                 } // if else
-            } // if else
-        } else if (res.getStatusCode() == 404) {
-            return false;
-        } else {
-            throw new CygnusPersistenceError("Could not check if the resource exists ("
-                    + "orgName=" + orgName + ", pkgName=" + pkgName + ", resName=" + resName
-                    + ", statusCode=" + res.getStatusCode() + ")");
-        } // if else
+            case 404:
+                return false;
+            default:
+                throw new CygnusPersistenceError("Could not check if the resource exists ("
+                        + "orgName=" + orgName + ", pkgName=" + pkgName + ", resName=" + resName
+                        + ", statusCode=" + res.getStatusCode() + ")");
+        } // switch
     } // isCachedRes
 
     /**
@@ -354,7 +357,7 @@ public class CKANCache extends HttpBackend {
     private void populatePackagesMap(JSONArray packages, String orgName)
         throws CygnusBadConfiguration, CygnusRuntimeError, CygnusPersistenceError {
         // this check is for debuging purposes
-        if (packages == null || packages.size() == 0) {
+        if (packages == null || packages.isEmpty()) {
             LOGGER.debug("The pacakges list is empty, nothing to cache");
             return;
         } // if
@@ -373,8 +376,7 @@ public class CKANCache extends HttpBackend {
             String pkgState = pkg.get("state").toString();
 
             if (pkgState.equals("deleted")) {
-                throw new CygnusBadConfiguration("The package exists but it is in a deleted state (orgName="
-                        + orgName + ", pkgName=" + pkgName + ")");
+                throw new CygnusBadConfiguration("The package '" + pkgName + "' exists but it is in a deleted state");
             } // if
             
             // put the package in the tree and in the packages map
@@ -403,7 +405,7 @@ public class CKANCache extends HttpBackend {
      */
     private void populateResourcesMap(JSONArray resources, String orgName, String pkgName, boolean checkExistence) {
         // this check is for debuging purposes
-        if (resources == null || resources.size() == 0) {
+        if (resources == null || resources.isEmpty()) {
             LOGGER.debug("The resources list is empty, nothing to cache");
             return;
         } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/hdfs/HDFSBackendImplBinary.java
@@ -90,9 +90,9 @@ public class HDFSBackendImplBinary implements HDFSBackend {
         try {
             ugi.doAs(pea);
         } catch (IOException e) {
-            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+            throw new CygnusPersistenceError("Directory creation error", "IOException", e.getMessage());
         } catch (InterruptedException e) {
-            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+            throw new CygnusPersistenceError("Directory creation error", "InterruptedException", e.getMessage());
         } // try catch
     } // createDir
 
@@ -104,9 +104,9 @@ public class HDFSBackendImplBinary implements HDFSBackend {
         try {
             ugi.doAs(pea);
         } catch (IOException e) {
-            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+            throw new CygnusPersistenceError("File creation error", "IOException", e.getMessage());
         } catch (InterruptedException e) {
-            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+            throw new CygnusPersistenceError("File creation error", "InterruptedException", e.getMessage());
         } // try catch
     } // createFile
 
@@ -118,9 +118,9 @@ public class HDFSBackendImplBinary implements HDFSBackend {
         try {
             ugi.doAs(pea);
         } catch (IOException e) {
-            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+            throw new CygnusPersistenceError("File appending error", "IOException", e.getMessage());
         } catch (InterruptedException e) {
-            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+            throw new CygnusPersistenceError("File appending error", "InterruptedException", e.getMessage());
         } // try catch
     } // append
 
@@ -132,9 +132,9 @@ public class HDFSBackendImplBinary implements HDFSBackend {
         try {
             ugi.doAs(pea);
         } catch (IOException e) {
-            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+            throw new CygnusPersistenceError("File existence checking error", "IOException",  e.getMessage());
         } catch (InterruptedException e) {
-            throw new CygnusPersistenceError("InterruptedException, " + e.getMessage());
+            throw new CygnusPersistenceError("File existence checking error", "InterruptedException", e.getMessage());
         } // try catch
         
         return pea.exists();

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/http/HttpBackend.java
@@ -184,7 +184,7 @@ public abstract class HttpBackend {
                 request = new HttpDelete(url);
                 break;
             default:
-                throw new CygnusRuntimeError("-, Http " + method + " method not supported"); // if else
+                throw new CygnusRuntimeError("Http '" + method + "' method not supported");
         } // switch
 
         if (headers != null) {
@@ -199,7 +199,7 @@ public abstract class HttpBackend {
             httpRes = httpClient.execute(request);
         } catch (IOException e) {
             request.releaseConnection();
-            throw new CygnusPersistenceError("IOException, " + e.getMessage());
+            throw new CygnusPersistenceError("Request error", "IOException", e.getMessage());
         } // try catch
 
         JsonResponse response = createJsonResponse(httpRes);
@@ -218,7 +218,7 @@ public abstract class HttpBackend {
             PrivilegedRequest req = new PrivilegedRequest(method, url, headers, entity);
             return createJsonResponse((HttpResponse) Subject.doAs(loginContext.getSubject(), req));
         } catch (LoginException e) {
-            throw new CygnusRuntimeError("LoginException, " + e.getMessage());
+            throw new CygnusRuntimeError("Privileged request error", "LoginException", e.getMessage());
         } // try catch
     } // doPrivilegedRequest
     
@@ -308,9 +308,9 @@ public abstract class HttpBackend {
             try {
                 reader = new BufferedReader(new InputStreamReader(httpRes.getEntity().getContent()));
             } catch (IOException e) {
-                throw new CygnusRuntimeError("IOException, " + e.getMessage());
+                throw new CygnusRuntimeError("Response handling error", "IOException", e.getMessage());
             } catch (IllegalStateException e) {
-                throw new CygnusRuntimeError("IllegalStateException, " + e.getMessage());
+                throw new CygnusRuntimeError("Response handling error", "IllegalStateException", e.getMessage());
             } // try catch
             
             String res = "";
@@ -321,7 +321,7 @@ public abstract class HttpBackend {
                     res += line;
                 } // while
             } catch (IOException e) {
-                throw new CygnusRuntimeError("IOException, " + e.getMessage());
+                throw new CygnusRuntimeError("Response handling error", "IOException", e.getMessage());
             } // try catch
             
             transactionResponseBytes += res.length();
@@ -329,7 +329,7 @@ public abstract class HttpBackend {
             try {
                 reader.close();
             } catch (IOException e) {
-                throw new CygnusRuntimeError("IOException, " + e.getMessage());
+                throw new CygnusRuntimeError("Response handling error", "IOException", e.getMessage());
             } // try catch
 
             LOGGER.debug("Http response payload: " + res);
@@ -343,7 +343,7 @@ public abstract class HttpBackend {
                     try {
                         object = jsonParser.parse(res);
                     } catch (ParseException e) {
-                        throw new CygnusRuntimeError("ParseException, " + e.getMessage());
+                        throw new CygnusRuntimeError("Response handling error", "ParseException", e.getMessage());
                     } // try catch
 
                     jsonPayload = new JSONObject();
@@ -352,7 +352,7 @@ public abstract class HttpBackend {
                     try {
                         jsonPayload = (JSONObject) jsonParser.parse(res);
                     } catch (ParseException e) {
-                        throw new CygnusRuntimeError("ParseException, " + e.getMessage());
+                        throw new CygnusRuntimeError("Response handling error", "ParseException", e.getMessage());
                     } // try catch
                 } // if else
             } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -88,7 +88,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             stmt = con.createStatement();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Database creation error", "SQLException", e.getMessage());
         } // try catch
         
         try {
@@ -96,7 +96,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
-            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+            throw new CygnusPersistenceError("Database creation error", "SQLException", e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -121,7 +121,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             stmt = con.createStatement();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Table creation error", "SQLException", e.getMessage());
         } // try catch
         
         try {
@@ -129,7 +129,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
-            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+            throw new CygnusPersistenceError("Table creation error", "SQLException", e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -149,7 +149,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             stmt = con.createStatement();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Data insertion error", "SQLException", e.getMessage());
         } // try catch
         
         try {
@@ -157,9 +157,9 @@ public class MySQLBackendImpl implements MySQLBackend {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLTimeoutException e) {
-            throw new CygnusPersistenceError("SQLTimeoutException, " + e.getMessage());
+            throw new CygnusPersistenceError("Data insertion error", "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
-            throw new CygnusBadContextData("SQLException, " + e.getMessage());
+            throw new CygnusBadContextData("Data insertion error", "SQLException", e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -179,7 +179,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             stmt = con.createStatement();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Querying error", "SQLException", e.getMessage());
         } // try catch
         
         try {
@@ -194,7 +194,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             return crs;
         } catch (SQLException e) {
             closeMySQLObjects(con, stmt);
-            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+            throw new CygnusPersistenceError("Querying error", "SQLException", e.getMessage());
         } // try catch
     } // select
     
@@ -208,7 +208,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             stmt = con.createStatement();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Deleting error", "SQLException", e.getMessage());
         } // try catch
         
         try {
@@ -216,7 +216,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
-            throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+            throw new CygnusPersistenceError("Deleting error", "SQLException", e.getMessage());
         } // try catch
         
         closeMySQLObjects(con, stmt);
@@ -237,7 +237,7 @@ public class MySQLBackendImpl implements MySQLBackend {
                 records.beforeFirst();
             } // if
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Data capping error", "SQLException", e.getMessage());
         } // try catch
         
         // Get the reception times (they work as IDs) for future deletion
@@ -260,7 +260,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             
             records.close();
         } catch (SQLException e) {
-            throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+            throw new CygnusRuntimeError("Data capping error", "SQLException", e.getMessage());
         } // try catch
         
         if (filters.isEmpty()) {
@@ -296,7 +296,7 @@ public class MySQLBackendImpl implements MySQLBackend {
                         records.beforeFirst();
                     } // if
                 } catch (SQLException e) {
-                    throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+                    throw new CygnusRuntimeError("Data expiration error", "SQLException", e.getMessage());
                 } // try catch
 
                 // Get the reception times (they work as IDs) for future deletion
@@ -321,9 +321,9 @@ public class MySQLBackendImpl implements MySQLBackend {
                         } // if else
                     } // for
                 } catch (SQLException e) {
-                    throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+                    throw new CygnusRuntimeError("Data expiration error", "SQLException", e.getMessage());
                 } catch (ParseException e) {
-                    throw new CygnusRuntimeError("ParseException, " + e.getMessage());
+                    throw new CygnusRuntimeError("Data expiration error", "ParseException", e.getMessage());
                 } // try catch
 
                 if (filters.isEmpty()) {
@@ -348,7 +348,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             try {
                 con.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+                throw new CygnusRuntimeError("Objects closing error", "SQLException", e.getMessage());
             } // try catch
         } // if
 
@@ -356,7 +356,7 @@ public class MySQLBackendImpl implements MySQLBackend {
             try {
                 stmt.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("SQLException, " + e.getMessage());
+                throw new CygnusRuntimeError("Objects closing error", "SQLException", e.getMessage());
             } // try catch
         } // if
     } // closeMySQLObjects
@@ -411,9 +411,9 @@ public class MySQLBackendImpl implements MySQLBackend {
 
                 return con;
             } catch (ClassNotFoundException e) {
-                throw new CygnusRuntimeError("ClassNotFoundException, " + e.getMessage());
+                throw new CygnusRuntimeError("Connection error", "ClassNotFoundException", e.getMessage());
             } catch (SQLException e) {
-                throw new CygnusPersistenceError("SQLException, " + e.getMessage());
+                throw new CygnusPersistenceError("Connection error", "SQLException", e.getMessage());
             } // try catch
         } // getConnection
         

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -93,16 +93,16 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
             try {
                 stmt = con.createStatement();
-            } catch (Exception e) {
-                throw new CygnusRuntimeError(e.getMessage());
+            } catch (SQLException e) {
+                throw new CygnusRuntimeError("Schema creation error", "SQLException", e.getMessage());
             } // try catch
 
             try {
                 String query = "CREATE SCHEMA IF NOT EXISTS " + schemaName;
                 LOGGER.debug("Executing SQL query '" + query + "'");
                 stmt.executeUpdate(query);
-            } catch (Exception e) {
-                throw new CygnusRuntimeError(e.getMessage());
+            } catch (SQLException e) {
+                throw new CygnusRuntimeError("Schema creation error", "SQLException", e.getMessage());
             } // try catch
 
             closePostgreSQLObjects(con, stmt);
@@ -130,16 +130,16 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
             try {
                 stmt = con.createStatement();
-            } catch (Exception e) {
-                throw new CygnusRuntimeError(e.getMessage());
+            } catch (SQLException e) {
+                throw new CygnusRuntimeError("Table creation error", "SQLException", e.getMessage());
             } // try catch
 
             try {
                 String query = "CREATE TABLE IF NOT EXISTS " + schemaName + "." + tableName + " " + typedFieldNames;
                 LOGGER.debug("Executing SQL query '" + query + "'");
                 stmt.executeUpdate(query);
-            } catch (Exception e) {
-                throw new CygnusRuntimeError(e.getMessage());
+            } catch (SQLException e) {
+                throw new CygnusRuntimeError("Table creation error", "SQLException", e.getMessage());
             } // try catch
 
             closePostgreSQLObjects(con, stmt);
@@ -158,8 +158,8 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
         try {
             stmt = con.createStatement();
-        } catch (Exception e) {
-            throw new CygnusRuntimeError(e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusRuntimeError("Data insertion error", "SQLException", e.getMessage());
         } // try catch
 
         try {
@@ -167,9 +167,9 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
             LOGGER.debug("Executing SQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLTimeoutException e) {
-            throw new CygnusPersistenceError(e.getMessage());
+            throw new CygnusPersistenceError("Data insertion error", "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
-            throw new CygnusBadContextData(e.getMessage());
+            throw new CygnusBadContextData("Data insertion error", "SQLException", e.getMessage());
         } // try catch
     } // insertContextData
 
@@ -184,8 +184,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
             try {
                 con.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("The Hive connection could not be closed. Details="
-                        + e.getMessage());
+                throw new CygnusRuntimeError("Objects closing error", "SQLException", e.getMessage());
             } // try catch
         } // if
 
@@ -193,8 +192,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
             try {
                 stmt.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError("The Hive statement could not be closed. Details="
-                        + e.getMessage());
+                throw new CygnusRuntimeError("Objects closing error", "SQLException", e.getMessage());
             } // try catch
         } // if
     } // closePostgreSQLObjects
@@ -221,7 +219,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
          */
         public PostgreSQLDriver(String postgresqlHost, String postgresqlPort, String postgresqlDatabase, 
                 String postgresqlUsername, String postgresqlPassword) {
-            connections = new HashMap<String, Connection>();
+            connections = new HashMap<>();
             this.postgresqlHost = postgresqlHost;
             this.postgresqlPort = postgresqlPort;
             this.postgresqlDatabase = postgresqlDatabase;
@@ -252,9 +250,9 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
                 return con;
             } catch (ClassNotFoundException e) {
-                throw new CygnusPersistenceError(e.getMessage());
+                throw new CygnusPersistenceError("Connection error", "ClassNotFoundException", e.getMessage());
             } catch (SQLException e) {
-                throw new CygnusPersistenceError(e.getMessage());
+                throw new CygnusPersistenceError("Connection error", "SQLException", e.getMessage());
             } // try catch
         } // getConnection
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
@@ -22,14 +22,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusBadConfiguration extends Exception {
+public class CygnusBadConfiguration extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusBadConfiguration(String message) {
-        super("Bad configuration. Message: " + message);
+    public CygnusBadConfiguration(String cygnusMessage) {
+        super("CygnusBadConfiguration", "-", cygnusMessage, "-");
+    } // CygnusBadConfiguration
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusBadConfiguration(String cygnusMessage, String javaException, String javaMessage) {
+        super("CygnusBadConfiguration", javaException, cygnusMessage, javaMessage);
     } // CygnusBadConfiguration
     
 } // CygnusBadConfiguration

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadConfiguration.java
@@ -29,7 +29,7 @@ public class CygnusBadConfiguration extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusBadConfiguration(String cygnusMessage) {
-        super("CygnusBadConfiguration", "-", cygnusMessage, "-");
+        super("CygnusBadConfiguration", null, cygnusMessage, null);
     } // CygnusBadConfiguration
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
@@ -29,7 +29,7 @@ public class CygnusBadContextData extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusBadContextData(String cygnusMessage) {
-        super("BadContextData", "-", cygnusMessage, "-");
+        super("BadContextData", null, cygnusMessage, null);
     } // CygnusBadContextData
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusBadContextData.java
@@ -22,14 +22,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusBadContextData extends Exception {
+public class CygnusBadContextData extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusBadContextData(String message) {
-        super("Bad context data. Message: " + message);
+    public CygnusBadContextData(String cygnusMessage) {
+        super("BadContextData", "-", cygnusMessage, "-");
+    } // CygnusBadContextData
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusBadContextData(String cygnusMessage, String javaException, String javaMessage) {
+        super("BadContextData", javaException, cygnusMessage, javaMessage);
     } // CygnusBadContextData
     
 } // CygnusBadContextData

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
@@ -28,7 +28,7 @@ public class CygnusCappingError extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusCappingError(String cygnusMessage) {
-        super("CygnusCappingError", "-", cygnusMessage, "-");
+        super("CygnusCappingError", null, cygnusMessage, null);
     } // CygnusCappingError
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusCappingError.java
@@ -21,14 +21,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusCappingError extends Exception {
+public class CygnusCappingError extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusCappingError(String message) {
-        super("Error while capping persistence elements. Message: " + message);
+    public CygnusCappingError(String cygnusMessage) {
+        super("CygnusCappingError", "-", cygnusMessage, "-");
+    } // CygnusCappingError
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusCappingError(String cygnusMessage, String javaException, String javaMessage) {
+        super("CygnusCappingError", javaException, cygnusMessage, javaMessage);
     } // CygnusCappingError
     
 } // CygnusCappingError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusError.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package com.telefonica.iot.cygnus.errors;
+
+/**
+ *
+ * @author frb
+ */
+public class CygnusError extends Exception {
+    
+    /**
+     * Constructor.
+     * @param cygnusException
+     * @param javaException
+     * @param cygnusMessage
+     * @param javaMessage
+     */
+    public CygnusError(String cygnusException, String javaException, String cygnusMessage, String javaMessage) {
+        super(cygnusException + "(" + javaException + "), " + cygnusMessage + "(" + javaMessage + ")");
+    } // CygnusError
+    
+} // CygnusError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusError.java
@@ -31,7 +31,8 @@ public class CygnusError extends Exception {
      * @param javaMessage
      */
     public CygnusError(String cygnusException, String javaException, String cygnusMessage, String javaMessage) {
-        super(cygnusException + "(" + javaException + "), " + cygnusMessage + "(" + javaMessage + ")");
+        super(cygnusException + (javaException == null ? ". " : " (" + javaException + "). ")
+                + cygnusMessage + (javaMessage == null ? ". " : " (" + javaMessage + "). "));
     } // CygnusError
     
 } // CygnusError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
@@ -21,14 +21,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusExpiratingError extends Exception {
+public class CygnusExpiratingError extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusExpiratingError(String message) {
-        super("Error while expirating records. Message: " + message);
+    public CygnusExpiratingError(String cygnusMessage) {
+        super("CygnusExpiratingError", "-", cygnusMessage, "-");
+    } // CygnusExpiratingError
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusExpiratingError(String cygnusMessage, String javaException, String javaMessage) {
+        super("CygnusExpiratingError", javaException, cygnusMessage, javaMessage);
     } // CygnusExpiratingError
     
 } // CygnusExpiratingError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusExpiratingError.java
@@ -28,7 +28,7 @@ public class CygnusExpiratingError extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusExpiratingError(String cygnusMessage) {
-        super("CygnusExpiratingError", "-", cygnusMessage, "-");
+        super("CygnusExpiratingError", null, cygnusMessage, null);
     } // CygnusExpiratingError
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
@@ -29,7 +29,7 @@ public class CygnusPersistenceError extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusPersistenceError(String cygnusMessage) {
-        super("CygnusPersistenceError", "-", cygnusMessage, "-");
+        super("CygnusPersistenceError", null, cygnusMessage, null);
     } // CygnusPersistenceError
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusPersistenceError.java
@@ -22,14 +22,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusPersistenceError extends Exception {
+public class CygnusPersistenceError extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusPersistenceError(String message) {
-        super("Persistence error. Message: " + message);
+    public CygnusPersistenceError(String cygnusMessage) {
+        super("CygnusPersistenceError", "-", cygnusMessage, "-");
+    } // CygnusPersistenceError
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusPersistenceError(String cygnusMessage, String javaException, String javaMessage) {
+        super("CygnusPersistenceError", javaException, cygnusMessage, javaMessage);
     } // CygnusPersistenceError
     
 } // CygnusPersistenceError

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
@@ -29,7 +29,7 @@ public class CygnusRuntimeError extends CygnusError {
      * @param cygnusMessage
      */
     public CygnusRuntimeError(String cygnusMessage) {
-        super("CygnusRuntimeError", "-", cygnusMessage, "-");
+        super("CygnusRuntimeError", null, cygnusMessage, null);
     } // CygnusRuntimeError
     
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/errors/CygnusRuntimeError.java
@@ -22,14 +22,24 @@ package com.telefonica.iot.cygnus.errors;
  *
  * @author frb
  */
-public class CygnusRuntimeError extends Exception {
+public class CygnusRuntimeError extends CygnusError {
     
     /**
      * Constructor.
-     * @param message
+     * @param cygnusMessage
      */
-    public CygnusRuntimeError(String message) {
-        super("Runtime error. Message: " + message);
+    public CygnusRuntimeError(String cygnusMessage) {
+        super("CygnusRuntimeError", "-", cygnusMessage, "-");
+    } // CygnusRuntimeError
+    
+    /**
+     * Constructor.
+     * @param cygnusMessage
+     * @param javaException
+     * @param javaMessage
+     */
+    public CygnusRuntimeError(String cygnusMessage, String javaException, String javaMessage) {
+        super("CygnusRuntimeError", javaException, cygnusMessage, javaMessage);
     } // CygnusRuntimeError
     
 } // CygnusRuntimeError

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -291,8 +291,12 @@ public class NGSICKANSink extends NGSISink {
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",orgName="
                         + orgName + ", pkgName=" + pkgName + ", resName=" + resName + ")");
                 persistenceBackend.capRecords(orgName, pkgName, resName, maxRecords);
-            } catch (CygnusBadConfiguration | CygnusRuntimeError | CygnusPersistenceError e) {
-                throw new CygnusCappingError(e.getMessage());
+            } catch (CygnusBadConfiguration e) {
+                throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
+            } catch (CygnusRuntimeError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusRuntimeError", e.getMessage());
+            } catch (CygnusPersistenceError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusPersistenceError", e.getMessage());
             } // try catch
         } // while
     } // capRecords
@@ -303,8 +307,10 @@ public class NGSICKANSink extends NGSISink {
         
         try {
             persistenceBackend.expirateRecordsCache(expirationTime);
-        } catch (CygnusRuntimeError | CygnusPersistenceError e) {
-            throw new CygnusExpiratingError(e.getMessage());
+        } catch (CygnusRuntimeError e) {
+            throw new CygnusExpiratingError("Data expiration error", "CygnusRuntimeError", e.getMessage());
+        } catch (CygnusPersistenceError e) {
+            throw new CygnusExpiratingError("Data expiration error", "CygnusPersistenceError", e.getMessage());
         } // try catch
     } // truncateByTime
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIHDFSSink.java
@@ -841,7 +841,7 @@ public class NGSIHDFSSink extends NGSISink {
             try {
                 attrMetadataJSON = (JSONArray) jsonParser.parse(attrMetadata);
             } catch (ParseException e) {
-                throw new CygnusBadContextData("ParseException, " + e.getMessage());
+                throw new CygnusBadContextData("Metadata parsing error", "ParseException", e.getMessage());
             } // try catch
 
             // iterate on the metadata
@@ -974,7 +974,7 @@ public class NGSIHDFSSink extends NGSISink {
             try {
                 attrMetadataJSON = (JSONArray) jsonParser.parse(attrMetadata);
             } catch (ParseException e) {
-                throw new CygnusBadContextData("ParseException, " + e.getMessage());
+                throw new CygnusBadContextData("Metadata parsing error", "ParseException", e.getMessage());
             } // try catch
 
             // iterate on the metadata
@@ -1074,7 +1074,7 @@ public class NGSIHDFSSink extends NGSISink {
                 transactionRequestBytes, transactionResponseBytes, 0);
         
         if (!persisted) {
-            throw new CygnusPersistenceError("-, No endpoint was available");
+            throw new CygnusPersistenceError("No endpoint was available");
         } // if
     } // persistAggregation
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -231,9 +231,13 @@ public class NGSIMySQLSink extends NGSISink {
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");
                 persistenceBackend.capRecords(dbName, tableName, maxRecords);
-            } catch (CygnusBadConfiguration | CygnusRuntimeError | CygnusPersistenceError e) {
-                throw new CygnusCappingError(e.getMessage());
-            } // catch
+            } catch (CygnusBadConfiguration e) {
+                throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
+            } catch (CygnusRuntimeError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusRuntimeError", e.getMessage());
+            } catch (CygnusPersistenceError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusPersistenceError", e.getMessage());
+            } // try catch
         } // while
     } // capRecords
 
@@ -243,8 +247,10 @@ public class NGSIMySQLSink extends NGSISink {
         
         try {
             persistenceBackend.expirateRecordsCache(expirationTime);
-        } catch (CygnusRuntimeError | CygnusPersistenceError e) {
-            throw new CygnusExpiratingError(e.getMessage());
+        } catch (CygnusRuntimeError e) {
+            throw new CygnusExpiratingError("Data expiration error", "CygnusRuntimeError", e.getMessage());
+        } catch (CygnusPersistenceError e) {
+            throw new CygnusExpiratingError("Data expiration error", "CygnusPersistenceError", e.getMessage());
         } // try catch
     } // expirateRecords
     

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -390,12 +390,12 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
             persistBatch(batch);
         } catch (CygnusBadConfiguration | CygnusBadContextData | CygnusRuntimeError e) {
             updateServiceMetrics(batch, true);
-            LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+            LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
             setMDCToNA();
             return Status.READY;
         } catch (CygnusPersistenceError e) {
             updateServiceMetrics(batch, true);
-            LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+            LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
             doRollbackAgain(rollbackedAccumulation);
             setMDCToNA();
             return Status.BACKOFF; // Slow down the sink since there are problems with the persistence backend
@@ -405,7 +405,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
             try {
                 capRecords(batch, persistencePolicyMaxRecords);
             } catch (CygnusCappingError e) {
-                LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+                LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
             } // try catch
         } // if
         
@@ -558,7 +558,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 persistBatch(batch);
             } catch (CygnusBadConfiguration | CygnusBadContextData | CygnusRuntimeError e) {
                 updateServiceMetrics(batch, true);
-                LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+                LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
                 accumulator.initialize(new Date().getTime());
                 txn.commit();
                 txn.close();
@@ -566,7 +566,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 return Status.READY;
             } catch (CygnusPersistenceError e) {
                 updateServiceMetrics(batch, true);
-                LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+                LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
                 doRollback(accumulator.clone()); // the global accumulator has to be cloned for rollbacking purposes
                 accumulator.initialize(new Date().getTime());
                 txn.commit();
@@ -579,7 +579,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 try {
                     capRecords(batch, persistencePolicyMaxRecords);
                 } catch (CygnusCappingError e) {
-                    LOGGER.error(e.getMessage() + ", Stack trace: " + Arrays.toString(e.getStackTrace()));
+                    LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
                 } // try
             } // if
             


### PR DESCRIPTION
* Implements issue #1441 
* (Unofficial) e2e tests passed (some examples):
```
time=2017-05-04T15:53:47.808UTC | lvl=ERROR | corr=N/A | trans=N/A | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=processRollbackedBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[398] : CygnusPersistenceError. No endpoint was available. Stack trace: [com.telefonica.iot.cygnus.sinks.NGSIHDFSSink.persistAggregation(NGSIHDFSSink.java:1077), com.telefonica.iot.cygnus.sinks.NGSIHDFSSink.persistBatch(NGSIHDFSSink.java:495), com.telefonica.iot.cygnus.sinks.NGSISink.processRollbackedBatches(NGSISink.java:390), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:372), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:745)]
```
```
time=2017-05-05T11:12:02.235UTC | lvl=ERROR | corr=d5bb77bb-fecd-4d86-b248-e88bff0fe5ce | trans=d5bb77bb-fecd-4d86-b248-e88bff0fe5ce | srv=sc_errors | subsrv=/gardens | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[569] : CygnusPersistenceError (SQLException). Connection error (Communications link failure. The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.). Stack trace: [com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver.getConnection(MySQLBackendImpl.java:416), com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl.insertContextData(MySQLBackendImpl.java:147), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistAggregation(NGSIMySQLSink.java:556), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistBatch(NGSIMySQLSink.java:200), com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:558), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:370), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:745)]
```