### PR TITLE
fix: handle unitCode when present on an attribute #1997

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+Fix: handle unitCode meta-property in NGSI-LD events received in cygnus-ngsi-ld module
 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,1 @@
-Fix: handle unitCode meta-property in NGSI-LD events received in cygnus-ngsi-ld module
-
+[cygnus-ngsi-ld] handle unitCode meta-property in NGSI-LD events received (#1997)

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -479,10 +479,11 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
                     for (Map.Entry<String, JsonElement> entry2 : y.entrySet()) {
                         String x2 = entry2.getKey();
                         Object y2 = entry2.getValue();
-                        if ("observedAt".contentEquals(x2)){
+                        if ("observedAt".contentEquals(x2) || "unitCode".contentEquals(x2)){
                             column += "," + "'"+entry2.getValue().getAsString()+"'";
                         }
-                        if (!"observedAt".contentEquals(x2) && !"type".contentEquals(x2) && !"value".contentEquals(x2) && !"object".contentEquals(x2)) {
+                        if (!"observedAt".contentEquals(x2) && !"unitCode".contentEquals(x2) && !"type".contentEquals(x2)
+                                && !"value".contentEquals(x2) && !"object".contentEquals(x2)) {
                             if (entry2.getValue().isJsonObject()){
                                 JsonObject subAttrJson = entry2.getValue().getAsJsonObject();
                                 subAttrType = subAttrJson.get("type").getAsString();


### PR DESCRIPTION
It addresses the problem raised in #1997.

In the proposed fix, the `unitCode` meta-property is handled similarly to the `observedAt` one.
