### PR TITLE
[Don't merge]remove symlink

### DIFF
--- a/docker/cygnus-ngsi/cygnus-entrypoint.sh
+++ b/docker/cygnus-ngsi/cygnus-entrypoint.sh
@@ -1075,7 +1075,6 @@ if [ "${CYGNUS_MULTIAGENT,,}" == "false" ]; then
 fi
 
 touch /var/log/cygnus/cygnus.log
-ln -snf /dev/stdout /var/log/cygnus/cygnus.log & PIDS="$PIDS $!"
 
 wait $PIDS
 trap - TERM INT


### PR DESCRIPTION
This PR removes the symlink wich outputs the content of the log file to stdout. 

This is because when log4j rotates the output file, then this symlink breaks.

fix for issue https://github.com/telefonicaid/fiware-cygnus/issues/1962
