### PR TITLE
Feature/1456 regex entityid mapping

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+[cygnus-ngsi][NGSINameMappingsInterceptor] Allow regular expression replacement for EntityIds (#1456)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/interceptors/NGSINameMappingsInterceptor.java
@@ -156,7 +156,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         } // if
         */
     } // close
-    
+
     /**
      * Builder class for this new interceptor.
      */
@@ -189,7 +189,7 @@ public class NGSINameMappingsInterceptor implements Interceptor {
         } // getInvalidConfiguration
         
     } // Builder
-    
+
     /**
      * Class in charge or periodically reading the NGSINameMappingsInterceptor configuration file.
      */
@@ -384,11 +384,10 @@ public class NGSINameMappingsInterceptor implements Interceptor {
             LOGGER.debug("[nmi] Entity found: " + originalEntityId + ", " + originalEntityType);
 
             if (entityMapping.getNewEntityId() != null) {
-            	LOGGER.debug("[nmi] IdPattern : " +entityMapping.getOriginalEntityIdPattern().toString());
-            	
-            	newEntityId = originalEntityId.replaceAll(entityMapping.getOriginalEntityIdPattern().toString()
-            											, entityMapping.getNewEntityId());
-            	LOGGER.debug("[nmi] newEntityId : " +newEntityId);
+                LOGGER.debug("[nmi] IdPattern : " + entityMapping.getOriginalEntityIdPattern().toString());
+                newEntityId = originalEntityId.replaceAll(entityMapping.getOriginalEntityIdPattern().toString(),
+                        entityMapping.getNewEntityId());
+                LOGGER.debug("[nmi] newEntityId : " + newEntityId);
             } // if
 
             if (entityMapping.getNewEntityType() != null) {
@@ -447,5 +446,5 @@ public class NGSINameMappingsInterceptor implements Interceptor {
 
         return new ImmutableTriple(newService, newServicePath, newCE);
     } // map
-    
+
 } // NGSINameMappingsInterceptor

--- a/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
@@ -171,6 +171,26 @@ $ cat /path/to/conf/name_mappings.conf
    ]
 }
 ```
+In addition, It's allowed to use regular expressions for EntityIds replacement. For instance, if we want to rename EntityIds maintaining each entity number:
+
+```
+{
+	"serviceMappings": [{
+		"originalService": "service",
+		"newService": "new_service",
+		"servicePathMappings": [{
+			"originalServicePath": "/subservice",
+			"newServicePath": "/new_subservice",
+			"entityMappings": [{
+				"originalEntityType": "myentitytype",
+				"originalEntityId": "(myentityid)([0-9]*)",
+				"newEntityId": "new_myentityid$2",
+				"attributeMappings": []
+			}]
+		}]
+	}]
+}
+```
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
@@ -171,7 +171,7 @@ $ cat /path/to/conf/name_mappings.conf
    ]
 }
 ```
-In addition, It's allowed to use regular expressions for EntityIds replacement. For instance, if we want to rename EntityIds maintaining each entity number:
+In addition, it's allowed to use regular expressions for EntityIds replacement. For instance, if we want to rename EntityIds maintaining each entity number:
 
 ```
 {

--- a/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
@@ -171,7 +171,7 @@ $ cat /path/to/conf/name_mappings.conf
    ]
 }
 ```
-In addition, it's allowed to use regular expressions for EntityIds replacement. For instance, if we want to rename EntityIds maintaining each entity number:
+In addition, above mentioned Java-based regular expressions can be also used in new entity IDs.. For instance, if we want to rename certain entity IDs described as a string concatenated with a number, and we want to replace the string but maintaining the number:
 
 ```
 {

--- a/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/name_mappings.md
@@ -171,7 +171,7 @@ $ cat /path/to/conf/name_mappings.conf
    ]
 }
 ```
-In addition, above mentioned Java-based regular expressions can be also used in new entity IDs.. For instance, if we want to rename certain entity IDs described as a string concatenated with a number, and we want to replace the string but maintaining the number:
+In addition, above mentioned Java-based regular expressions can be also used in new entity IDs. For instance, if we want to rename certain entity IDs described as a string concatenated with a number, and we want to replace the string but maintaining the number:
 
 ```
 {


### PR DESCRIPTION
Implements Issue #1456 .

The current behavior is that only RegEx Matching is allowed with a constant replacement. 
It will be nice to allow the use of reular expressions also in replacement.

E.g.  
        **Entities like**: _"Air_0001","Air_0002","Air_0003","Air_0004",..._
	**should be mapped like**: _"AirQualityObserved0001",..._
			
```javascript
{
  "serviceMappings": [{
    "originalService": "service",
    "newService": "new_service",
    "servicePathMappings": [{
      "originalServicePath": "/subservice",
      "newServicePath": "/new_subservice",
      "entityMappings": [{
        "originalEntityType": "entity_type",
        "originalEntityId": "(Air_)([0-9]*)",
        "newEntityId": "AirQualityObserved$2",
        "attributeMappings": []
      }]
    }]
  }]
}
```