### PR TITLE
Task/ngsiv2

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 Fix: Changing cygnus port does not work (#1698)
 [cygnus-commons][MongoBackend] Proper processing of mongo errors in create index operations (#1756)
+[cygnus-ngsi] Support for NGSIv2 notifications

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
 Fix: Changing cygnus port does not work (#1698)
 [cygnus-commons][MongoBackend] Proper processing of mongo errors in create index operations (#1756)
-[cygnus-ngsi] Support for NGSIv2 notifications
+[cygnus-ngsi] Support for NGSIv2 notifications (#953)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonConstants.java
@@ -40,6 +40,7 @@ public final class CommonConstants {
     public static final String HEADER_FIWARE_SERVICE      = "fiware-service";
     public static final String HEADER_FIWARE_SERVICE_PATH = "fiware-servicepath";
     public static final String HEADER_CORRELATOR_ID       = "fiware-correlator";
+    public static final String HEADER_NGSI_VERSION        = "ngsiv2-attrsformat";
     
     // Used by CKANBackendImpl... TBD: should not be here!!
     public static final String RECV_TIME_TS        = "recvTimeTs";

--- a/cygnus-ngsi/README.md
+++ b/cygnus-ngsi/README.md
@@ -163,7 +163,7 @@ $ ./notification-json-simple.sh http://localhost:5050/notify myservice myservice
 
 Or you can connect a real NGSI source such as [Orion Context Broker](https://github.com/telefonicaid/fiware-orion). Please, check the [User and Programmer Guide](../doc/cygnus-ngsi/user_and_programmer_guide/connecting_orion.md) for further details.
 
-Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](./resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+Support for NGSIv2 notifications has been added from version above 1.17.1. For this purpose, it's been added a new dir [/NGSIv2](./resources/ngsi-examples/NGSIv2) which contains script files in order to emulate some NGSIv2 notification types. 
 
 [Top](#top)
 

--- a/cygnus-ngsi/README.md
+++ b/cygnus-ngsi/README.md
@@ -163,6 +163,8 @@ $ ./notification-json-simple.sh http://localhost:5050/notify myservice myservice
 
 Or you can connect a real NGSI source such as [Orion Context Broker](https://github.com/telefonicaid/fiware-orion). Please, check the [User and Programmer Guide](../doc/cygnus-ngsi/user_and_programmer_guide/connecting_orion.md) for further details.
 
+Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](./resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+
 [Top](#top)
 
 ### <a name="section2.7"></a>Management API overview

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-compound.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-compound.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "field1" :  {
+          "type" : "type1",
+          "value" : { "a": "1", "b": "2" },
+          "metadata": {}
+        },
+      "field2" : {
+          "type" : "type2",
+          "value" : [ "v1", "v2" ],
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room2"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-geom.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-geom.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+        "temperature" : 
+          {
+            "type" : "centigrade",
+            "value" : "26.5",
+            "metadata": {}
+          },
+        "the_geom" : 
+          {
+            "type" : "geometry",
+            "value" : "$4, $5",
+            "metadata": {
+              "location": {
+                "type": "string",
+                "value": "WGS84"
+              }
+            }
+          },
+        "type" : "Car",
+        "id" : "Car1"
+      }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-md.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-md.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json: charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "temperature": {
+        "type" : "centigrade",
+        "value" : "26.5",
+        "metadata": {}
+      },
+      "pressure": {
+        "type" : "mmhg",
+        "value" : "720",
+        "metadata": {
+          "ID": {
+            "type": "string",
+            "value": "ground"
+          }
+        }
+      },
+      "humidity": {
+        "type" : "percentage",
+        "value" : "42",
+        "metadata": {}
+      },
+      "type" : "Room",
+      "id" : "Room1"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-modelentity.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-modelentity.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "id": "netrisModel",
+      "type": "model",
+      "TimeInstant": {
+          "type": "ISO8601",
+          "value": "2014-03-20T14:21:14Z",
+          "metadata": {}
+        },
+      "ModelProp1": {
+        "type": "String",
+        "value": "abc",
+        "metadata": {}
+      },
+      "ModelProp2": {
+        "type": "String",
+        "value": "def",
+        "metadata": {}
+      },
+      "et": {
+        "type": "compound",
+        "value":
+          {
+            "name": "external temperature",
+            "phenomenon": "temperature",
+            "type": "Quantity",
+            "uom": "Cel",
+            "persistence": [ "sth", "ckan" ]
+          },
+        "metadata": {}
+      },
+      "internal temperature": {
+        "type": "compound",
+        "value": [
+          {
+            "name": "internal temperature",
+            "phenomenon": "temperature",
+            "type": "Quantity",
+            "uom": "Cel"
+          }
+        ],
+        "metadata": {}
+      },
+      "h": {
+        "type": "compound",
+        "value": [
+          {
+            "name": "house humidity",
+            "phenomenon": "humidity",
+            "type": "Quantity",
+            "uom": "%"
+          }
+        ],
+        "metadata": {}
+      },
+      "reset": {
+        "type": "compound",
+        "value": [
+          {
+            "type": "action",
+            "input_params": "reqTimeInstant,correlatorID,param_a,param_b",
+            "output_params": "result,resTimeIntant,param_c,param_d"
+          }
+        ],
+        "metadata": {}
+      },
+      "color": {
+        "type": "compound",
+        "value": [
+          {
+            "type": "action",
+            "input_params": "reqTimeInstant,correlatorID",
+            "output_params": "result,resTimeInstant"
+          }
+        ],
+        "metadata": {}
+      }
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple-correct.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple-correct.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+if [ "$4" != "" ]
+then
+   SERVICE_PATH2=$4
+else
+   SERVICE_PATH2=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH,$SERVICE_PATH2" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "temperature" : {
+          "type" : "centigrade",
+          "value" : "26.5",
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room.1"
+    },
+    {
+      "temperature" : {
+          "type" : "centigrade",
+          "value" : "19.3",
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room.suite"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized"-d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "temperature" : {
+          "type" : "centigrade",
+          "value" : "26.5",
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room.1"
+    },
+    {
+      "temperature" : {
+          "type" : "centigrade",
+          "value" : "19.3",
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room.suite"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-multiple.sh
@@ -37,7 +37,7 @@ else
    SERVICE_PATH=/
 fi
 
-curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized"-d @- <<EOF
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
 {
   "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
   "data" : [

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-simple.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-simple.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a1",
+  "data" : [
+    {
+      "temperature" : {
+        "type" : "centigrade",
+        "value" : "26.5",
+        "metadata": {}
+      },
+      "type" : "Room",
+      "id" : "Room1"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-timeinstant.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-timeinstant.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+	"subscriptionId": "56e2ad4e8001ff5e0a5260ec",
+	"data": [{
+		"type": "Car",
+		"id": "Car1",
+		"temperature": {
+			"type": "centigrade",
+			"value": "26.5",
+			"metadata": {
+				"TimeInstant": {
+					"type": "recvTime",
+					"value": "2015-12-12 11:11:11.123"
+				}
+			}
+		}
+	}]
+}
+EOF

--- a/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-utf8.sh
+++ b/cygnus-ngsi/resources/ngsi-examples/NGSIv2/notification-json-utf8.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of fiware-cygnus.
+#
+# fiware-cygnus is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fiware-cygnus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with fiware-cygnus. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# francisco.romerobueno@telefonica.com
+
+# This script is aimed to Cygnus debugging.
+
+URL=$1
+
+if [ "$2" != "" ]
+then
+   SERVICE=$2
+else
+   SERVICE=default
+fi
+
+if [ "$3" != "" ]
+then
+   SERVICE_PATH=$3
+else
+   SERVICE_PATH=/
+fi
+
+curl $URL -v -s -S --header 'Content-Type: application/json; charset=utf-8' --header 'Accept: application/json' --header 'User-Agent: orion/0.10.0' --header "Fiware-Service: $SERVICE" --header "Fiware-ServicePath: $SERVICE_PATH" --header "ngsiv2-attrsformat: normalized" -d @- <<EOF
+{
+  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+  "data" : [
+    {
+      "owner" : 
+        {
+          "type" : "string",
+          "value" : "Íñigo",
+          "metadata": {}
+        },
+      "type" : "Room",
+      "id" : "Room1"
+    }
+  ]
+}
+EOF

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequest.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequest.java
@@ -112,7 +112,7 @@ public class NotifyContextRequest {
     /**
      * Class for storing contextElementResponse information from a notifyContextRequest.
      */
-    public class ContextElementResponse {
+    public static class ContextElementResponse {
         
         private ContextElement contextElement;
         private StatusCode statusCode;
@@ -163,7 +163,7 @@ public class NotifyContextRequest {
     /**
      * Class for storing contextElement information from a notifyContextRequest.
      */
-    public class ContextElement {
+    public static class ContextElement {
         
         private ArrayList<ContextAttribute> attributes;
         private String type;
@@ -295,7 +295,7 @@ public class NotifyContextRequest {
     /**
      * Class for storing contextAttribute information from a notifyContextRequest.
      */
-    public class ContextAttribute {
+    public static class ContextAttribute {
     
         private String name;
         private String type;
@@ -445,7 +445,7 @@ public class NotifyContextRequest {
     /**
      * Class for storing contextMetadata information from a contestAttribute.
      */
-    public class ContextMetadata {
+    public static class ContextMetadata {
         
         private String name;
         private String type;
@@ -513,7 +513,7 @@ public class NotifyContextRequest {
     /**
      * Class for storing statusCode information from a notifyContextRequest.
      */
-    public class StatusCode {
+    public static class StatusCode {
         
         private String code;
         private String reasonPhrase;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
@@ -31,7 +31,7 @@ public class NotifyContextRequestNGSIv2 {
     private ArrayList <Data> data;
 
     /**
-     * Gets subscription id.
+     * Gets subscription id from NGSIv2 Object.
      *
      * @return the subscription id
      */
@@ -40,7 +40,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * Sets subscription id.
+     * Sets subscription id for NGSIv2 Object.
      *
      * @param subscriptionId the subscription id
      */
@@ -49,7 +49,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * Gets data.
+     * Gets data object from NGSIv2 Object.
      *
      * @return the data
      */
@@ -58,7 +58,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * Sets data.
+     * Sets data object for NGSIv2 Object.
      *
      * @param data the data
      */
@@ -68,10 +68,10 @@ public class NotifyContextRequestNGSIv2 {
 
 
     /**
-     * To notify context request notify context request.
-     * This casts NotifyContextRequestNGSIv2 to NotifyContextRequest
+     * notifycontextrequestNGSIv2 object to notifycontextrequest object.
+     * This function casts NotifyContextRequestNGSIv2 object to NotifyContextRequest object
      *
-     * @return the notify context request
+     * @return the notifycontextrequest
      */
     public NotifyContextRequest toNotifyContextRequest() {
         NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
@@ -87,7 +87,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * The type Data.
+     * Class that contains data objects from NGSIv2 object
      */
     public static class Data {
 
@@ -96,7 +96,7 @@ public class NotifyContextRequestNGSIv2 {
         private Map<String, Attribute> attributes;
 
         /**
-         * Gets id.
+         * Gets id from NGSIv2.Data object.
          *
          * @return the id
          */
@@ -105,7 +105,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets id.
+         * Sets id for NGSIv2.Data object.
          *
          * @param id the id
          */
@@ -114,7 +114,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Gets type.
+         * Gets type from NGSIv2.Data object.
          *
          * @return the type
          */
@@ -123,7 +123,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets type.
+         * Sets type for NGSIv2.Data object.
          *
          * @param type the type
          */
@@ -132,7 +132,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Gets atributes.
+         * Gets atributes from NGSIv2.Data object.
          *
          * @return the atributes
          */
@@ -141,7 +141,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets atributes.
+         * Sets atributes for NGSIv2.Data object.
          *
          * @param atributes the atributes
          */
@@ -150,9 +150,10 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Data to context element notify context request . context element.
+         * dataToContextElement Data object to NotifyContextRequest.ContextElement object.
+         * This function casts NotifyContextRequestNGSIv2.Data object to NotifyContextRequest.ContextElement object
          *
-         * @return the notify context request . context element
+         * @return the NotifyContextRequest.ContextElement object
          */
         public NotifyContextRequest.ContextElement dataToContextElement () {
             NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
@@ -168,7 +169,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * The type Attribute.
+     * Class that contains attribute objects from NGSIv2.Data object
      */
     public static class Attribute {
         private JsonElement value;
@@ -176,7 +177,7 @@ public class NotifyContextRequestNGSIv2 {
         private Map<String, Metadata> metadata;
 
         /**
-         * Gets value.
+         * Gets value from NGSIv2.Attribute object.
          *
          * @return the value
          */
@@ -185,7 +186,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets value.
+         * Sets value for data NGSIv2.Attribute object.
          *
          * @param value the value
          */
@@ -194,7 +195,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Gets type.
+         * Gets type from NGSIv2.Attribute object.
          *
          * @return the type
          */
@@ -203,7 +204,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets type.
+         * Sets type for NGSIv2.Attribute object.
          *
          * @param type the type
          */
@@ -212,7 +213,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Gets metadata.
+         * Gets metadata from NGSIv2.Attribute object.
          *
          * @return the metadata
          */
@@ -221,7 +222,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets metadata.
+         * Sets metadata for NGSIv2.Attribute object.
          *
          * @param metadata the metadata
          */
@@ -230,10 +231,11 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Attribute to context attribute notify context request . context attribute.
+         * dataToContextAttribute Attribute object to NotifyContextRequest.ContextAttribute object.
+         * This function casts NotifyContextRequestNGSIv2.Attribute object to NotifyContextRequest.ContextAttribute object
          *
-         * @param name the name
-         * @return the notify context request . context attribute
+         * @param name the name of the attribute
+         * @return the NotifyContextRequest.ContextAttribute object
          */
         public NotifyContextRequest.ContextAttribute attributeToContextAttribute (String name) {
             NotifyContextRequest.ContextAttribute contextAttribute = new NotifyContextRequest.ContextAttribute();
@@ -250,7 +252,7 @@ public class NotifyContextRequestNGSIv2 {
     }
 
     /**
-     * The type Metadata.
+     * Class that contains metadata objects from NGSIv2.Attribute object
      */
     public static class Metadata {
 
@@ -258,7 +260,7 @@ public class NotifyContextRequestNGSIv2 {
         private String type;
 
         /**
-         * Gets value.
+         * Gets value from NGSIv2.Metadata object.
          *
          * @return the value
          */
@@ -267,7 +269,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets value.
+         * Sets value for NGSIv2.Metadata object.
          *
          * @param value the value
          */
@@ -276,7 +278,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Gets type.
+         * Gets type from NGSIv2.Metadata object.
          *
          * @return the type
          */
@@ -285,7 +287,7 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Sets type.
+         * Sets type for NGSIv2.Metadata object.
          *
          * @param type the type
          */
@@ -294,10 +296,11 @@ public class NotifyContextRequestNGSIv2 {
         }
 
         /**
-         * Metadata to context metadata notify context request . context metadata.
+         * dataToContextMetadata Metadata object to NotifyContextRequest.ContextMetadata object.
+         * This function casts NotifyContextRequestNGSIv2.Metadata object to NotifyContextRequest.ContextMetadata object
          *
-         * @param name the name
-         * @return the notify context request . context metadata
+         * @param name the name of the metadata
+         * @return the NotifyContextRequest.ContextMetadata object.
          */
         public NotifyContextRequest.ContextMetadata metadataToContextMetadata (String name) {
             NotifyContextRequest.ContextMetadata contextMetadata = new NotifyContextRequest.ContextMetadata();

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2014-2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
 package com.telefonica.iot.cygnus.containers;
 
 import com.google.gson.JsonElement;
@@ -5,28 +22,57 @@ import com.google.gson.JsonElement;
 import java.util.ArrayList;
 import java.util.Map;
 
+/**
+ * The type Notify context request ngs iv 2.
+ */
 public class NotifyContextRequestNGSIv2 {
 
     private String subscriptionId;
     private ArrayList <Data> data;
 
+    /**
+     * Gets subscription id.
+     *
+     * @return the subscription id
+     */
     public String getSubscriptionId() {
         return subscriptionId;
     }
 
+    /**
+     * Sets subscription id.
+     *
+     * @param subscriptionId the subscription id
+     */
     public void setSubscriptionId(String subscriptionId) {
         this.subscriptionId = subscriptionId;
     }
 
+    /**
+     * Gets data.
+     *
+     * @return the data
+     */
     public ArrayList<Data> getData() {
         return data;
     }
 
+    /**
+     * Sets data.
+     *
+     * @param data the data
+     */
     public void setData(ArrayList<Data> data) {
         this.data = data;
     }
 
 
+    /**
+     * To notify context request notify context request.
+     * This casts NotifyContextRequestNGSIv2 to NotifyContextRequest
+     *
+     * @return the notify context request
+     */
     public NotifyContextRequest toNotifyContextRequest() {
         NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
         notifyContextRequest.setSubscriptionId(this.subscriptionId);
@@ -40,36 +86,74 @@ public class NotifyContextRequestNGSIv2 {
         return notifyContextRequest;
     }
 
+    /**
+     * The type Data.
+     */
     public static class Data {
 
         private String id;
         private String type;
         private Map<String, Attribute> attributes;
 
+        /**
+         * Gets id.
+         *
+         * @return the id
+         */
         public String getId() {
             return id;
         }
 
+        /**
+         * Sets id.
+         *
+         * @param id the id
+         */
         public void setId(String id) {
             this.id = id;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public String getType() {
             return type;
         }
 
+        /**
+         * Sets type.
+         *
+         * @param type the type
+         */
         public void setType(String type) {
             this.type = type;
         }
 
+        /**
+         * Gets atributes.
+         *
+         * @return the atributes
+         */
         public Map<String, Attribute> getAtributes() {
             return attributes;
         }
 
+        /**
+         * Sets atributes.
+         *
+         * @param atributes the atributes
+         */
         public void setAtributes(Map<String, Attribute> atributes) {
             this.attributes = atributes;
         }
 
+        /**
+         * Data to context element notify context request . context element.
+         *
+         * @return the notify context request . context element
+         */
         public NotifyContextRequest.ContextElement dataToContextElement () {
             NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
             contextElement.setId(this.id);
@@ -83,35 +167,74 @@ public class NotifyContextRequestNGSIv2 {
         }
     }
 
+    /**
+     * The type Attribute.
+     */
     public static class Attribute {
         private JsonElement value;
         private String type;
         private Map<String, Metadata> metadata;
 
+        /**
+         * Gets value.
+         *
+         * @return the value
+         */
         public JsonElement getValue() {
             return value;
         }
 
+        /**
+         * Sets value.
+         *
+         * @param value the value
+         */
         public void setValue(JsonElement value) {
             this.value = value;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public String getType() {
             return type;
         }
 
+        /**
+         * Sets type.
+         *
+         * @param type the type
+         */
         public void setType(String type) {
             this.type = type;
         }
 
+        /**
+         * Gets metadata.
+         *
+         * @return the metadata
+         */
         public Map<String, Metadata> getMetadata() {
             return metadata;
         }
 
+        /**
+         * Sets metadata.
+         *
+         * @param metadata the metadata
+         */
         public void setMetadata(Map<String, Metadata> metadata) {
             this.metadata = metadata;
         }
 
+        /**
+         * Attribute to context attribute notify context request . context attribute.
+         *
+         * @param name the name
+         * @return the notify context request . context attribute
+         */
         public NotifyContextRequest.ContextAttribute attributeToContextAttribute (String name) {
             NotifyContextRequest.ContextAttribute contextAttribute = new NotifyContextRequest.ContextAttribute();
             contextAttribute.setName(name);
@@ -126,27 +249,56 @@ public class NotifyContextRequestNGSIv2 {
         }
     }
 
+    /**
+     * The type Metadata.
+     */
     public static class Metadata {
 
         private JsonElement value;
         private String type;
 
+        /**
+         * Gets value.
+         *
+         * @return the value
+         */
         public JsonElement getValue() {
             return value;
         }
 
+        /**
+         * Sets value.
+         *
+         * @param value the value
+         */
         public void setValue(JsonElement value) {
             this.value = value;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public String getType() {
             return type;
         }
 
+        /**
+         * Sets type.
+         *
+         * @param type the type
+         */
         public void setType(String type) {
             this.type = type;
         }
 
+        /**
+         * Metadata to context metadata notify context request . context metadata.
+         *
+         * @param name the name
+         * @return the notify context request . context metadata
+         */
         public NotifyContextRequest.ContextMetadata metadataToContextMetadata (String name) {
             NotifyContextRequest.ContextMetadata contextMetadata = new NotifyContextRequest.ContextMetadata();
             contextMetadata.setName(name);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.TreeMap;
 
 public class NotifyContextRequestNGSIv2 {
 
@@ -31,7 +30,7 @@ public class NotifyContextRequestNGSIv2 {
     public NotifyContextRequest toNotifyContextRequest() {
         NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
         notifyContextRequest.setSubscriptionId(this.subscriptionId);
-        ArrayList<NotifyContextRequest.ContextElementResponse> contextElementResponses = null;
+        ArrayList<NotifyContextRequest.ContextElementResponse> contextElementResponses = new ArrayList<NotifyContextRequest.ContextElementResponse>();
         for (Data dataElement : data) {
             NotifyContextRequest.ContextElementResponse contextElementResponse = new NotifyContextRequest.ContextElementResponse();
             contextElementResponse.setContextElement(dataElement.dataToContextElement());
@@ -41,11 +40,11 @@ public class NotifyContextRequestNGSIv2 {
         return notifyContextRequest;
     }
 
-    public class Data {
+    public static class Data {
 
         private String id;
         private String type;
-        private TreeMap<String, Attribute> attributes;
+        private Map<String, Attribute> attributes;
 
         public String getId() {
             return id;
@@ -67,7 +66,7 @@ public class NotifyContextRequestNGSIv2 {
             return attributes;
         }
 
-        public void setAtributes(TreeMap<String, Attribute> atributes) {
+        public void setAtributes(Map<String, Attribute> atributes) {
             this.attributes = atributes;
         }
 
@@ -75,15 +74,16 @@ public class NotifyContextRequestNGSIv2 {
             NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
             contextElement.setId(this.id);
             contextElement.setType(this.type);
-            ArrayList<NotifyContextRequest.ContextAttribute> attributes = null;
+            ArrayList<NotifyContextRequest.ContextAttribute> attributes = new ArrayList<NotifyContextRequest.ContextAttribute>();
             for(Map.Entry<String, Attribute> map : this.attributes.entrySet()) {
                 attributes.add(map.getValue().attributeToContextAttribute(map.getKey()));
             }
+            contextElement.setAttributes(attributes);
                 return contextElement;
         }
     }
 
-    public class Attribute {
+    public static class Attribute {
         private JsonElement value;
         private String type;
         private Map<String, Metadata> metadata;
@@ -108,7 +108,7 @@ public class NotifyContextRequestNGSIv2 {
             return metadata;
         }
 
-        public void setMetadata(TreeMap<String, Metadata> metadata) {
+        public void setMetadata(Map<String, Metadata> metadata) {
             this.metadata = metadata;
         }
 
@@ -117,15 +117,16 @@ public class NotifyContextRequestNGSIv2 {
             contextAttribute.setName(name);
             contextAttribute.setType(this.type);
             contextAttribute.setContextValue(this.value);
-            ArrayList<NotifyContextRequest.ContextMetadata> metadatas = null;
+            ArrayList<NotifyContextRequest.ContextMetadata> metadatas = new ArrayList<NotifyContextRequest.ContextMetadata>();
             for(Map.Entry<String, Metadata> map : this.metadata.entrySet()) {
                 metadatas.add(map.getValue().metadataToContextMetadata(map.getKey()));
             }
+            contextAttribute.setContextMetadata(metadatas);
             return contextAttribute;
         }
     }
 
-    public class Metadata {
+    public static class Metadata {
 
         private JsonElement value;
         private String type;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 /**
- * The type Notify context request ngs iv 2.
+ * The type Notify context request NGSIv2.
  */
 public class NotifyContextRequestNGSIv2 {
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/containers/NotifyContextRequestNGSIv2.java
@@ -1,0 +1,157 @@
+package com.telefonica.iot.cygnus.containers;
+
+import com.google.gson.JsonElement;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class NotifyContextRequestNGSIv2 {
+
+    private String subscriptionId;
+    private ArrayList <Data> data;
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public void setSubscriptionId(String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public ArrayList<Data> getData() {
+        return data;
+    }
+
+    public void setData(ArrayList<Data> data) {
+        this.data = data;
+    }
+
+
+    public NotifyContextRequest toNotifyContextRequest() {
+        NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
+        notifyContextRequest.setSubscriptionId(this.subscriptionId);
+        ArrayList<NotifyContextRequest.ContextElementResponse> contextElementResponses = null;
+        for (Data dataElement : data) {
+            NotifyContextRequest.ContextElementResponse contextElementResponse = new NotifyContextRequest.ContextElementResponse();
+            contextElementResponse.setContextElement(dataElement.dataToContextElement());
+            contextElementResponses.add(contextElementResponse);
+        }
+        notifyContextRequest.setContextResponses(contextElementResponses);
+        return notifyContextRequest;
+    }
+
+    public class Data {
+
+        private String id;
+        private String type;
+        private TreeMap<String, Attribute> attributes;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public Map<String, Attribute> getAtributes() {
+            return attributes;
+        }
+
+        public void setAtributes(TreeMap<String, Attribute> atributes) {
+            this.attributes = atributes;
+        }
+
+        public NotifyContextRequest.ContextElement dataToContextElement () {
+            NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
+            contextElement.setId(this.id);
+            contextElement.setType(this.type);
+            ArrayList<NotifyContextRequest.ContextAttribute> attributes = null;
+            for(Map.Entry<String, Attribute> map : this.attributes.entrySet()) {
+                attributes.add(map.getValue().attributeToContextAttribute(map.getKey()));
+            }
+                return contextElement;
+        }
+    }
+
+    public class Attribute {
+        private JsonElement value;
+        private String type;
+        private Map<String, Metadata> metadata;
+
+        public JsonElement getValue() {
+            return value;
+        }
+
+        public void setValue(JsonElement value) {
+            this.value = value;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public Map<String, Metadata> getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(TreeMap<String, Metadata> metadata) {
+            this.metadata = metadata;
+        }
+
+        public NotifyContextRequest.ContextAttribute attributeToContextAttribute (String name) {
+            NotifyContextRequest.ContextAttribute contextAttribute = new NotifyContextRequest.ContextAttribute();
+            contextAttribute.setName(name);
+            contextAttribute.setType(this.type);
+            contextAttribute.setContextValue(this.value);
+            ArrayList<NotifyContextRequest.ContextMetadata> metadatas = null;
+            for(Map.Entry<String, Metadata> map : this.metadata.entrySet()) {
+                metadatas.add(map.getValue().metadataToContextMetadata(map.getKey()));
+            }
+            return contextAttribute;
+        }
+    }
+
+    public class Metadata {
+
+        private JsonElement value;
+        private String type;
+
+        public JsonElement getValue() {
+            return value;
+        }
+
+        public void setValue(JsonElement value) {
+            this.value = value;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public NotifyContextRequest.ContextMetadata metadataToContextMetadata (String name) {
+            NotifyContextRequest.ContextMetadata contextMetadata = new NotifyContextRequest.ContextMetadata();
+            contextMetadata.setName(name);
+            contextMetadata.setType(type);
+            contextMetadata.setContextMetadata(value);
+            return contextMetadata;
+        }
+    }
+}

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -22,6 +22,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElementResponse;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequestNGSIv2;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.CommonConstants;
@@ -321,6 +322,7 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
         
         // Parse the original data into a NotifyContextRequest object
         NotifyContextRequest ncr = null;
+        NotifyContextRequestNGSIv2 notifyContextRequestNGSIv2 = null;
         Gson gson = new Gson();
 
         try {
@@ -331,7 +333,9 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
                         LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on legacy NGSI: " + ncr.toString());
                         break;
                     case "normalized":
-                        LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on normalized NGSIv2: ");
+                        notifyContextRequestNGSIv2 = gson.fromJson(data, NotifyContextRequestNGSIv2.class);
+                        ncr = notifyContextRequestNGSIv2.toNotifyContextRequest();
+                        LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on normalized NGSIv2: " + notifyContextRequestNGSIv2.toString());
                         break;
                     default:
                         LOGGER.warn("Unknown value: " + ngsiVersion + " for NGSI format");
@@ -382,7 +386,9 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
             headers.put(NGSIConstants.FLUME_HEADER_TRANSACTION_ID, transId);
             LOGGER.debug("[NGSIRestHandler] Header added to NGSI event ("
                     + NGSIConstants.FLUME_HEADER_TRANSACTION_ID + ": " + transId + ")");
-            
+            headers.put(CommonConstants.HEADER_NGSI_VERSION, ngsiVersion);
+            LOGGER.debug("[NGSIRestHandler] Header added to NGSI event ("
+                    + CommonConstants.HEADER_NGSI_VERSION + ": " + ngsiVersion+ ")");
             // Create the NGSI event and add it to the list
             NGSIEvent ngsiEvent = new NGSIEvent(
                     // Headers

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandler.java
@@ -19,6 +19,7 @@
 package com.telefonica.iot.cygnus.handlers;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest.ContextElementResponse;
@@ -34,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import com.telefonica.iot.cygnus.utils.NotifyContextRequestNGSIv2Deserializer;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.source.http.HTTPBadRequestException;
@@ -333,14 +336,14 @@ public class NGSIRestHandler extends CygnusHandler implements HTTPSourceHandler 
                         LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on legacy NGSI: " + ncr.toString());
                         break;
                     case "normalized":
+                        gson = new GsonBuilder().registerTypeAdapter(NotifyContextRequestNGSIv2.class, new NotifyContextRequestNGSIv2Deserializer()).create();
                         notifyContextRequestNGSIv2 = gson.fromJson(data, NotifyContextRequestNGSIv2.class);
                         ncr = notifyContextRequestNGSIv2.toNotifyContextRequest();
-                        LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on normalized NGSIv2: " + notifyContextRequestNGSIv2.toString());
+                        LOGGER.debug("[NGSIRestHandler] Parsed NotifyContextRequest on normalized NGSIv2: " + ncr.toString());
                         break;
                     default:
                         LOGGER.warn("Unknown value: " + ngsiVersion + " for NGSI format");
-                        throw new HTTPBadRequestException(ngsiVersion
-                                + " format not supported");
+                        throw new HTTPBadRequestException(ngsiVersion + " format not supported");
                 }
             } else {
                 ncr = gson.fromJson(data, NotifyContextRequest.class);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NotifyContextRequestNGSIv2Deserializer.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NotifyContextRequestNGSIv2Deserializer.java
@@ -1,0 +1,86 @@
+package com.telefonica.iot.cygnus.utils;
+
+import com.google.gson.*;
+import com.google.gson.JsonObject;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequestNGSIv2;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequestNGSIv2.Attribute;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequestNGSIv2.Data;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequestNGSIv2.Metadata;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class NotifyContextRequestNGSIv2Deserializer implements JsonDeserializer<NotifyContextRequestNGSIv2> {
+
+    @Override
+    public NotifyContextRequestNGSIv2 deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        String subscriptionId = jsonObject.get("subscriptionId").getAsString();
+        ArrayList<Data> data = deserializeAllData(jsonObject.getAsJsonArray("data"));
+        NotifyContextRequestNGSIv2 ncr = new NotifyContextRequestNGSIv2();
+        ncr.setSubscriptionId(subscriptionId);
+        ncr.setData(data);
+        return ncr;
+    }
+
+    private ArrayList<Data> deserializeAllData(JsonArray jsonArray) {
+        ArrayList<Data> dataList = new ArrayList<>(jsonArray.size());
+        for (JsonElement element : jsonArray) {
+            dataList.add(deserializeData(element.getAsJsonObject()));
+        }
+        return dataList;
+    }
+
+    private Data deserializeData(JsonObject jsonObject) {
+        Data data = new Data();
+
+        data.setId(jsonObject.get("id").getAsString());
+        data.setType(jsonObject.get("type").getAsString());
+        data.setAtributes(deserializeAttributes(jsonObject));
+
+        return data;
+    }
+
+    private Map<String, Attribute> deserializeAttributes(JsonObject jsonObject) {
+        Map<String, Attribute> attributes = new HashMap<>();
+        Set<Map.Entry<String, JsonElement>> entrySet = jsonObject.entrySet();
+        for(Map.Entry<String, JsonElement> entry : entrySet) {
+            if (!entry.getKey().equals("id") && !entry.getKey().equals("type")) {
+                attributes.put(entry.getKey(), deserializeAttribute(entry.getValue().getAsJsonObject()));
+            }
+        }
+        return attributes;
+    }
+
+    private Attribute deserializeAttribute(JsonObject jsonObject) {
+        Attribute attribute = new Attribute();
+        attribute.setType(jsonObject.get("type").getAsString());
+        attribute.setValue(jsonObject.get("value"));
+        attribute.setMetadata(deserializeMetadatas(jsonObject.get("metadata").getAsJsonObject()));
+
+        return attribute;
+    }
+
+    private Map<String, Metadata> deserializeMetadatas(JsonObject jsonObject) {
+        Map<String, Metadata> metadatas = new HashMap<>();
+        Set<Map.Entry<String, JsonElement>> entrySet = jsonObject.entrySet();
+        for(Map.Entry<String, JsonElement> entry : entrySet) {
+            if (!entry.getKey().equals("value") && !entry.getKey().equals("type")) {
+                metadatas.put(entry.getKey(), deserializeMetadata(entry.getValue().getAsJsonObject()));
+            }
+        }
+        return metadatas;
+    }
+
+    private Metadata deserializeMetadata(JsonObject jsonObject) {
+        Metadata metadata = new Metadata();
+        metadata.setType(jsonObject.get("type").getAsString());
+        metadata.setValue(jsonObject.get("value"));
+        return metadata;
+    }
+
+}

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NotifyContextRequestNGSIv2Deserializer.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NotifyContextRequestNGSIv2Deserializer.java
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2014-2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+
 package com.telefonica.iot.cygnus.utils;
 
 import com.google.gson.*;
@@ -13,6 +31,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * The type Notify context request ngsiv2 deserializer for gson.
+ */
 public class NotifyContextRequestNGSIv2Deserializer implements JsonDeserializer<NotifyContextRequestNGSIv2> {
 
     @Override

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/handlers/NGSIRestHandlerTest.java
@@ -56,7 +56,13 @@ public class NGSIRestHandlerTest {
     private HttpServletRequest mockHttpServletRequest;
     @Mock
     private HttpServletRequest mockHttpServletRequest2;
-    
+    @Mock
+    private HttpServletRequest mockHttpServletRequest3;
+    @Mock
+    private HttpServletRequest mockHttpServletRequest4;
+    @Mock
+    private HttpServletRequest mockHttpServletRequest5;
+
     // Other variables
     private final String notification = ""
             + "{"
@@ -126,7 +132,92 @@ public class NGSIRestHandlerTest {
             + "    }"
             + "  ]"
             + "}";
-    
+
+    private final String notification3 = ""
+            + "{"
+            + "  \"subscriptionId\": \"51c0ac9ed714fb3b37d7d5a8\","
+            + "  \"data\": ["
+            + "    {"
+            + "      \"id\": \"E1\","
+            + "      \"type\": \"T\","
+            + "      \"A\": {"
+            + "        \"value\": \"Aval\","
+            + "        \"type\": \"AT\","
+            + "        \"metadata\": {"
+            + "          \"MD1\": {"
+            + "            \"value\": \"MD1val\","
+            + "            \"type\": \"MD1type\""
+            + "          },"
+            + "          \"MD2\": {"
+            + "            \"value\": \"MD2val\","
+            + "            \"type\": \"MD2type\""
+            + "          }"
+            + "        }"
+            + "      },"
+            + "      \"B\": {"
+            + "        \"value\": \"Bval\","
+            + "        \"type\": \"BT\","
+            + "        \"metadata\": {}"
+            + "      }"
+            + "    }"
+            + "  ]"
+            + "}";
+
+    private final String notification4 = ""
+            + "{"
+            + "  \"subscriptionId\": \"51c0ac9ed714fb3b37d7d5a8\","
+            + "  \"data\": ["
+            + "    {"
+            + "      \"id\": \"E1\","
+            + "      \"type\": \"T\","
+            + "      \"A\": {"
+            + "        \"value\": \"Aval\","
+            + "        \"type\": \"AT\","
+            + "        \"metadata\": {"
+            + "          \"MD1\": {"
+            + "            \"value\": \"MD1val\","
+            + "            \"type\": \"MD1type\""
+            + "          },"
+            + "          \"MD2\": {"
+            + "            \"value\": \"MD2val\","
+            + "            \"type\": \"MD2type\""
+            + "          }"
+            + "        }"
+            + "      },"
+            + "      \"B\": {"
+            + "        \"value\": \"Bval\","
+            + "        \"type\": \"BT\","
+            + "        \"metadata\": {}"
+            + "      }"
+            + "    },"
+            + "    {"
+            + "      \"id\": \"E2\","
+            + "      \"type\": \"T2\","
+            + "      \"A\": {"
+            + "        \"value\": \"Aval2\","
+            + "        \"type\": \"AT2\","
+            + "        \"metadata\": {"
+            + "          \"MD1\": {"
+            + "            \"value\": \"MD1val2\","
+            + "            \"type\": \"MD1type2\""
+            + "          },"
+            + "          \"MD2\": {"
+            + "            \"value\": \"MD2val2\","
+            + "            \"type\": \"MD2type2\""
+            + "          }"
+            + "        }"
+            + "      },"
+            + "      \"B2\": {"
+            + "        \"value\": \"Bval\","
+            + "        \"type\": \"BT\","
+            + "        \"metadata\": {}"
+            + "      }"
+            + "    }"
+            + "  ]"
+            + "}";
+
+
+
     /**
      * Constructor.
      */
@@ -162,6 +253,39 @@ public class NGSIRestHandlerTest {
         when(mockHttpServletRequest2.getHeader("fiware-servicepath")).thenReturn("/a,/b");
         when(mockHttpServletRequest2.getReader()).thenReturn(
                 new BufferedReader(new InputStreamReader(new ByteArrayInputStream(notification2.getBytes()))));
+        when(mockHttpServletRequest3.getMethod()).thenReturn("POST");
+        when(mockHttpServletRequest3.getRequestURI()).thenReturn("/notify");
+        String[] headerNames3 = {"Content-Type", "fiware-service", "fiware-servicePath", "ngsiv2-attrsformat"};
+        when(mockHttpServletRequest3.getHeaderNames()).thenReturn(
+                Collections.enumeration(new ArrayList(Arrays.asList(headerNames3))));
+        when(mockHttpServletRequest3.getHeader("content-type")).thenReturn("application/json; charset=utf-8");
+        when(mockHttpServletRequest3.getHeader("fiware-service")).thenReturn("myservice");
+        when(mockHttpServletRequest3.getHeader("fiware-servicepath")).thenReturn("/myservicepath");
+        when(mockHttpServletRequest3.getHeader("ngsiv2-attrsformat")).thenReturn("normalized");
+        when(mockHttpServletRequest3.getReader()).thenReturn(
+                new BufferedReader(new InputStreamReader(new ByteArrayInputStream(notification3.getBytes()))));
+        when(mockHttpServletRequest4.getMethod()).thenReturn("POST");
+        when(mockHttpServletRequest4.getRequestURI()).thenReturn("/notify");
+        String[] headerNames4 = {"Content-Type", "fiware-service", "fiware-servicePath", "ngsiv2-attrsformat"};
+        when(mockHttpServletRequest4.getHeaderNames()).thenReturn(
+                Collections.enumeration(new ArrayList(Arrays.asList(headerNames4))));
+        when(mockHttpServletRequest4.getHeader("content-type")).thenReturn("application/json; charset=utf-8");
+        when(mockHttpServletRequest4.getHeader("fiware-service")).thenReturn("myservice");
+        when(mockHttpServletRequest4.getHeader("fiware-servicepath")).thenReturn("/myservicepath");
+        when(mockHttpServletRequest4.getHeader("ngsiv2-attrsformat")).thenReturn("legacy");
+        when(mockHttpServletRequest4.getReader()).thenReturn(
+                new BufferedReader(new InputStreamReader(new ByteArrayInputStream(notification.getBytes()))));
+        when(mockHttpServletRequest5.getMethod()).thenReturn("POST");
+        when(mockHttpServletRequest5.getRequestURI()).thenReturn("/notify");
+        String[] headerNames5 = {"Content-Type", "fiware-service", "fiware-servicePath", "ngsiv2-attrsformat"};
+        when(mockHttpServletRequest5.getHeaderNames()).thenReturn(
+                Collections.enumeration(new ArrayList(Arrays.asList(headerNames5))));
+        when(mockHttpServletRequest5.getHeader("content-type")).thenReturn("application/json; charset=utf-8");
+        when(mockHttpServletRequest5.getHeader("fiware-service")).thenReturn("myservice");
+        when(mockHttpServletRequest5.getHeader("fiware-servicepath")).thenReturn("/a,/b");
+        when(mockHttpServletRequest5.getHeader("ngsiv2-attrsformat")).thenReturn("normalized");
+        when(mockHttpServletRequest5.getReader()).thenReturn(
+                new BufferedReader(new InputStreamReader(new ByteArrayInputStream(notification4.getBytes()))));
     } // setUp
     
     /**
@@ -352,6 +476,55 @@ public class NGSIRestHandlerTest {
             assertTrue(false);
         } // try catch // try catch
     } // testGetEventsContentTypeHeader
+
+    /**
+     * [NGSIRestHandler.getEvents] -------- When a notification is sent, the headers are valid. This test considers also attrsFormat new header
+     */
+    @Test
+    public void testGetEventsContentTypeHeaderFormat() {
+        System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                + "-------- When a notification is sent, the headers are valid");
+        NGSIRestHandler handler = new NGSIRestHandler();
+        handler.configure(createContext(null, null, null)); // default configuration
+
+        try {
+            handler.getEvents(mockHttpServletRequest4);
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The value for 'Content-Type' header is 'application/json; charset=utf-83'");
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The value for 'fiware-servicePath' header starts with '/'");
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The length of 'fiware-service' header value is "
+                    + " less or equal than '" + NGSIConstants.SERVICE_HEADER_MAX_LEN + "'");
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The length of 'fiware-servicePath' header value "
+                    + "is less or equal than '" + NGSIConstants.SERVICE_PATH_HEADER_MAX_LEN + "'");
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The value for 'attrsFormat' header value is valid");
+        } catch (Exception e) {
+            if (e.getMessage().contains("content type not supported")) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The value for 'Content-Type' is not 'application/json; charset=utf-8'");
+            } else if (e.getMessage().contains("header value must start with '/'")) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The value for 'fiware-servicePath' does not start with '/'");
+            } else if (e.getMessage().contains("'fiware-service' header length greater than")) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The length of 'fiware-service' header value "
+                        + "is greater than '" + NGSIConstants.SERVICE_HEADER_MAX_LEN + "'");
+            } else if (e.getMessage().contains("'fiware-servicePath' header length greater than")) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The length of 'fiware-servicePath' header "
+                        + "value is greater than '" + NGSIConstants.SERVICE_PATH_HEADER_MAX_LEN + "'");
+            } else if (e.getMessage().contains("format not supported")) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The value for 'attrsFormat' is not valid");
+            } // if else
+
+            assertTrue(false);
+        } // try catch // try catch
+    } // testGetEventsContentTypeHeader
     
     /**
      * [NGSIRestHandler.getEvents] -------- When a the configuration is wrong, no events are obtained.
@@ -400,7 +573,7 @@ public class NGSIRestHandlerTest {
         List<Event> events;
         
         try {
-            events = handler.getEvents(mockHttpServletRequest);
+            events = handler.getEvents(mockHttpServletRequest3);
             
             try {
                 assertEquals(1, events.size());
@@ -432,7 +605,7 @@ public class NGSIRestHandlerTest {
         Map<String, String> headers;
         
         try {
-            headers = handler.getEvents(mockHttpServletRequest).get(0).getHeaders();
+            headers = handler.getEvents(mockHttpServletRequest3).get(0).getHeaders();
             
             try {
                 assertTrue(headers.containsKey("fiware-service"));
@@ -473,6 +646,17 @@ public class NGSIRestHandlerTest {
                         + "- FAIL - The generated Flume event does not contain 'transaction-id'");
                 throw e4;
             } // try catch
+
+            try {
+                assertTrue(headers.containsKey("ngsiv2-attrsformat"));
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "-  OK  - The generated Flume event contains 'ngsiv2-attrsformat'");
+            } catch (AssertionError e4) {
+                System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                        + "- FAIL - The generated Flume event does not contain 'ngsiv2-attrsformat'");
+                throw e4;
+            } // try catch
+
         } catch (Exception e) {
             System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
                     + "- FAIL - There was some problem while processing the events");
@@ -526,7 +710,54 @@ public class NGSIRestHandlerTest {
             throw e1;
         } // try catch
     } // testGetEventsMultiValuedServicePath
-    
+
+    /**
+     * [NGSIRestHandler.getEvents] -------- When a notification contains multiple ContextElementResponses, a NGSIEvent
+     * is generated for each one of them; the notified service path is split as well.
+     */
+    @Test
+    public void testGetEventsMultiValuedServicePathNgsiv2() {
+        System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                + "-------- When a notification contains multiple ContextElementResponses, a NGSIEvent is generated "
+                + "for each one of them; the notified service path is split as well this tests considers NGSIv2 format");
+        NGSIRestHandler handler = new NGSIRestHandler();
+        handler.configure(createContext(null, null, null)); // default configuration
+        List<Event> events;
+
+        try {
+            events = handler.getEvents(mockHttpServletRequest5);
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "- FAIL - There was some problem when intercepting the event NGSIv2 format");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+
+        try {
+            assertEquals(2, events.size());
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The generated events are 2 for NGSIv2 format");
+        } catch (AssertionError e1) {
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "- FAIL - The generated events are not 2 on NGSIv2 format");
+            throw e1;
+        } // try catch
+
+        try {
+            String event1ServicePath = events.get(0).getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE_PATH);
+            String event2ServicePath = events.get(1).getHeaders().get(CommonConstants.HEADER_FIWARE_SERVICE_PATH);
+            assertTrue((event1ServicePath.equals("/a") && event2ServicePath.equals("/b"))
+                    || (event1ServicePath.equals("/b") && event2ServicePath.equals("/a")));
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "-  OK  - The generated events have a service path equals to a split of the notified service for NGSIv2 format "
+                    + "path");
+        } catch (AssertionError e1) {
+            System.out.println(getTestTraceHead("[NGSIRestHandler.getEvents]")
+                    + "- FAIL - The generated events have not a service path equals to a split of the notified service on NGSIv2 format "
+                    + "path");
+            throw e1;
+        } // try catch
+    } // testGetEventsMultiValuedServicePath
+
     /**
      * [NGSIRestHandler.generateUniqueId] -------- An internal transaction ID is generated.
      */

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -2037,18 +2037,18 @@ public class NGSICartoDBSinkTest {
     
     private ContextElement createContextElement() {
         NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
-        ContextMetadata contextMetadata = notifyContextRequest.new ContextMetadata();
+        ContextMetadata contextMetadata = new ContextMetadata();
         contextMetadata.setName("location");
         contextMetadata.setType("string");
         contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
         ArrayList<ContextMetadata> metadata = new ArrayList<>();
         metadata.add(contextMetadata);
-        ContextAttribute contextAttribute1 = notifyContextRequest.new ContextAttribute();
+        ContextAttribute contextAttribute1 = new ContextAttribute();
         contextAttribute1.setName("someName1");
         contextAttribute1.setType("someType1");
         contextAttribute1.setContextValue(new JsonPrimitive("-3.7167, 40.3833"));
         contextAttribute1.setContextMetadata(metadata);
-        ContextAttribute contextAttribute2 = notifyContextRequest.new ContextAttribute();
+        ContextAttribute contextAttribute2 = new ContextAttribute();
         contextAttribute2.setName("someName2");
         contextAttribute2.setType("someType2");
         contextAttribute2.setContextValue(new JsonPrimitive("someValue2"));
@@ -2056,7 +2056,7 @@ public class NGSICartoDBSinkTest {
         ArrayList<ContextAttribute> attributes = new ArrayList<>();
         attributes.add(contextAttribute1);
         attributes.add(contextAttribute2);
-        ContextElement contextElement = notifyContextRequest.new ContextElement();
+        ContextElement contextElement = new ContextElement();
         contextElement.setId("someId");
         contextElement.setType("someType");
         contextElement.setIsPattern("false");

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
@@ -1021,18 +1021,18 @@ public class NGSIPostgisSinkTest {
 
     private ContextElement createContextElement() {
         NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
-        ContextMetadata contextMetadata = notifyContextRequest.new ContextMetadata();
+        ContextMetadata contextMetadata = new ContextMetadata();
         contextMetadata.setName("location");
         contextMetadata.setType("string");
         contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
         ArrayList<ContextMetadata> metadata = new ArrayList<>();
         metadata.add(contextMetadata);
-        ContextAttribute contextAttribute1 = notifyContextRequest.new ContextAttribute();
+        ContextAttribute contextAttribute1 = new ContextAttribute();
         contextAttribute1.setName("someName1");
         contextAttribute1.setType("someType1");
         contextAttribute1.setContextValue(new JsonPrimitive("-3.7167, 40.3833"));
         contextAttribute1.setContextMetadata(metadata);
-        ContextAttribute contextAttribute2 = notifyContextRequest.new ContextAttribute();
+        ContextAttribute contextAttribute2 = new ContextAttribute();
         contextAttribute2.setName("someName2");
         contextAttribute2.setType("someType2");
         contextAttribute2.setContextValue(new JsonPrimitive("someValue2"));
@@ -1040,7 +1040,7 @@ public class NGSIPostgisSinkTest {
         ArrayList<ContextAttribute> attributes = new ArrayList<>();
         attributes.add(contextAttribute1);
         attributes.add(contextAttribute2);
-        ContextElement contextElement = notifyContextRequest.new ContextElement();
+        ContextElement contextElement = new ContextElement();
         contextElement.setId("someId");
         contextElement.setType("someType");
         contextElement.setIsPattern("false");

--- a/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
@@ -150,7 +150,7 @@ $ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
-Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](cygnus-ngsi/resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+Support for NGSIv2 notifications has been added from version above 1.17.1. For this purpose, it's been added a new dir [/NGSIv2](./resources/ngsi-examples/NGSIv2) which contains script files in order to emulate some NGSIv2 notification types. 
 
 [Top](#top)
 

--- a/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/install_with_docker.md
@@ -150,6 +150,8 @@ $ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
+Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](cygnus-ngsi/resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+
 [Top](#top)
 
 ### <a name="section3.2"></a>Using a specific configuration

--- a/doc/cygnus-ngsi/installation_and_administration_guide/testing.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/testing.md
@@ -330,6 +330,6 @@ You will see the server (Cygnus) is sending back a `200 OK` response.
 
 Of course, this is just a e2e test. For real e2e integration with a real NGSI-like source, such as [Orion Context Broker](https://github.com/telefonicaid/fiware-orion), please refer to the [User and Programmer Guide](../user_and_programmer_guide/connecting_orion.md).
 
-Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](../../../cygnus-ngsi/resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+Support for NGSIv2 notifications has been added from version above 1.17.1. For this purpose, it's been added a new dir [/NGSIv2](./resources/ngsi-examples/NGSIv2) which contains script files in order to emulate some NGSIv2 notification types. 
 
 [Top](#top)

--- a/doc/cygnus-ngsi/installation_and_administration_guide/testing.md
+++ b/doc/cygnus-ngsi/installation_and_administration_guide/testing.md
@@ -330,4 +330,6 @@ You will see the server (Cygnus) is sending back a `200 OK` response.
 
 Of course, this is just a e2e test. For real e2e integration with a real NGSI-like source, such as [Orion Context Broker](https://github.com/telefonicaid/fiware-orion), please refer to the [User and Programmer Guide](../user_and_programmer_guide/connecting_orion.md).
 
+Support for NGSIv2 notifications it's added from version above 1.17.0. For this pourpose it's been added a new dir [/NGSIv2](../../../cygnus-ngsi/resources/ngsi-examples/NGSIv2) wich contans script files in order to emulate som NGSIv2 notification types. 
+
 [Top](#top)


### PR DESCRIPTION
PR that solves issue #953. 
The scope for this PR considers the following values for new header `ngsiv2-attrsformat`:

- normalized. This value considers NGSIv2 format, 
- legacy. This value considers NGSI format
- empty. When header is not 

keyValues and values are not considered in this scope. (according to [NGSIv2 spec](http://telefonicaid.github.io/fiware-orion/api/v2/stable/))

The solution provided is to adapt NGSIv2 response to NGSI controllers, so internally all objects are handled as NGSI object not NGSIv2.

