### PR TITLE
Fix/mysql sink datetime

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+[cygnus-ngsi][MySQL] Fix datetime format used (#1646)
 [cygnus-ngsi][PostGIS] Fix geo location persistence bug in column mode

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -162,7 +162,7 @@ public final class CommonUtils {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         String humanRedable = sdf.format(new Date(ts));
-        humanRedable += "T";
+        humanRedable += (addUTC ? "T" : " ");
         sdf = new SimpleDateFormat("HH:mm:ss.S");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         humanRedable += sdf.format(new Date(ts)) + (addUTC ? "Z" : "");


### PR DESCRIPTION
fix issue https://github.com/telefonicaid/fiware-cygnus/issues/1646

Only  getHumanReadable is called with non UTC by MySQL sink, others always are using UTC format.