### PR TITLE
FIX syntax error in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,7 +129,7 @@ pages:
               - 'Introduction': 'cygnus-ngsi-ld/flume_extensions_catalogue/introduction.md'
               - 'NGSIRestHandler': 'cygnus-ngsi-ld/flume_extensions_catalogue/ngsi_rest_handler.md'
               - 'NGSIPostgreSQLSink': 'cygnus-ngsi-ld/flume_extensions_catalogue/ngsi_postgresql_sink.md'
-              - 'NGSIPostGISSink':'cygnus-ngsi-ld/flume_extensions_catalogue/ngsi_postgis_sink.md'
+              - 'NGSIPostGISSink': 'cygnus-ngsi-ld/flume_extensions_catalogue/ngsi_postgis_sink.md'
               - 'Reporting issues and contact information': 'cygnus-ngsi-ld/flume_extensions_catalogue/issues_and_contact.md'
         - 'User and Programmer Guide':
               - 'Programmer Guide': 'cygnus-ngsi-ld/user_and_programmer_guide/README.md'


### PR DESCRIPTION
RTD documentation built is currently broken:

![imagen](https://user-images.githubusercontent.com/1534240/93745563-0bfddd00-fbf4-11ea-8111-4ed92d7b56ec.png)

This is an attemp to solve it... alghouth I'm not sure about the right syntax.

CC: @anmunoz 