### PR TITLE
edited exception handling to manage all exceptions when persisting batch

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 [cygnus-ngsi][RestHandler] Add a not null validation for ngsiVersion header of request.
 [cygnus-ngsi][HDFSSink] Separate files by property periodicity (#1830)
 [cygnus-common][Elasticsearch] Fix a bug raised NullPointerException when 'ignore_white_spaces' is true and an attribute has null value. (#1838)
+[cygnus-ngsi][NGSISink]Handle generic exception to manage all scenarios when persisting batch (#1844)


### PR DESCRIPTION
Fixes #1844 

While trying to ANY batch if there is an exception different than:

`CygnusBadConfiguration | CygnusBadContextData | CygnusRuntimeError | CygnusPersistenceError `´

Cygnus will not be able to handle it and this creates an infinite loop. With this PR Cygnus will handle any other exception as "CygnusPersistenceError". This means that it will try to persist it as many times as the agent.conf file describes.