### PR TITLE
Warn about index creation error instead of throw exception and about 

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -130,7 +130,7 @@ public class MongoBackendImpl implements MongoBackend {
                 db.getCollection(collectionName).createIndex(keys, options);
             } // if
         } catch (Exception e) {
-            throw e;
+            LOGGER.warn("Error in collection " + collectionName + " creating index ex=" + e.getMessage());
         } // try catch
     } // createCollection
 


### PR DESCRIPTION
extend https://github.com/telefonicaid/fiware-cygnus/pull/1650 to add other case
There are two `createCollecction` methods, one for STH and other for MongoDB. In both cases it seems good idea apply the same policy about index creation error.