### PR TITLE
catch generic exception in transaction

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+[cygnus-ngsi][NGSISink] Catch generic exception and rollback in transacation
 [cygnus-common][PostgreSQL][MySQL] catch exception close invalid connection
 [cygnus-common] Upgrade MongoDB driver from 3.0.4 to 3.11.0

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -595,6 +595,9 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         } catch (ChannelException ex) {
             LOGGER.info("Rollback transaction by ChannelException  (" + ex.getMessage() + ")");
             txn.rollback();
+        } catch (Exception ex) {
+            LOGGER.info("Rollback transaction by Exception  (" + ex.getMessage() + ")");
+            txn.rollback();
         } finally {
             txn.close();
         }


### PR DESCRIPTION
and rollback it

Maybe this is happens when an unexpected exception (corner case):
```
| msg=org.apache.flume.SinkRunner$PollingRunner[160] : Unable to deliver event. Exception follows.
java.lang.IllegalStateException: close() called when transaction is OPEN - you must either commit or rollback first
                at com.google.common.base.Preconditions.checkState(Preconditions.java:172)
                at org.apache.flume.channel.BasicTransactionSemantics.close(BasicTransactionSemantics.java:179)
                at com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:599)
                at com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:371)
                at org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68)
                at org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147)
                at java.lang.Thread.run(Thread.java:748)
```


According with flume transaction
https://flume.apache.org/releases/content/1.8.0/apidocs/org/apache/flume/Transaction.html
current block is ok