### PR TITLE
Updating default ports in documentation to use 5050 and 5080

### DIFF
--- a/doc/cygnus-common/installation_and_administration_guide/cygnus_agent_conf.md
+++ b/doc/cygnus-common/installation_and_administration_guide/cygnus_agent_conf.md
@@ -39,7 +39,7 @@ AGENT_NAME=cygnus-common
 # Name of the logfile located at /var/log/cygnus. It is important to put the extension '.log' in order to the log rotation works properly
 LOGFILE_NAME=cygnus.log
 # Administration port. Must be unique per instance
-ADMIN_PORT=8081
+ADMIN_PORT=5080
 # Polling interval (seconds) for the configuration reloading
 POLLING_INTERVAL=30
 ```

--- a/doc/cygnus-common/installation_and_administration_guide/diagnosis_procedures.md
+++ b/doc/cygnus-common/installation_and_administration_guide/diagnosis_procedures.md
@@ -52,20 +52,20 @@ Check the apender value is `LOG_FILE`.
 
 ## <a name="section2"></a>Problem: The API does not work
 ### <a name="section2.1"></a>Reason: There may be a problem with the configured port
-Check the port you are using in the request is the one configued in Cygnus. By default, it is `8081`, but can be modified by Cygnus administrator.
+Check the port you are using in the request is the one configued in Cygnus. By default, it is `5080`, but can be modified by Cygnus administrator.
 
 [Top](#top)
 
 ### <a name="section2.2"></a>Reason: The configured port is not open in the firewall
 The API port may be properly configured but not opened in the firewall (if such a firewall is running) protecting your machine.
 
-The specific solution depends on the specific firewall. Here, `iptables`-based firewalling is shown. Please, check the port is open (default `8081` is used in the examples):
+The specific solution depends on the specific firewall. Here, `iptables`-based firewalling is shown. Please, check the port is open (default `5080` is used in the examples):
 
 ```
 $ (sudo) iptables -L
 Chain INPUT (policy ACCEPT)
 target     prot opt source               destination
-ACCEPT     tcp  --  anywhere             anywhere            tcp dpt:8081
+ACCEPT     tcp  --  anywhere             anywhere            tcp dpt:5080
 
 Chain FORWARD (policy ACCEPT)
 target     prot opt source               destination
@@ -76,7 +76,7 @@ target     prot opt source               destination
 
 If not, open it:
 
