### PR TITLE
Task/mapped attributes nm

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 [cygnus-ngsi][MySQLSink, PostgreSQLSink, PostgisSQLSink] Remove SQLBackend singleton, thus allowing two sinks of the same SQL-type in the same Cygnus instance
 [cygnus-ngsi][CKANSink] New datamodel for CKAN (dm-by-entity-id) implementing mapping: subservice -> org, entityId -> dataset, entityId -> resource (#1792)
 [cygnus-ngsi][PostgisSQLSink, PostgreSQLSink] Add dm-by-entity-database and dm-by-entity-database-schema.
+[cygnus-ngsi][Generic Aggregation] If name mappings is enabled, then the aggregation will take all attributes from the mapped element on the event.
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -53,11 +53,18 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
         aggregation.put(NGSIConstants.FIWARE_SERVICE_PATH, new ArrayList<JsonElement>());
         aggregation.put(NGSIConstants.ENTITY_ID, new ArrayList<JsonElement>());
         aggregation.put(NGSIConstants.ENTITY_TYPE, new ArrayList<JsonElement>());
+
         // iterate on all this context element attributes, if there are attributes
-        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = event.getContextElement().getAttributes();
-        if (contextAttributes == null || contextAttributes.isEmpty()) {
+        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = null;
+        if (isEnableNameMappings() && event.getMappedCE() != null && event.getMappedCE().getAttributes() != null && !event.getMappedCE().getAttributes().isEmpty()) {
+            contextAttributes = event.getMappedCE().getAttributes();
+        } else if (event.getContextElement() != null && event.getContextElement().getAttributes() != null && !event.getContextElement().getAttributes().isEmpty()) {
+            contextAttributes = event.getContextElement().getAttributes();
+        } else {
+            LOGGER.warn("No attributes within the notified entity, nothing is done");
             return;
         } // if
+
         for (NotifyContextRequest.ContextAttribute contextAttribute : contextAttributes) {
             String attrName = contextAttribute.getName();
             aggregation.put(attrName, new ArrayList<JsonElement>());
@@ -76,12 +83,17 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
         String recvTime = CommonUtils.getHumanReadable(recvTimeTs, isEnableUTCRecvTime());
         // get the event body
         NotifyContextRequest.ContextElement contextElement = event.getContextElement();
+        NotifyContextRequest.ContextElement mappedContextElement = event.getMappedCE();
         String entityId = contextElement.getId();
         String entityType = contextElement.getType();
         LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type=" + entityType + ")");
         // Iterate on all this context element attributes, if there are attributes
-        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = contextElement.getAttributes();
-        if (contextAttributes == null || contextAttributes.isEmpty()) {
+        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = null;
+        if (isEnableNameMappings() && mappedContextElement != null && mappedContextElement.getAttributes() != null && !mappedContextElement.getAttributes().isEmpty()) {
+            contextAttributes = mappedContextElement.getAttributes();
+        } else if (contextElement!= null && contextElement.getAttributes() != null && !contextElement.getAttributes().isEmpty()) {
+            contextAttributes = event.getContextElement().getAttributes();
+        } else {
             LOGGER.warn("No attributes within the notified entity, nothing is done (id=" + entityId
                     + ", type=" + entityType + ")");
             return;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericRowAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericRowAggregator.java
@@ -60,13 +60,18 @@ public class NGSIGenericRowAggregator extends NGSIGenericAggregator{
         String recvTime = CommonUtils.getHumanReadable(recvTimeTs, isEnableUTCRecvTime());
         // get the getRecvTimeTs body
         NotifyContextRequest.ContextElement contextElement = event.getContextElement();
+        NotifyContextRequest.ContextElement mappedContextElement = event.getMappedCE();
         String entityId = contextElement.getId();
         String entityType = contextElement.getType();
         LOGGER.debug("[" + getName() + "] Processing context element (id=" + entityId + ", type="
                 + entityType + ")");
-        // iterate on all this context element attributes, if there are attributes
-        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = contextElement.getAttributes();
-        if (contextAttributes == null || contextAttributes.isEmpty()) {
+        // Iterate on all this context element attributes, if there are attributes
+        ArrayList<NotifyContextRequest.ContextAttribute> contextAttributes = null;
+        if (isEnableNameMappings() && mappedContextElement != null && mappedContextElement.getAttributes() != null && !mappedContextElement.getAttributes().isEmpty()) {
+            contextAttributes = mappedContextElement.getAttributes();
+        } else if (contextElement!= null && contextElement.getAttributes() != null && !contextElement.getAttributes().isEmpty()) {
+            contextAttributes = event.getContextElement().getAttributes();
+        } else {
             LOGGER.warn("No attributes within the notified entity, nothing is done (id=" + entityId
                     + ", type=" + entityType + ")");
             return;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
@@ -1584,6 +1584,35 @@ public class NGSIPostgisSinkTest {
         contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
         ArrayList<ContextMetadata> metadata = new ArrayList<>();
         metadata.add(contextMetadata);
+        ContextAttribute contextAttribute2 = new ContextAttribute();
+        contextAttribute2.setName("someName2");
+        contextAttribute2.setType("someType2");
+        contextAttribute2.setContextValue(new JsonPrimitive("someValue2"));
+        contextAttribute2.setContextMetadata(null);
+        ContextAttribute contextAttribute1 = new ContextAttribute();
+        contextAttribute1.setName("someName1");
+        contextAttribute1.setType("geooint");
+        contextAttribute1.setContextValue(new JsonPrimitive("-3.7167, 40.3833"));
+        contextAttribute1.setContextMetadata(metadata);
+        ArrayList<ContextAttribute> attributes = new ArrayList<>();
+        attributes.add(contextAttribute2);
+        attributes.add(contextAttribute1);
+        ContextElement contextElement = new ContextElement();
+        contextElement.setId("someId");
+        contextElement.setType("someType");
+        contextElement.setIsPattern("false");
+        contextElement.setAttributes(attributes);
+        return contextElement;
+    } // createContextElement
+
+    private ContextElement createMappedContextElement() {
+        NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
+        ContextMetadata contextMetadata = new ContextMetadata();
+        contextMetadata.setName("location");
+        contextMetadata.setType("string");
+        contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
+        ArrayList<ContextMetadata> metadata = new ArrayList<>();
+        metadata.add(contextMetadata);
         ContextAttribute contextAttribute1 = new ContextAttribute();
         contextAttribute1.setName("someName1");
         contextAttribute1.setType("geo:point");
@@ -1683,7 +1712,7 @@ public class NGSIPostgisSinkTest {
         NotifyContextRequest.ContextElement contextElement = createContextElementForNativeTypes();
         NotifyContextRequest.ContextElement contextElement2 = createContextElement();
         NGSIEvent ngsiEvent = new NGSIEvent(headers, contextElement.toString().getBytes(), contextElement, null);
-        NGSIEvent ngsiEvent2 = new NGSIEvent(headers, contextElement2.toString().getBytes(), contextElement2, null);
+        NGSIEvent ngsiEvent2 = new NGSIEvent(headers, contextElement2.toString().getBytes(), contextElement2, createMappedContextElement());
         NGSIBatch batch = new NGSIBatch();
         batch.addEvent(destination, ngsiEvent);
         batch.addEvent(destination, ngsiEvent2);
@@ -1715,6 +1744,7 @@ public class NGSIPostgisSinkTest {
                 aggregator.setAttrNativeTypes(true);
                 aggregator.setEnableGeoParse(true);
                 aggregator.setAttrMetadataStore(true);
+                aggregator.setEnableNameMappings(true);
                 aggregator.initialize(events.get(0));
                 for (NGSIEvent event : events) {
                     aggregator.aggregate(event);


### PR DESCRIPTION
As discussed, this PR changes the way the aggregation is made. From now on if name mappings is enabled on agent properties, then the agggregation will look for mapped attributes on the NGSIEvent, if those attributes are empty or they are null, then the attributes will be taken from the original element as usual.

Please notice that this change applies for all sinks that uses the generic aggregation. (Postgis, PostgreSQL, MySQL, CKAN, HDFS, Mongo)