### PR TITLE
[WIP] Update pom.xml log4j to 1.2.27 due to security vulnerabilities

### DIFF
--- a/cygnus-common/pom.xml
+++ b/cygnus-common/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.27</version>
         </dependency>
         <!-- Required by HDFSBackendImplBinary -->
         <dependency>

--- a/cygnus-ngsi/pom.xml
+++ b/cygnus-ngsi/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.27</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/cygnus-twitter/pom.xml
+++ b/cygnus-twitter/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.27</version>
         </dependency>
         <!-- Required by any agent -->
         <dependency>


### PR DESCRIPTION
CVE-2019-17571
moderate severity
Vulnerable versions: >= 1.2, <= 1.2.27
Patched version: No fix

Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data. This affects Log4j versions up to 1.2 up to 1.2.17.