### PR TITLE
add stack trace to error creating persistence sink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+[cygnus-ngsi] [PostgisSink,PostgreSQL,MySQL] Add stack trace and config options to error log about createPersistenceBackend
 [cygnus-ngsi] [PostgisSink] Fix PostgreSQL encoding when enabled.
 [cygnus-ngsi] [MysqlSink, PostgisSink, PosgreSQLSink] Update sinks to initialize persistance backend objects without database. (#2004)
 [cygnus-common] Remove database initialization on constructors. (#2004)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -19,6 +19,7 @@
 package com.telefonica.iot.cygnus.sinks;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericAggregator;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericColumnAggregator;
@@ -280,8 +281,11 @@ public class NGSIMySQLSink extends NGSISink {
             createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, mysqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] MySQL persistence backend created");
         } catch (Exception e) {
-            LOGGER.error("Error while creating the MySQL persistence backend. Details="
-                    + e.getMessage());
+            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            LOGGER.error("Error while creating the MySQL persistence backend. " +
+                         "Config params= " + configParams +
+                         "Details=" + e.getMessage() +
+                         "Stack trace: " + Arrays.toString(e.getStackTrace()));
         } // try catch
         
         super.start();

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -326,7 +326,7 @@ public class NGSIPostgisSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             LOGGER.error("Error while creating the Postgis persistence backend. Details="
-                    + e.getMessage());
+                         + e.getMessage() + " Stack trace: " + Arrays.toString(e.getStackTrace()));
         } // try catch
 
         super.start();

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -33,6 +33,7 @@ import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
 import com.telefonica.iot.cygnus.utils.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import org.apache.flume.Context;
 
 /**

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -325,8 +325,13 @@ public class NGSIPostgisSink extends NGSISink {
             createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, postgisOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
-            LOGGER.error("Error while creating the Postgis persistence backend. Details="
-                         + e.getMessage() + " Stack trace: " + Arrays.toString(e.getStackTrace()));
+            String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " postgisOptions " +
+                postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
+            LOGGER.error("Error while creating the Postgis persistence backend. " +
+                         "Config params= " + configParams +
+                         "Details=" + e.getMessage() +
+                         "Stack trace: " + Arrays.toString(e.getStackTrace()));
         } // try catch
 
         super.start();

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -38,6 +38,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import org.apache.flume.Context;
 
 /**
@@ -318,8 +319,14 @@ public class NGSIPostgreSQLSink extends NGSISink {
             createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, postgresqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] Postgresql persistence backend created");
         } catch (Exception e) {
-            LOGGER.error("Error while creating the PostgreSQL persistence backend. Details="
-                    + e.getMessage());
+            String configParams = " postgresqlHost " + postgresqlHost + " postgresqlPort " + postgresqlPort +
+                "  postgresqlUsername " + postgresqlUsername + " postgresqlPassword " + postgresqlPassword +
+                " maxPoolSize " +  maxPoolSize + " postgresqlOptions " +
+                postgresqlOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
+            LOGGER.error("Error while creating the Postgresql persistence backend. " +
+                         "Config params= " + configParams +
+                         "Details=" + e.getMessage() +
+                         "Stack trace: " + Arrays.toString(e.getStackTrace()));
         } // try catch
 
         super.start();


### PR DESCRIPTION
Looking more info when

time=2021-03-30T11:33:30.479Z | lvl=ERROR | corr=N/A | trans=N/A | srv=N/A | subsrv=N/A | op=start | comp=Cygnus | msg=com.telefonica.iot.cygnus.sinks.NGSIPostgisSink[333] : Error while creating the Postgis persistence backend. Details=null