### PR TITLE
Task/sql error persistence

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 [cygnus-ngsi][PostgisSink, PostGRESQLSink] Enable datamodel by entity type (dm-by-entity-type) (#1684)
 [cygnus-ngsi] Add correlatorId rollbacked transactions (#1770)
 [cygnus-ngsi][PostGRESQLSink] Fix schemaName when inserting data into DB
+[cygnus-common][PostgreSQL, MySQL] SQL error persistance.

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 [cygnus-ngsi][PostgisSink, PostGRESQLSink] Enable datamodel by entity type (dm-by-entity-type) (#1684)
 [cygnus-ngsi] Add correlatorId rollbacked transactions (#1770)
 [cygnus-ngsi][PostGRESQLSink] Fix schemaName when inserting data into DB
-[cygnus-common][PostgreSQL, MySQL] SQL error persistance.
+[cygnus-common][PostgreSQL, MySQL] SQL error persistance (#1791)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -103,6 +103,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
         // get a connection to an empty database
         Connection con = driver.getConnection("");
+        String query = "create database if not exists `" + dbName + "`";
 
         try {
             stmt = con.createStatement();
@@ -112,7 +113,6 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
 
         try {
-            String query = "create database if not exists `" + dbName + "`";
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
@@ -138,6 +138,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
         // get a connection to the given database
         Connection con = driver.getConnection(dbName);
+        String query = "create table if not exists `" + tableName + "`" + typedFieldNames;
 
         try {
             stmt = con.createStatement();
@@ -147,7 +148,6 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
 
         try {
-            String query = "create table if not exists `" + tableName + "`" + typedFieldNames;
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
@@ -168,6 +168,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
         // get a connection to the given database
         Connection con = driver.getConnection(dbName);
+        String query = "insert into `" + tableName + "` " + fieldNames + " values " + fieldValues;
 
         try {
             stmt = con.createStatement();
@@ -177,7 +178,6 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
 
         try {
-            String query = "insert into `" + tableName + "` " + fieldNames + " values " + fieldValues;
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLTimeoutException e) {
@@ -199,6 +199,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
         // get a connection to the given database
         Connection con = driver.getConnection(dbName);
+        String query = "select " + selection + " from `" + tableName + "` order by recvTime";
 
         try {
             stmt = con.createStatement();
@@ -210,7 +211,6 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             // to-do: refactor after implementing
             // https://github.com/telefonicaid/fiware-cygnus/issues/1371
-            String query = "select " + selection + " from `" + tableName + "` order by recvTime";
             LOGGER.debug("Executing MySQL query '" + query + "'");
             ResultSet rs = stmt.executeQuery(query);
             // A CachedRowSet is "disconnected" from the source, thus can be
@@ -233,6 +233,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
         // get a connection to the given database
         Connection con = driver.getConnection(dbName);
+        String query = "delete from `" + tableName + "` where " + filters;
 
         try {
             stmt = con.createStatement();
@@ -242,7 +243,6 @@ public class MySQLBackendImpl implements MySQLBackend {
         } // try catch
 
         try {
-            String query = "delete from `" + tableName + "` where " + filters;
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -461,9 +461,9 @@ public class MySQLBackendImpl implements MySQLBackend {
                 ", error" +
                 ", query)";
         String fieldValues = "(" +
-                timestamp +
-                ", '" + exception + "'" +
-                ", '" + errorQuery + "')";
+                "'" + timestamp + "'" +
+                ", '" + escapeStringForMySQL(exception.toString())+ "'" +
+                ", '" + escapeStringForMySQL(errorQuery )+ "')";
         // get a connection to the given database
         Connection con = driver.getConnection(dbName);
         String query = "insert into `" + errorTable + "` " + fieldNames + " values " + fieldValues;
@@ -502,6 +502,18 @@ public class MySQLBackendImpl implements MySQLBackend {
         } catch (Exception e) {
             LOGGER.debug("failed to persist error on db " + bd + "_error_log" + e);
         }
+    }
+
+    private String escapeStringForMySQL(String query) {
+        return query.replace("\\", "\\\\")
+                .replace("\b","\\b")
+                .replace("\n","\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                .replace("\\x1A", "\\Z")
+                .replace("\\x00", "\\0")
+                .replace("'", "\\'")
+                .replace("\"", "\\\"");
     }
 
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -146,8 +146,11 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
+        } catch (SQLTimeoutException e) {
+            throw new CygnusPersistenceError("Table creation error. Query " + query, "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
             closeMySQLObjects(con, stmt);
+            persistError(dbName, query, e);
             throw new CygnusPersistenceError("Table creation error", "SQLException", e.getMessage());
         } // try catch
 
@@ -179,6 +182,7 @@ public class MySQLBackendImpl implements MySQLBackend {
         } catch (SQLTimeoutException e) {
             throw new CygnusPersistenceError("Data insertion error. Query insert into `" + tableName + "` " + fieldNames + " values " + fieldValues, "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
+            persistError(dbName, query, e);
             throw new CygnusBadContextData("Data insertion error. Query: insert into `" + tableName + "` " + fieldNames + " values " + fieldValues, "SQLException", e.getMessage());
         } finally {
             closeMySQLObjects(con, stmt);
@@ -217,8 +221,11 @@ public class MySQLBackendImpl implements MySQLBackend {
             crs.populate(rs); // FIXME: close Resultset Objects??
             closeMySQLObjects(con, stmt);
             return crs;
+        } catch (SQLTimeoutException e) {
+            throw new CygnusPersistenceError("Data select error. Query " + query, "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
             closeMySQLObjects(con, stmt);
+            persistError(dbName, query, e);
             throw new CygnusPersistenceError("Querying error", "SQLException", e.getMessage());
         } // try catch
     } // select
@@ -241,8 +248,11 @@ public class MySQLBackendImpl implements MySQLBackend {
         try {
             LOGGER.debug("Executing MySQL query '" + query + "'");
             stmt.executeUpdate(query);
-        } catch (SQLException e) {
+        } catch (SQLTimeoutException e) {
+            throw new CygnusPersistenceError("Data delete error. Query " + query, "SQLTimeoutException", e.getMessage());
+        }catch (SQLException e) {
             closeMySQLObjects(con, stmt);
+            persistError(dbName, query, e);
             throw new CygnusPersistenceError("Deleting error", "SQLException", e.getMessage());
         } // try catch
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mysql/MySQLBackendImpl.java
@@ -483,6 +483,7 @@ public class MySQLBackendImpl implements MySQLBackend {
 
     public void persistError(String bd, String query, Exception exception) throws CygnusPersistenceError, CygnusRuntimeError {
         try {
+            createErrorTable(bd);
             insertErrorLog(bd, query, exception);
             return;
         } catch (CygnusBadContextData cygnusBadContextData) {
@@ -490,12 +491,6 @@ public class MySQLBackendImpl implements MySQLBackend {
             createErrorTable(bd);
         } catch (Exception e) {
             LOGGER.debug("failed to persist error on db " + bd + "_error_log" + e);
-        }
-        try {
-            insertErrorLog(bd, query, exception);
-            return;
-        } catch (Exception e) {
-            createErrorTable(bd);
         }
     }
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/postgresql/PostgreSQLBackendImpl.java
@@ -18,12 +18,9 @@
 
 package com.telefonica.iot.cygnus.backends.postgresql;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
-import java.sql.Statement;
+import java.sql.*;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -42,7 +39,6 @@ import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 
-import java.sql.DriverManager;
 import java.util.Properties;
 
 /**
@@ -109,6 +105,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
         // get a connection to an empty database
         Connection con = driver.getConnection("");
+        String query = "CREATE SCHEMA IF NOT EXISTS " + schemaName;
 
         try {
             stmt = con.createStatement();
@@ -118,7 +115,6 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
         } // try catch
 
         try {
-            String query = "CREATE SCHEMA IF NOT EXISTS " + schemaName;
             LOGGER.debug("Executing SQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLException e) {
@@ -149,6 +145,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
         // get a connection to the given schema
         Connection con = driver.getConnection(schemaName);
+        String query = "CREATE TABLE IF NOT EXISTS " + schemaName + "." + tableName + " " + typedFieldNames;
 
         try {
             stmt = con.createStatement();
@@ -158,11 +155,13 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
         } // try catch
 
         try {
-            String query = "CREATE TABLE IF NOT EXISTS " + schemaName + "." + tableName + " " + typedFieldNames;
             LOGGER.debug("Executing SQL query '" + query + "'");
             stmt.executeUpdate(query);
+        } catch (SQLTimeoutException e) {
+            throw new CygnusPersistenceError("Table creation error. Query " + query, "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
             closePostgreSQLObjects(con, stmt);
+            persistError(schemaName, query, e);
             throw new CygnusPersistenceError("Table creation error", "SQLException", e.getMessage());
         } // try catch
 
@@ -178,6 +177,7 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
 
         // get a connection to the given database
         Connection con = driver.getConnection(schemaName);
+        String query = "INSERT INTO " + schemaName + "." + tableName + " " + fieldNames + " VALUES " + fieldValues;
 
         try {
             stmt = con.createStatement();
@@ -187,12 +187,12 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
         } // try catch
 
         try {
-            String query = "INSERT INTO " + schemaName + "." + tableName + " " + fieldNames + " VALUES " + fieldValues;
             LOGGER.debug("Executing SQL query '" + query + "'");
             stmt.executeUpdate(query);
         } catch (SQLTimeoutException e) {
             throw new CygnusPersistenceError("Data insertion error. Query: INSERT INTO " + schemaName + "." + tableName + " " + fieldNames + " VALUES " + fieldValues, "SQLTimeoutException", e.getMessage());
         } catch (SQLException e) {
+            persistError(schemaName, query, e);
             throw new CygnusBadContextData("Data insertion error. Query: INSERT INTO " + schemaName + "." + tableName + " " + fieldNames + " VALUES " + fieldValues, "SQLException", e.getMessage());
         } finally {
             closePostgreSQLObjects(con, stmt);
@@ -201,6 +201,109 @@ public class PostgreSQLBackendImpl implements PostgreSQLBackend {
         cache.persistSchemaInCache(schemaName);
         cache.persistTableInCache(schemaName, tableName);
     } // insertContextData
+
+    public void createErrorTable(String dbName)
+            throws CygnusRuntimeError, CygnusPersistenceError {
+        // the defaul table for error log will be called the same as the db name
+        String errorTable = dbName + "_error_log";
+        if (cache.isTableInCachedSchema(dbName, errorTable)) {
+            LOGGER.debug("'" + errorTable + "' is cached, thus it is not created");
+            return;
+        } // if
+        String typedFieldNames = "(" +
+                "timestamp TIMESTAMP" +
+                ", error text" +
+                ", query text)";
+
+        Statement stmt = null;
+        // get a connection to the given database
+        Connection con = driver.getConnection(dbName);
+        String query = "create table if not exists " + dbName + "." + errorTable + " " + typedFieldNames;
+
+        try {
+            stmt = con.createStatement();
+        } catch (SQLException e) {
+            closePostgreSQLObjects(con, stmt);
+            throw new CygnusRuntimeError("Table creation error", "SQLException", e.getMessage());
+        } // try catch
+
+        try {
+            LOGGER.debug("Executing SQL query '" + query + "'");
+            stmt.executeUpdate(query);
+        } catch (SQLException e) {
+            closePostgreSQLObjects(con, stmt);
+            throw new CygnusPersistenceError("Table creation error", "SQLException", e.getMessage());
+        } // try catch
+
+        closePostgreSQLObjects(con, stmt);
+
+        LOGGER.debug("Trying to add '" + errorTable + "' to the cache after table creation");
+        cache.persistTableInCache(dbName, errorTable);
+    } // createErrorTable
+
+    public void insertErrorLog(String dbName, String errorQuery, Exception exception)
+            throws CygnusBadContextData, CygnusRuntimeError, CygnusPersistenceError {
+        Statement stmt = null;
+        String errorTable = dbName + "_error_log";
+        String fieldNames  = "(" +
+                "timestamp" +
+                ", error" +
+                ", query)";
+        String fieldValues = "(" +
+                "'" + java.sql.Timestamp.from(Instant.now()) + "'" +
+                ", '" + escapeStringForSQL(exception.toString())+ "'" +
+                ", '" + escapeStringForSQL(errorQuery )+ "')";
+        // get a connection to the given database
+        Connection con = driver.getConnection(dbName);
+        String query = "INSERT INTO " + dbName + "." + errorTable + " " + fieldNames + " VALUES " + fieldValues;
+
+        try {
+            stmt = con.createStatement();
+        } catch (SQLException e) {
+            closePostgreSQLObjects(con, stmt);
+            throw new CygnusRuntimeError("Data insertion error", "SQLException", e.getMessage());
+        } // try catch
+
+        try {
+            LOGGER.debug("Executing SQL query '" + query + "'");
+            stmt.executeUpdate(query);
+        } catch (SQLTimeoutException e) {
+            throw new CygnusPersistenceError("Data insertion error. Query insert into `" + errorTable + "` " + fieldNames + " values " + fieldValues, "SQLTimeoutException", e.getMessage());
+        } catch (SQLException e) {
+            throw new CygnusBadContextData("Data insertion error. Query: insert into `" + errorTable + "` " + fieldNames + " values " + fieldValues, "SQLException", e.getMessage());
+        } finally {
+            closePostgreSQLObjects(con, stmt);
+        } // try catch
+
+        LOGGER.debug("Trying to add '" + dbName + "' and '" + errorTable + "' to the cache after insertion");
+        cache.persistSchemaInCache(dbName);
+        cache.persistTableInCache(dbName, errorTable);
+    } // insertErrorLog
+
+    public void persistError(String bd, String query, Exception exception) throws CygnusPersistenceError, CygnusRuntimeError {
+        try {
+            createErrorTable(bd);
+            insertErrorLog(bd, query, exception);
+            return;
+        } catch (CygnusBadContextData cygnusBadContextData) {
+            LOGGER.debug("failed to persist error on db " + bd + "_error_log" + cygnusBadContextData);
+            createErrorTable(bd);
+        } catch (Exception e) {
+            LOGGER.debug("failed to persist error on db " + bd + "_error_log" + e);
+        }
+    }
+
+    private String escapeStringForSQL(String query) {
+        return query.replace("\\", "\\\\")
+                .replace("\b","\\b")
+                .replace("\n","\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                .replace("\\x1A", "\\Z")
+                .replace("\\x00", "\\0")
+                .replace("'", "\\'")
+                .replace("\"", "\\\"");
+    }
 
     /**
      * Close all the PostgreSQL objects previously opened by createSchema and createTable.

--- a/doc/cygnus-common/backends_catalogue/mysql_backend.md
+++ b/doc/cygnus-common/backends_catalogue/mysql_backend.md
@@ -20,3 +20,5 @@ This is a convenience backend class for MySQL that implements the `MySQLBackend`
 `MySQLBackendImpl` really wraps the [MySQL JDBC driver](https://dev.mysql.com/downloads/connector/j/).
 
 It must be said this backend implementation enforces UTF-8 encoding through the usage of `useUnicode=true` and  `characterEncoding=UTF-8` properties when getting a connection via the JDBC driver.
+
+Also, this class persists into persistence manager any error regarding to any attempt to persist information. For further reference read [Error persistence](../installation_and_administration_guide/error_persistance.md).

--- a/doc/cygnus-common/backends_catalogue/postgresql_backend.md
+++ b/doc/cygnus-common/backends_catalogue/postgresql_backend.md
@@ -20,3 +20,5 @@ This is a convenience backend class for PostgreSQL that implements the `PostgreS
 `PostgreSQLBackendImpl` really wraps the [PostgreSQL JDBC driver](https://jdbc.postgresql.org/).
 
 It must be said this backend implementation enforces UTF-8 encoding through the usage of `charSet=UTF-8` property when getting a connection via the JDBC driver.
+
+Also, this class persists into persistence manager any error regarding to any attempt to persist information. For further reference read [Error persistence](../installation_and_administration_guide/error_persistance.md).

--- a/doc/cygnus-common/installation_and_administration_guide/error_persistance.md
+++ b/doc/cygnus-common/installation_and_administration_guide/error_persistance.md
@@ -1,0 +1,51 @@
+# Error persistence.
+
+If there is an exception when trying to persist data into storage. Cygnus is capable to store it into a new table as long as there is successful connection to persistence manager.
+
+This only applies to SQL type backends PostgreSQL & MySQL. Notice that Postgis uses PostgreSQL backend so this function extends to Postgis as well as PostgreSQL and MySQL.
+
+As mentioned before, if there is an exception when trying to persist data, Cygnus tryes to create a table with the following pattern.
+
+```
+$databaseName_error_log
+```
+
+with the following scheme.
+
+Column name   | SQL Type
+------------- | --------------------------------------- 
+timestamp     | TIMESTAMP
+error         | TEXT
+query         | TEXT
+
+`For instance.`
+
+If Cygnus receives a request that attemp to execute the query:
+
+```
+INSERT INTO prueba2.streetlight (recvT
+ime,fiwareServicePath,entityId,entityType,TimeInstant,TimeInstant_md,serialNumber,serialNumber_md) VALUES ('2020-02-27 09:12:29.344','/e','farolahttpu
+l','Streetlight','2019-10-31T13:49:17.00Z','[]','OP00096F160318C000004','[]'),('2020-02-27 09:12:30.510','/e','farolahttpul','Streetlight','2019-10-31
+T13:49:17.00Z','[]','OP00096F160318C000004','[]')
+```
+
+But the table streetlight doesn't exists, then this will produce a SQL Exception;
+
+```
+ERROR: relation "prueba2.streetlight" does not exist
+```
+
+Then Cygnus will create a table:
+
+```
+prueba2_error_log
+```
+
+And finally execute a query to insert the exception into the new table.
+
+```
+2020-02-27 09:12:42.049 | ERROR: relation "prueba2.streetlight" does not exist+| INSERT INTO prueba2.streetlight (recvT
+ime,fiwareServicePath,entityId,entityType,TimeInstant,TimeInstant_md,serialNumber,serialNumber_md) VALUES ('2020-02-27 09:12:29.344','/e','farolahttpu
+l','Streetlight','2019-10-31T13:49:17.00Z','[]','OP00096F160318C000004','[]'),('2020-02-27 09:12:30.510','/e','farolahttpul','Streetlight','2019-10-31
+T13:49:17.00Z','[]','OP00096F160318C000004','[]')
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ pages:
           - 'Sanity checks': 'cygnus-common/installation_and_administration_guide/sanity_checks.md'
           - 'Diagnosis procedures': 'cygnus-common/installation_and_administration_guide/diagnosis_procedures.md'
           - 'Reporting issues and contact information': 'cygnus-common/installation_and_administration_guide/issues_and_contact.md'
+          - 'Error persistence': 'cygnus-common/installation_and_administration_guide/error_persistance.md'
       - 'Backends catalogue':
           - 'Introduction': 'cygnus-common/backends_catalogue/introduction.md'
           - 'CKAN backend': 'cygnus-common/backends_catalogue/ckan_backend.md'


### PR DESCRIPTION
Solves #1791

This PR inserts all errors on sql persistance on a new table on the DB. If the table doesn't exists, then it's created. The layout for the table is the following.

postgresql=# select * from prueba2.prueba2_error_log;
        **timestamp        |                                error                                |                  query**                                    

 2020-02-27 09:12:42.049 ### **|** ERROR: relation "prueba2.e_farolahttpul_streetlight" does not exist+### **|** INSERT INTO prueba2.e_farola (recvT
ime,fiwareServicePath,entityId,entityType,TimeInstant,TimeInstant_md,serialNumber,serialNumber_md) VALUES ('2020-02-27 15:15:29.344','/e','farolahttpu
l','Streetlight','2019-10-31T13:49:17.00Z','[]','OP00096F160318C000004','[]'),('2020-02-27 15:15:30.510','/e','farolahttpul','Streetlight','2019-10-31
T13:49:17.00Z','[]','OP00096F160318C000004','[]')

for both SQL kind of sinlks.
