### PR TITLE
Update Dockerfiles to add backend.enable option to Postgres

### DIFF
--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -134,6 +134,7 @@ ENV CYGNUS_POSTGRESQL_ATTR_PERSISTENCE ""
 ENV CYGNUS_POSTGRESQL_BATCH_SIZE ""
 ENV CYGNUS_POSTGRESQL_BATCH_TIMEOUT ""
 ENV CYGNUS_POSTGRESQL_BATCH_TTL ""
+ENV CYGNUS_POSTGRESQL_ENABLE_CACHE ""
 
 # Carto options
 ENV CYGNUS_CARTO_USER ""
@@ -231,10 +232,12 @@ RUN \
       ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
     rm -f ${FLUME_HOME}/plugins.d/cygnus/libext/cygnus-common-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
     rm -f ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
-    echo "INFO: Copy some files needed for starting cygnus-ngsi" && \
-    cp -p ${CYGNUS_HOME}/docker/cygnus-ngsi/cygnus-entrypoint.sh / && \
-    cp -p ${CYGNUS_HOME}/docker/cygnus-ngsi/agent.conf ${FLUME_HOME}/conf/ && \
-    cp -p ${CYGNUS_HOME}/docker/cygnus-ngsi/cartodb_keys.conf ${FLUME_HOME}/conf/
+
+
+COPY cygnus-entrypoint.sh / 
+COPY agent.conf ${FLUME_HOME}/conf/ 
+COPY agent.conf ${CYGNUS_HOME}/docker/cygnus-ngsi/agent.conf
+COPY cartodb_keys.conf ${FLUME_HOME}/conf/
 
 # Define the entry point
 ENTRYPOINT ["/cygnus-entrypoint.sh"]

--- a/docker/cygnus-ngsi/agent.conf
+++ b/docker/cygnus-ngsi/agent.conf
@@ -164,6 +164,7 @@ cygnus-ngsi.sinks.postgresql-sink.postgresql_password =
 #cygnus-ngsi.sinks.postgresql-sink.batch_size = 1
 #cygnus-ngsi.sinks.postgresql-sink.batch_timeout = 30
 #cygnus-ngsi.sinks.postgresql-sink.batch_ttl = 10
+#cygnus-ngsi.sinks.postgresql-sink.backend.enable_cache = false
 
 
 cygnus-ngsi.channels.mysql-channel.type = com.telefonica.iot.cygnus.channels.CygnusMemoryChannel

--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -349,6 +349,9 @@ if [ "$CYGNUS_POSTGRESQL_HOST" != "" ]; then
     if [ "$CYGNUS_POSTGRESQL_BATCH_TTL" != "" ]; then
         sed -i '/#'${CYGNUS_AGENT_NAME}'.sinks.postgresql-sink.batch_ttl/c '${CYGNUS_AGENT_NAME}'.sinks.postgresql-sink.batch_ttl = '${CYGNUS_POSTGRESQL_BATCH_TTL} ${FLUME_HOME}/conf/${AGENT_CONF_FILE}
     fi
+    if [ "$CYGNUS_POSTGRESQL_ENABLE_CACHE" != "" ]; then
+        sed -i '/#'${CYGNUS_AGENT_NAME}'.sinks.postgresql-sink.backend.enable_cache/c '${CYGNUS_AGENT_NAME}'.sinks.postgresql-sink.backend.enable_cache = '${CYGNUS_POSTGRESQL_ENABLE_CACHE} ${FLUME_HOME}/conf/${AGENT_CONF_FILE}
+    fi
 
     if [ "${CYGNUS_MULTIAGENT,,}" == "true" ]; then
         # Run the Cygnus command


### PR DESCRIPTION
I have been attempting to run a Dockerized Cygnus to connect to a Postgres database.  The changes in this PR enable me to do so.

Currently when I docker-compose using default values, I can't successfully add any data to Postgres since I get the #1467 issue. This is because the default value  (`postgresql-sink.backend.enable_cache = false` ) causes a null pointer error since the cache is uninitialized.

A value for `postgresql-sink.backend.enable_cache` does not exist in the `agent.conf` which is copied over when the entrypoint point is run, and no environment variable exists to override it, therefore I'm stuck with the broken default value without creating my own custom Docker file.

This amendment adds the default value (`false`) to the Docker `agent.conf` and ensures that the dummy file `agent.conf`  in the same folder as the `Dockerfile` gets copied into the image correctly. Note that `agent.conf` must be copied twice , since the docker-cygnus agent version is used if `CYGNUS_MULTIAGENT` is not set.  The default value can be overwritten using an environment variable (`CYGNUS_POSTGRESQL_ENABLE_CACHE`)

The `entrypoint` has been amended to copy the external configuration files into the container using the Docker `COPY` command rather than copying the internal files from within the downloaded github repository using the bash `cp` command. This allows a user to  more easily override the default dummy `agent.conf` with their own files regardless of whether `CYGNUS_MULTIAGENT` is set.

Using Docker `COPY`  is preferred, since ordinary users won't have push rights to the git repo - see #1418 which proposes similar changes. 