-    $ (sudo) iptables -I INPUT -p tcp --dport 8081 -j ACCEPT
+    $ (sudo) iptables -I INPUT -p tcp --dport 5080 -j ACCEPT
 
 [Top](#top)
 

--- a/doc/cygnus-common/installation_and_administration_guide/install_with_docker.md
+++ b/doc/cygnus-common/installation_and_administration_guide/install_with_docker.md
@@ -77,7 +77,7 @@ SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 time=2016-05-17T06:36:23.867UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp= | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[166] : Starting Cygnus, version 1.0.0_SNAPSHOT.d7cfee4455a59a1854cc53f37e16ff4866b26010
 ...
 ...
-time=2016-05-17T06:36:25.046UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-common | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 8081 (Management Interface)
+time=2016-05-17T06:36:25.046UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-common | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 5080 (Management Interface)
 ```
 
 You can check the running container (in a second terminal shell):
@@ -85,7 +85,7 @@ You can check the running container (in a second terminal shell):
 ```
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS              PORTS                NAMES
-c88bc1b66cdc        cygnus-common       "/cygnus-entrypoint.   6 seconds ago       Up 5 seconds        5050/tcp, 8081/tcp   naughty_mayer  
+c88bc1b66cdc        cygnus-common       "/cygnus-entrypoint.   6 seconds ago       Up 5 seconds        5050/tcp, 5080/tcp   naughty_mayer  
 ```
 
 You can check the IP address of the container above by doing:
@@ -98,14 +98,14 @@ $ docker inspect c88bc1b66cdc | grep \"IPAddress\"
 Once the IP address of the container is gotten, you may ask for the Cygnus version (in a second terminal shell):
 
 ```
-$ curl "http://172.17.0.8:8081/v1/version"
+$ curl "http://172.17.0.8:5080/v1/version"
 {"success":"true","version":"1.0.0_SNAPSHOT.d7cfee4455a59a1854cc53f37e16ff4866b26010"}
 ```
 
 Even you can use API methods to see how to cygnus-common print the logs at INFO level.
 
 ```
-$ curl -X POST "http://172.17.0.7:8081/v1/subscriptions?ngsi_version=2" -d '{"subscription":{"description": "title_of_subscription","subject": {"entities": [{"idPattern": ".*","type": "Room"}],"condition": {"attrs": ["attr1"],"expression": {"q": "attr1>40"}}},"notification": {"http": {"url": "http://localhost:1234"},"attrs": ["attr1","attr2"]},"expires": "2016-05-05T14:00:00.00Z","throttling": 5}, "endpoint":{"host":"orion_host", "port":"orion_port", "ssl":"false", "xauthtoken":"your_auth_token"}}'
+$ curl -X POST "http://172.17.0.7:5080/v1/subscriptions?ngsi_version=2" -d '{"subscription":{"description": "title_of_subscription","subject": {"entities": [{"idPattern": ".*","type": "Room"}],"condition": {"attrs": ["attr1"],"expression": {"q": "attr1>40"}}},"notification": {"http": {"url": "http://localhost:1234"},"attrs": ["attr1","attr2"]},"expires": "2016-05-05T14:00:00.00Z","throttling": 5}, "endpoint":{"host":"orion_host", "port":"orion_port", "ssl":"false", "xauthtoken":"your_auth_token"}}'
 {"success":"true","result" : { SubscriptionID = 573ac3b6aba73680b1905f5c}
 ```
 

--- a/doc/cygnus-common/installation_and_administration_guide/management_interface.md
+++ b/doc/cygnus-common/installation_and_administration_guide/management_interface.md
@@ -336,7 +336,7 @@ Responses:
 
 Valid path to the instance configuration file:
 ```
-{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"5080","CONFIG_FOLDER":"\/usr\/cygnus\/conf","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}
 ```
 
 Invalid path to the instance configuration file:
@@ -414,7 +414,7 @@ Responses:
 Valid path to the instance configuration file:
 
 ```
-{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT_2":"8082","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"5080","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT_2":"5081","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
 ```
 
 Invalid path to the instance configuration file:
@@ -426,7 +426,7 @@ Invalid path to the instance configuration file:
 Existing value in the instance configuration file:
 
 ```
-{"success":"false","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT":"8081","CYGNUS_USER":"cygnus","LOGFILE_NAME":"cygnus.log","POLLING_INTERVAL":"30"}}}
+{"success":"false","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","CONFIG_FOLDER":"\/usr\/cygnus\/conf","ADMIN_PORT":"5080","CYGNUS_USER":"cygnus","LOGFILE_NAME":"cygnus.log","POLLING_INTERVAL":"30"}}}
 ```
 
 Instance configuration file not found:
@@ -456,13 +456,13 @@ Responses:
 Valid path to the instance configuration file. Adding `NEW_PARAM` with value `old_value`:
 
 ```
