### PR TITLE
Fix errors in YML configuration file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: fiware-cygnus
 site_url: https://fiware-cygnus.readthedocs.org
-repo_url: https://github.com/telefonicaid/fiware-cygnus.git
+repo_url: https://github.com/telefonicaid/fiware-cygnus
 site_description: Cygnus Documentation
 docs_dir: doc
 site_dir: html


### PR DESCRIPTION
Links to GitHub in https://fiware-cygnus.readthedocs.io are broken for this reason.
Repo URL must be:
repo_url: https://github.com/telefonicaid/fiware-cygnus
Instead of
repo_url: https://github.com/telefonicaid/fiware-cygnus.git