### PR TITLE
update log level of timeinstant  parser chaing (CommonUtils.java)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+[cygnus-common] Change log level of timeinstant parser chain (from error to debug)
 [cygnus-ngsi][NGSISink] Set srv and subsrv logs N/A in proccesBatch (#1983)
 [cygnus-ngsi][NGSIArcgisFeatureTableSink] New sink to persist Arcgis data, removing the old ArgGis sink (#1672)
 [cygnus-common][ArcGis] New Rest based backend to persist Arcgis data (#1672)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -304,7 +304,7 @@ public final class CommonUtils {
         try {
             return FORMATTER1.parseDateTime(tsString);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormats exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormats exception " + e.getMessage());
             return parseStringWithFormatPattern2(tsString);
         }
     }
@@ -313,7 +313,7 @@ public final class CommonUtils {
         try {
             return FORMATTER2.parseDateTime(tsString);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern2 exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern2 exception " + e.getMessage());
             return parseStringWithFormatPattern2NoTZ(tsString);
         }
     }
@@ -324,7 +324,7 @@ public final class CommonUtils {
             String tsStringTruncated = tsString.substring(0, tsString.length() - 4) + "Z";
             return FORMATTER2.parseDateTime(tsStringTruncated);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern2NoTZ exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern2NoTZ exception " + e.getMessage());
             return parseStringWithFormatPattern3(tsString);
         }
     }
@@ -333,7 +333,7 @@ public final class CommonUtils {
         try {
             return FORMATTER3.parseDateTime(tsString);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern3 exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern3 exception " + e.getMessage());
             return parseStringWithFormatPattern4(tsString);
         }
     }
@@ -342,7 +342,7 @@ public final class CommonUtils {
         try {
             return FORMATTER4.parseDateTime(tsString);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern4 exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern4 exception " + e.getMessage());
             return parseStringWithFormatPattern4NoTZ(tsString);
         }
     }
@@ -352,7 +352,7 @@ public final class CommonUtils {
             String tsStringTruncated = tsString.substring(0, tsString.length() - 3);
             return FORMATTER4.parseDateTime(tsStringTruncated);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern4NoTZ exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern4NoTZ exception " + e.getMessage());
             return parseStringWithFormatPattern5(tsString);
         }
     }
@@ -361,7 +361,7 @@ public final class CommonUtils {
         try {
             return FORMATTER5.parseDateTime(tsString);
         } catch (Exception e) {
-            LOGGER.error("parseStringWithFormatPattern5 exception " + e.getMessage());
+            LOGGER.debug("parseStringWithFormatPattern5 exception " + e.getMessage());
             return parseStringWithFormatPattern6(tsString);
         }
     }


### PR DESCRIPTION
from ERROR to DEBUG
```
comp=Cygnus | msg=com.telefonica.iot.cygnus.utils.CommonUtils[307] : parseStringWithFormats exception Invalid format: "2017-07-07T07:07:07.777Z" is malformed at ".777Z"
```