### PR TITLE
KafkaBackendImpl reuses zkClient

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,4 +4,5 @@
 [cygnus-ngsi][NGSIDynamoDBSink] [bug] Southeast regions are bad coded (#1448)
 [cygnus-common][CommonUtils][debug] Modify that CommonUtils#getTimeInstant can accepts the ISO8601 format with offset like 2018-01-02T03:04:05+09:00 (#1517)
 [cygnus-ngsi][Docker] Add new env var  CYGNUS_MONITORING_TYPE
+[cygnus-ngsi][KafkaSink] Using global connection to zookeeper instead of creating one each time an event arrives
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/kafka/KafkaBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/kafka/KafkaBackendImpl.java
@@ -37,6 +37,7 @@ public class KafkaBackendImpl implements KafkaBackend {
     private KafkaProducer<String, String> kafkaProducer;
     private static final CygnusLogger LOGGER = new CygnusLogger(KafkaBackendImpl.class);
     private final String zkEndpoint;
+    private ZkClient zookeeperClient;
     
     /**
      * Constructor.
@@ -51,18 +52,17 @@ public class KafkaBackendImpl implements KafkaBackend {
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         kafkaProducer = new KafkaProducer<String, String>(properties);
+        zookeeperClient = new ZkClient(zkEndpoint, 10000, 10000, ZKStringSerializer$.MODULE$);
     } // KafkaBackendImpl
 
     @Override
     public boolean topicExists(String topic) throws Exception {
         LOGGER.debug("Checking if topic '" + topic + "' already exists.");
-        ZkClient zookeeperClient = new ZkClient(zkEndpoint, 10000, 10000, ZKStringSerializer$.MODULE$);
         return AdminUtils.topicExists(zookeeperClient, topic);
     } // topicExists
 
     @Override
     public void createTopic(String topic, int partitions, int replicationFactor) {
-        ZkClient zookeeperClient = new ZkClient(zkEndpoint, 10000, 10000, ZKStringSerializer$.MODULE$);
         AdminUtils.createTopic(zookeeperClient, topic, partitions, replicationFactor, new Properties());
         LOGGER.debug("Creating topic: " + topic + " , partitions: " + partitions
                 + " , " + "replication factor: " + replicationFactor + ".");


### PR DESCRIPTION
NGSIKafkaSink opens too many connections to zookeeper, being blocked by the latter when the maximum allowed is reached. In previous versions of zookeeper, with no limit for client connections from the same IP, I have experienced out of memory issues, probably caused by the instances of zkClient continuously created. Apparently the sessions with zookeeper are never closed, so the instances are never deleted by the garbage collector.

I found out the KafkaBackendImpl creates an instance of zkClient every time it has to push data to Kafka, in order to check if the topic exists .  I modified KafkaBackendImpl so now it uses only an instance of zkClient (which is now a class attribute).