-{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","NEW_PARAM":"old_value","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"5080","CONFIG_FOLDER":"\/usr\/cygnus\/conf","NEW_PARAM":"old_value","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
 ```
 
 Valid path to the instance configuration file. Updating `NEW_PARAM` with value `new_value`:
 
 ```
-{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","NEW_PARAM":"new_value","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"5080","CONFIG_FOLDER":"\/usr\/cygnus\/conf","NEW_PARAM":"new_value","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
 ```
 
 Invalid path to the instance configuration file:
@@ -505,7 +505,7 @@ CONFIG_FILE=/usr/cygnus/conf/agent.conf
 AGENT_NAME=cygnus-common
 
 # Administration port. Must be unique per instance
-ADMIN_PORT=8081
+ADMIN_PORT=5080
 
 # Where is the config folder
 CONFIG_FOLDER=/usr/cygnus/conf
@@ -544,7 +544,7 @@ Responses:
 Valid path to the instance configuration file:
 
 ```
-{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"8081","CONFIG_FOLDER":"\/usr\/cygnus\/conf","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
+{"success":"true","result" : {"instance":{"CONFIG_FILE":"\/usr\/cygnus\/conf\/agent.conf","AGENT_NAME":"cygnus-common","ADMIN_PORT":"5080","CONFIG_FOLDER":"\/usr\/cygnus\/conf","LOGFILE_NAME":"cygnus.log","CYGNUS_USER":"cygnus","POLLING_INTERVAL":"30"}}}
 ```
 
 Inexisting value in the instance configuration file:

--- a/doc/cygnus-common/installation_and_administration_guide/running_as_process.md
+++ b/doc/cygnus-common/installation_and_administration_guide/running_as_process.md
@@ -18,7 +18,7 @@ The parameters used in these commands are:
 * `-Dflume.root.logger`. Changes the logging level and the logging appender for log4j.
 * `-Duser.timezone=UTC`. Changes the timezone in order all the timestamps (logs, data reception times, etc) are UTC.
 * `-Dfile.encoding=UTF-8`. Sets the JVM encoding to UTF-8.
-* `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `8081`.
-* `-g` (or `--web-app-port`). Configures the port where the web application for Cygnus runs. If not configured, the default value is used, `8082`.
+* `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `5080`.
+* `-g` (or `--web-app-port`). Configures the port where the web application for Cygnus runs. If not configured, the default value is used, `5050`.
 * `-t` (or `--polling-interval`). Configures the polling interval (seconds) when the configuration is periodically reloaded. If not configured, the default value is used, `30`.
 * `--no-yafs`. Disables Cygnus' [YAFS (Yet Another Flume Supervisor)](./yafs.md), a supervisor in charge of starting an ordered stop of Cygnus when some thread is found dead.

--- a/doc/cygnus-common/installation_and_administration_guide/sanity_checks.md
+++ b/doc/cygnus-common/installation_and_administration_guide/sanity_checks.md
@@ -63,7 +63,7 @@ time=2016-05-09T09:50:34.207CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | 
 time=2016-05-09T09:50:34.224CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=<init> | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.interceptors.CygnusGroupingRules[61] : Grouping rules read: {    "grouping_rules": [        {            "id": 1,            "fields": [                "servicePath"            ],            "regex": "/moba",            "destination": "newdest1",            "fiware_service_path": "/newservpath1"        },        {            "id": 2,            "fields": [                "entityType"            ],            "regex": "TYPEMATCH:2",            "destination": "newdest2",            "fiware_service_path": "/newservpath2"        },        {            "id": 3,            "fields": [                "entityId",                "entityType"            ],            "regex": "DEVMATCH:3TYPEMATCH:3",            "destination": "newdest3",            "fiware_service_path": "/newservpath3"        },        {            "id": 4,            "fields": [                "entityType"            ],            "regex": "Room",            "destination": "allrooms",            "fiware_service_path": "/rooms"        }      ]}
 time=2016-05-09T09:50:34.225CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=<init> | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.interceptors.CygnusGroupingRules[71] : Grouping rules syntax is OK
 time=2016-05-09T09:50:34.225CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=<init> | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.interceptors.CygnusGroupingRules[75] : Grouping rules regex'es have been compiled
-time=2016-05-09T09:50:34.407CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 8081 (Management Interface)
+time=2016-05-09T09:50:34.407CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 5080 (Management Interface)
 time=2016-05-09T09:50:34.683CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=register | comp=cygnus-ngsi | msg=org.apache.flume.instrumentation.MonitoredCounterGroup[110] : Monitoried counter group for type: SOURCE, name: http-source, registered successfully.
 time=2016-05-09T09:50:34.684CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=start | comp=cygnus-ngsi | msg=org.apache.flume.instrumentation.MonitoredCounterGroup[94] : Component type: SOURCE, name: http-source started
 ```
@@ -89,17 +89,17 @@ time=2016-05-09T09:50:34.225CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | 
 
 And the Management Interface is setup: 
 
-    time=2016-05-09T09:50:34.407CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 8081 (Management Interface)
+    time=2016-05-09T09:50:34.407CEST | lvl=INFO | corr= | trans= | svc= | subsvc= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 5080 (Management Interface)
 
 [Top](#top)
 
 ## <a name="section3"></a>Check: API port
-The API must be up and running in the port you configured (either using the `-p` option in the command line, either using the `ADMIN_PORT` parameter in the `cygnus_instance_<id>.conf` file). `8081` is the default.
+The API must be up and running in the port you configured (either using the `-p` option in the command line, either using the `ADMIN_PORT` parameter in the `cygnus_instance_<id>.conf` file). `5080` is the default.
 
 You can check it by asking for the Cygnus version:
 
 ```
-$ curl "http://localhost:8081/v1/version"
+$ curl "http://localhost:5080/v1/version"
 {"success":"true","version":"0.13.0_SNAPSHOT.180fd310917cade2f1f3f5f864610ea0b15907f9"}
 ```
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/configuration_examples.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/configuration_examples.md
@@ -305,7 +305,7 @@ CONFIG_FOLDER=/usr/cygnus/conf
 CONFIG_FILE=/usr/cygnus/conf/agent_all.conf
 AGENT_NAME=cygnus-ngsi
 LOGFILE_NAME=cygnus.log
-ADMIN_PORT=8081
+ADMIN_PORT=5080
 POLLING_INTERVAL=30
 ```
 
@@ -404,7 +404,7 @@ CONFIG_FOLDER=/usr/cygnus/conf
 CONFIG_FILE=/usr/cygnus/conf/agent_all.conf
 AGENT_NAME=cygnus-ngsi
 LOGFILE_NAME=cygnus.log
-ADMIN_PORT=8081
+ADMIN_PORT=5080
 POLLING_INTERVAL=30
 ```
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
@@ -78,7 +78,7 @@ SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 time=2016-05-05T09:57:55.150UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp= | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[166] : Starting Cygnus, version 0.13.0_SNAPSHOT.5200773899b468930e82df4a0b34d44fd4632893
 ...
 ...
-time=2016-05-05T09:57:56.287UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 8081 (Management Interface)
+time=2016-05-05T09:57:56.287UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-ngsi | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 5080 (Management Interface)
 ```
 
 You can check the running container (in a second terminal shell):
@@ -86,7 +86,7 @@ You can check the running container (in a second terminal shell):
 ```
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                CREATED              STATUS              PORTS                NAMES
-9ce0f09f5676        cygnus-ngsi         "/cygnus-entrypoint.   About a minute ago   Up About a minute   5050/tcp, 8081/tcp   focused_kilby
+9ce0f09f5676        cygnus-ngsi         "/cygnus-entrypoint.   About a minute ago   Up About a minute   5050/tcp, 5080/tcp   focused_kilby
 ```
 
 You can check the IP address of the container above by doing:
@@ -99,7 +99,7 @@ $ docker inspect 9ce0f09f5676 | grep \"IPAddress\"
 Once the IP address of the container is gotten, you may ask for the Cygnus version (in a second terminal shell):
 
 ```
-$ curl "http://172.17.0.13:8081/v1/version"
+$ curl "http://172.17.0.13:5080/v1/version"
 {"success":"true","version":"0.13.0_SNAPSHOT.5200773899b468930e82df4a0b34d44fd4632893"}
 ```
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/running_as_process.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/running_as_process.md
@@ -18,7 +18,7 @@ The parameters used in these commands are:
 * `-Dflume.root.logger`. Changes the logging level and the logging appender for log4j.
 * `-Duser.timezone=UTC`. Changes the timezone in order all the timestamps (logs, data reception times, etc) are UTC.
 * `-Dfile.encoding=UTF-8`. Sets the JVM encoding to UTF-8.
-* `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `8081`.
-* `-g` (or `--web-app-port`). Configures the port where the web application for Cygnus runs. If not configured, the default value is used, `8082`.
+* `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `5080`.
+* `-g` (or `--web-app-port`). Configures the port where the web application for Cygnus runs. If not configured, the default value is used, `5050`.
 * `-t` (or `--polling-interval`). Configures the polling interval (seconds) when the configuration is periodically reloaded. If not configured, the default value is used, `30`.
 * `--no-yafs`. Disables Cygnus' [YAFS (Yet Another Flume Supervisor)](../../cygnus-common/installation_and_administration_guide/yafs.md), a supervisor in charge of starting an ordered stop of Cygnus when some thread is found dead.

--- a/doc/cygnus-ngsi/integration/orion_cygnus_spark.md
+++ b/doc/cygnus-ngsi/integration/orion_cygnus_spark.md
@@ -127,7 +127,7 @@ CONFIG_FOLDER=/usr/cygnus/conf
 CONFIG_FILE=/usr/cygnus/conf/agent_spark.conf
 AGENT_NAME=cygnus-ngsi
 LOGFILE_NAME=cygnus.log
-ADMIN_PORT=8081
+ADMIN_PORT=5080
 POLLING_INTERVAL=30
 ```
 

--- a/doc/cygnus-twitter/installation_and_administration_guide/install_with_docker.md
+++ b/doc/cygnus-twitter/installation_and_administration_guide/install_with_docker.md
@@ -78,7 +78,7 @@ SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 time=2016-05-05T09:57:55.150UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp= | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[166] : Starting Cygnus, version 0.13.0_SNAPSHOT.5200773899b468930e82df4a0b34d44fd4632893
 ...
 ...
-time=2016-05-05T09:57:56.287UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-twitter | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 8081 (Management Interface)
+time=2016-05-05T09:57:56.287UTC | lvl=INFO | corr= | trans= | srv= | subsrv= | function=main | comp=cygnus-twitter | msg=com.telefonica.iot.cygnus.nodes.CygnusApplication[286] : Starting a Jetty server listening on port 5080 (Management Interface)
 ```
 
 You can check the running container (in a second terminal shell):
@@ -86,7 +86,7 @@ You can check the running container (in a second terminal shell):
 ```
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                CREATED              STATUS              PORTS                NAMES
-9ce0f09f5676        cygnus-twitter      "/cygnus-entrypoint.   About a minute ago   Up About a minute   5050/tcp, 8081/tcp   focused_kilby
+9ce0f09f5676        cygnus-twitter      "/cygnus-entrypoint.   About a minute ago   Up About a minute   5050/tcp, 5080/tcp   focused_kilby
 ```
 
 You can check the IP address of the container above by doing:
@@ -99,7 +99,7 @@ $ docker inspect 9ce0f09f5676 | grep \"IPAddress\"
 Once the IP address of the container is gotten, you may ask for the Cygnus version (in a second terminal shell):
 
 ```
-$ $ curl "http://172.17.0.13:8081/v1/version"
+$ $ curl "http://172.17.0.13:5080/v1/version"
 {"success":"true","version":"0.13.0_SNAPSHOT.5200773899b468930e82df4a0b34d44fd4632893"}
 ```
 


### PR DESCRIPTION
According to the latest Docker file **Cygnus**  now uses:

```
ENV CYGNUS_SERVICE_PORT "5050"
ENV CYGNUS_API_PORT "5080"
```

The existing documentation does not reflect this. It still uses 8080 and 8081


* Simple grep replacement - instead of 8081 use 5080 as a default port
* The listening port 8082 has been manually altered to 5050 as this is the current default