### PR TITLE
Catch exception trying to close a invalid connection (MySQL and PostgreSQL)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+[cygnus-common][PostgreSQL][MySQL] catch exception close invalid connection
 [cygnus-common] Upgrade MongoDB driver from 3.0.4 to 3.11.0

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -462,7 +462,7 @@ public class MySQLBackendImpl implements MySQLBackend {
                         try {
                             connection.close();
                         } catch (SQLException e) {
-                            LOGGER.warn("error closing connection: " + e.getMessage());
+                            LOGGER.warn("error closing invalid connection: " + e.getMessage());
                         }
                     } // if
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -459,7 +459,11 @@ public class MySQLBackendImpl implements MySQLBackend {
                 if (connection == null || !connection.isValid(0)) {
                     if (connection != null) {
                         LOGGER.debug("Closing invalid mysql connection for db " + dbName);
-                        connection.close();
+                        try{
+                            connection.close();
+                        } catch (SQLException e) {
+                            LOGGER.warn("error closing connection: " + e.getMessage());
+                        }
                     } // if
 
                     DataSource datasource = createConnectionPool(dbName);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -459,7 +459,7 @@ public class MySQLBackendImpl implements MySQLBackend {
                 if (connection == null || !connection.isValid(0)) {
                     if (connection != null) {
                         LOGGER.debug("Closing invalid mysql connection for db " + dbName);
-                        try{
+                        try {
                             connection.close();
                         } catch (SQLException e) {
                             LOGGER.warn("error closing connection: " + e.getMessage());

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -284,7 +284,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
                         try {
                             connection.close();
                         } catch (SQLException e) {
-                            LOGGER.warn("error closing connection: " + e.getMessage());
+                            LOGGER.warn("error closing invalid connection: " + e.getMessage());
                         }
                     } // if
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -281,7 +281,11 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
                 if (connection == null || !connection.isValid(0)) {
                     if (connection != null) {
                         LOGGER.debug("Closing invalid postgresql connection for db " + schemaName);
-                        connection.close();
+                        try {
+                            connection.close();
+                        } catch (SQLException e) {
+                            LOGGER.warn("error closing connection: " + e.getMessage());
+                        }
                     } // if
 
                     DataSource datasource = createConnectionPool(schemaName);


### PR DESCRIPTION
Exception obtained:

time=2019-10-15T13:50:47.184Z | lvl=ERROR | corr=c7e49f04-ef52-11e9-ab2c-fa163e0e6feb | trans=43620604-b87a-4d3c-9ec9-2ccf6036bd80 | srv=sc_vlci | subsrv=/MedioAmbiente | op=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSISink[569] : CygnusPersistenceError (SQLException). Connection error (Already closed.). Stack trace: [com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver.getConnection(**MySQLBackendImpl.java:483**), com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl.insertContextData(**MySQLBackendImpl.java:170)**, com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistAggregation(NGSIMySQLSink.java:678), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistBatch(NGSIMySQLSink.java:242), com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:559), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:371), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:748)]
time=2019-10-15T13:50:47.184Z | lvl=ERROR | corr=c7e49f04-ef52-11e9-ab2c-fa163e0e6feb | trans=43620604-b87a-4d3c-9ec9-2ccf6036bd80 | srv=sc_vlci | subsrv=/MedioAmbiente | op=processNewBatches | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSISink[569] : CygnusPersistenceError (SQLException). Connection error (Already closed.). Stack trace: [com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl$MySQLDriver.getConnection(MySQLBackendImpl.java:483), com.telefonica.iot.cygnus.backends.mysql.MySQLBackendImpl.insertContextData(MySQLBackendImpl.java:170), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistAggregation(NGSIMySQLSink.java:678), com.telefonica.iot.cygnus.sinks.NGSIMySQLSink.persistBatch(NGSIMySQLSink.java:242), com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:559), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:371), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147), java.lang.Thread.run(Thread.java:748)]

https://github.com/telefonicaid/fiware-cygnus/blob/master/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java#L483