### PR TITLE
[FIX] Fixing an error when the attr is a geo field

### DIFF
--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -459,6 +459,9 @@ public class NGSIPostgisSink extends NGSISink {
                                            swapCoordinates).getRight()) {
                     typedFieldNames += "," + attrName + " text," + attrName + "_md text";
                     fieldNames += "," + attrName + "," + attrName + "_md";
+                } else {
+                    typedFieldNames += "," + attrName + " " + DEFAULT_POSTGIS_TYPE + "," + attrName + "_md text";
+                    fieldNames += "," + attrName + "," + attrName + "_md";
                 }
             } // for
 
@@ -505,7 +508,7 @@ public class NGSIPostgisSink extends NGSISink {
 
                 if (location.right) {
                     LOGGER.debug("location=" + location.getLeft());
-                    column += ",'" + location.getLeft() + "','"  + attrMetadata;
+                    column += ",'" + location.getLeft() + "','"  + attrMetadata + "'";
 
                 } else {
                     // create part of the column with the current attribute (a.k.a. a column)


### PR DESCRIPTION
I found a bug when the attr persistence is in column mode and a geo var is captured, now, when the geo var is captured, it is added to attributes and the values properly.