### PR TITLE
FIX CHANGES_NEXT_RELEASE (follow up of PR #1784)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,5 +4,6 @@
 Fix: Changing cygnus port does not work (#1698)
 [cygnus-commons][MongoBackend] Proper processing of mongo errors in create index operations (#1756)
 [cygnus-ngsi] Support for NGSIv2 notifications (#953)
-[cygnus-ngsi] Changed log level for some events (#1768, #1769)
+[cygnus-ngsi] Make CygnusPersistenceError more descriptive (#1768)
+[cygnus-ngsi] Changed log level for some events (#1769)
 [cygnus-ngsi][PostgisSink, PostGRESQLSink] Support for native Postgres and Postgis types (#1780)


### PR DESCRIPTION
Commit https://github.com/telefonicaid/fiware-cygnus/commit/d04526af68d97f600c1e36c7f8fbcc67e3ac0fab (part of PR #1784) changes the solution for #1768 (see https://github.com/telefonicaid/fiware-cygnus/issues/1768#issuecomment-575194160). Thus the CHANGES_NEXT_RELEASE entry should be fixed accordingly.

In addition, this PR could also include a modification in CHANGES_NEXT_RELEASE to address https://github.com/telefonicaid/fiware-cygnus/pull/1784#discussion_r364829104:

> If at the end this PR [meaning PR #1794] has done a cleanup in the MySQLSink, maybe should it be mentioned also in CNR (in a separated line, maybe)?

In the case if this is correct, of course (please @IvanHdzC provide the right entry to add in that case)