### PR TITLE
avoid use purge due to mysql reserved word

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+[cygnus-common][SQLBackendImpl] Avoid use word `purge` as tmp when purge mysql error table due is a reserved word in mysql

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -660,9 +660,9 @@ public class SQLBackendImpl implements SQLBackend{
 
         String query = "";
         if (sqlInstance.equals("mysql")) {
-            query = "delete from `" + errorTable + "` "  + "where timestamp not in (select timestamp from (select timestamp from `" + errorTable + "` "  + "order by timestamp desc limit " + limit + " ) purge )";
+            query = "delete from `" + errorTable + "` "  + "where timestamp not in (select timestamp from (select timestamp from `" + errorTable + "` "  + "order by timestamp desc limit " + limit + " ) tmppurge )";
         } else {
-            query = "DELETE FROM " + destination + "." + errorTable + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + destination + "." + errorTable + " "  + "ORDER BY timestamp DESC LIMIT " + limit + " ) purge )";
+            query = "DELETE FROM " + destination + "." + errorTable + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + destination + "." + errorTable + " "  + "ORDER BY timestamp DESC LIMIT " + limit + " ) tmppurge )";
         }
 
         try {


### PR DESCRIPTION
mysql reserved words https://dev.mysql.com/doc/refman/8.0/en/keywords.html

time=2020-10-21T13:08:39.091Z | lvl=DEBUG | corr=dd62b65f-75e0-49de-8807-c4d6731aca55 | trans=f7271db5-50ec-46e9-be96-1d27cffa3ad5 | srv=smartcity | subsrv=/ | comp=cygnus-ngsi | op=persistError | msg=com.telefonica.iot.cygnus.backends.sql.SQLBackendImpl[740] : MYSQL failed to persist error on database/scheme smartcity_error_logcom.telefonica.iot.cygnus.errors.CygnusPersistenceError: CygnusPersistenceError (SQLException). MYSQL Purge error table error (You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'purge )' at line 1). 
time=2020-10-21T13:08:39.091Z | lvl=DEBUG | corr=dd62b65f-75e0-49de-8807-c4d6731aca55 | trans=f7271db5-50ec-46e9-be96-1d27cffa3ad5 | srv=smartcity | subsrv=/ | comp=cygnus-ngsi | op=closeSQLObjects | msg=com.telefonica.iot.cygnus.backends.sql.SQLBackendImpl[457] : MYSQL Closing SQL connection objects.