### PR TITLE
[NGSIRestHandler] Bad HTTP notification (application/json; charset=UTF-8 content type not supported)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,3 +8,4 @@
 - [cygnus-common][mongo] Upgrade mongo driver from 3.0.0 to 3.0.4
 - [cygnus-common] Upgrade flume-ng-node version from 1.4.0 to 1.9.0
 - [cygnus-twitter] Upgrade flume-ng-node version from 1.4.0 to 1.9.0
+- [cygnus-ngsi][NGSIRestHandler]Fix Content Type header validation issue. (#1609)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -393,7 +393,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
      * @return True is the header value length is wrong, otherwise false
      */
     protected boolean wrongContentType(String headerValue) {
-        return !headerValue.contains("application/json; charset=utf-8");
+        return !headerValue.toLowerCase(Locale.ENGLISH).contains("application/json; charset=utf-8");
     } // wrongContentType
     
     /**


### PR DESCRIPTION
Fix  issue #1609

When Apache Flume is updated to v1.9 unexpected "400 Bad request" was returned while sending data to Cygnus.