### PR TITLE
log error when closing connection

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+[cygnus-common][SQLBackendImpl] Exception handle for connection/statement SQL objects.

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -425,7 +425,7 @@ public class SQLBackendImpl implements SQLBackend{
             try {
                 stmt.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError(sqlInstance.toUpperCase() + " Objects closing error", "SQLException", e.getMessage());
+                LOGGER.warn(sqlInstance.toUpperCase() + " error closing invalid statement: " + e.getMessage());
             } // try catch
         } // if
 
@@ -433,7 +433,7 @@ public class SQLBackendImpl implements SQLBackend{
             try {
                 con.close();
             } catch (SQLException e) {
-                throw new CygnusRuntimeError(sqlInstance.toUpperCase() + " Objects closing error", "SQLException", e.getMessage());
+                LOGGER.warn(sqlInstance.toUpperCase() + " error closing invalid connection: " + e.getMessage());
             } // try catch
         } // if
 


### PR DESCRIPTION
This PR is related to issue #1907.

As in PR #1744 this PR handle thrown exceptions when closing SQL statements or connections. 

Nowadays, this exceptions are thrown inside the `finally` block. If the `finally` block throws an execption, it potentially will be priorized to any exception handled by any previous try/catch.

For this reason, this PR suppresses any connection/statement exception by logging it and not throwing it to the stack (as PR #1744 does). So if any previous step throws an exception it will be visible to the stack.

This error is not related to the previous generic SQLbackend/aggregation changes.