### PR TITLE
Revert "task/enable_JAVA_OPTS_for_flume"

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,5 +2,4 @@
 [cygnus-ngsi] Fix error response code from 501 to 404 in case of invalid API (#1630)
 [cygnus-ngsi][ArcGis] Add ArcGis sink (#1672)
 [cygnus-ngsi][Postgis, Cartodb] Fix double precision for coordinates
-[cygnus-flume] Enable JAVA_OPTS for flume (#1704)
 

--- a/cygnus-common/src/main/resources/cygnus-flume-ng
+++ b/cygnus-common/src/main/resources/cygnus-flume-ng
@@ -240,8 +240,7 @@ run_flume() {
 # set default params
 FLUME_CLASSPATH=""
 FLUME_JAVA_LIBRARY_PATH=""
-# Default JAVA_OPTS is -Xmx64m -Xms64m
-[[ "${JAVA_OPTS}" == "" ]] && JAVA_OPTS="-Xmx64m -Xms64m"
+JAVA_OPTS="-Xmx20m"
 LD_LIBRARY_PATH=""
 
 opt_conf=""

--- a/cygnus-ngsi/src/main/resources/cygnus-flume-ng
+++ b/cygnus-ngsi/src/main/resources/cygnus-flume-ng
@@ -240,8 +240,7 @@ run_flume() {
 # set default params
 FLUME_CLASSPATH=""
 FLUME_JAVA_LIBRARY_PATH=""
-# Default JAVA_OPTS is -Xmx64m -Xms64m
-[[ "${JAVA_OPTS}" == "" ]] && JAVA_OPTS="-Xmx64m -Xms64m"
+JAVA_OPTS="-Xmx20m"
 LD_LIBRARY_PATH=""
 
 opt_conf=""


### PR DESCRIPTION
Reverts telefonicaid/fiware-cygnus#1705

We have found that just after merging this PR dockerhub failed to build Cygnus. Let's try rolling it back and see what it happens.