### PR TITLE
Remove line concatenation from RUN command

### DIFF
--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -231,7 +231,7 @@ RUN \
       ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar.pack.gz \
       ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
     rm -f ${FLUME_HOME}/plugins.d/cygnus/libext/cygnus-common-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
-    rm -f ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar && \
+    rm -f ${FLUME_HOME}/plugins.d/cygnus/lib/cygnus-ngsi-${CYGNUS_VERSION}-jar-with-dependencies.jar
 
 
 COPY cygnus-entrypoint.sh / 


### PR DESCRIPTION
Fixing typo with #1492 

I'd left a line concatenation hanging on the committed Dockerfile it was therefore attempting to RUN the COPY command
