### PR TITLE
set default hostname verifier for arcgis

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 
 import com.google.gson.JsonArray;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -207,7 +207,6 @@ public class RestApi  {
             URL url = new java.net.URL(strUrl);
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
- 
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {
                 conn.setDoOutput(true);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javax.net.ssl.SSLSession;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -33,7 +33,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
+
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -176,6 +182,11 @@ public class RestApi  {
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
  
+            // Install the all-trusting trust manager
+            SSLContext sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+            
             // Create all-trusting host name verifier
             HostnameVerifier allHostsValid = new HostnameVerifier() {
                 public boolean verify(String hostname, SSLSession session) {
@@ -183,7 +194,7 @@ public class RestApi  {
                 }
             };
             // Install the all-trusting host verifier
-            conn.setDefaultHostnameVerifier(allHostsValid);
+            HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
 
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -178,11 +178,6 @@ public class RestApi  {
             String strUrl = fullUrl(urlToRead, params);
             LOGGER.debug("requesting HTTP: " + strUrl);
 
-            URL url = new java.net.URL(strUrl);
-            conn = (java.net.HttpURLConnection) url.openConnection();
-            conn.setRequestMethod(httpMethod.toString());
- 
-            
             // Create a trust manager that does not validate certificate chains
             TrustManager[] trustAllCerts = new TrustManager[] {new X509TrustManager() {
                     public java.security.cert.X509Certificate[] getAcceptedIssuers() {
@@ -209,6 +204,10 @@ public class RestApi  {
             // Install the all-trusting host verifier
             HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
 
+            URL url = new java.net.URL(strUrl);
+            conn = (java.net.HttpURLConnection) url.openConnection();
+            conn.setRequestMethod(httpMethod.toString());
+ 
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {
                 conn.setDoOutput(true);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -207,6 +207,7 @@ public class RestApi  {
             URL url = new java.net.URL(strUrl);
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
+
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {
                 conn.setDoOutput(true);

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -172,6 +172,15 @@ public class RestApi  {
             URL url = new java.net.URL(strUrl);
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
+ 
+            // Create all-trusting host name verifier
+            HostnameVerifier allHostsValid = new HostnameVerifier() {
+                public boolean verify(String hostname, SSLSession session) {
+                    return true;
+                }
+            };
+            // Install the all-trusting host verifier
+            conn.setDefaultHostnameVerifier(allHostsValid);
 
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -182,6 +182,19 @@ public class RestApi  {
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
  
+            
+            // Create a trust manager that does not validate certificate chains
+            TrustManager[] trustAllCerts = new TrustManager[] {new X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                    }
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
+                }
+            };
+            
             // Install the all-trusting trust manager
             SSLContext sc = SSLContext.getInstance("SSL");
             sc.init(null, trustAllCerts, new java.security.SecureRandom());


### PR DESCRIPTION
Disable Certificate Validation in Java SSL Connections

Possible fix for https://github.com/telefonicaid/fiware-cygnus/issues/1992

- [x] Should be tested

No CNR update is needed, just included in ```[cygnus-common][ArcGis] New Rest based backend to persist Arcgis data (#1672)```