### PR TITLE
Task/stdout

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,5 @@
 [cygnus-ngsi][CKANSink] New datamodel for CKAN (dm-by-entity-id) implementing mapping: subservice -> org, entityId -> dataset, entityId -> resource (#1792)
 [cygnus-ngsi][PostgisSQLSink, PostgreSQLSink] Add dm-by-entity-database and dm-by-entity-database-schema.
 [cygnus-ngsi][Generic Aggregation] If name mappings is enabled, then the aggregation will take all attributes from the mapped element on the event.
+[cygnus-ngsi] Update entrypoint to create a symlink from the logfile to stdout, and remove tail execution to stream logfile.
 

--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -1073,7 +1073,7 @@ if [ "${CYGNUS_MULTIAGENT,,}" == "false" ]; then
 fi
 
 touch /var/log/cygnus/cygnus.log 
-ln -snf /dev/stdout /var/log/cygnus/cygnus.log 
+ln -snf /dev/stdout /var/log/cygnus/cygnus.log & PIDS="$PIDS $!"
 
 wait $PIDS
 trap - TERM INT

--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -1072,8 +1072,8 @@ if [ "${CYGNUS_MULTIAGENT,,}" == "false" ]; then
     PIDS="$PIDS $!"
 fi
 
-touch /var/log/cygnus/cygnus.log && tail -f /var/log/cygnus/cygnus.log &
-PIDS="$PIDS $!"
+touch /var/log/cygnus/cygnus.log 
+ln -snf /dev/stdout /var/log/cygnus/cygnus.log 
 
 wait $PIDS
 trap - TERM INT


### PR DESCRIPTION
Update entrypoint to create a symlink to output it's content to stdout. By doing this, it's not necessary to use tail anymore to output the log content to console.