### PR TITLE
enable postgis functions even if native types flag is off

### DIFF
--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericAggregator.java
@@ -184,10 +184,18 @@ public abstract class NGSIGenericAggregator {
                 stringValue = "'" + value.toString() + "'";
             }
         } else {
-            if (value.isJsonPrimitive()) {
-                stringValue = "'" + value.getAsString() + "'";
+            if (value!= null && value.isJsonPrimitive()) {
+                if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID")) {
+                    stringValue = value.getAsString().replace("\\", "");
+                } else {
+                    stringValue = "'" + value.getAsString() + "'";
+                }
             } else {
-                stringValue = "'" + value.toString() + "'";
+                if (value == null || value.isJsonNull()) {
+                    stringValue = "NULL";
+                } else {
+                    stringValue = "'" + value.toString() + "'";
+                }
             }
         }
         LOGGER.debug("[" + getName() + "] aggregation entry = "  + stringValue);


### PR DESCRIPTION
This PR also includes a not null validation not related to the postgis functions.

As a reference PR #1824 applies same change on master.