### PR TITLE
[WIP] upgrade apache-hive-exec dep from 2.3.4 to 3.1.2 to avoid use old repo dep

### DIFF
--- a/cygnus-common/pom.xml
+++ b/cygnus-common/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>2.3.4</version>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
 Error:  Failed to execute goal on project cygnus-common: Could not resolve dependencies for project com.telefonica.iot:cygnus-common:jar:2.9.0: Failed to collect dependencies at org.apache.hive:hive-exec:jar:2.3.4 -> org.apache.calcite:calcite-core:jar:1.10.0 -> org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: **Failed to read artifact descriptor for org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories**: [datanucleus (http://www.datanucleus.org/downloads/maven2, default, releases), glassfish-repository (http://maven.glassfish.org/content/groups/glassfish, default, disabled), glassfish-repo-archive (http://maven.glassfish.org/content/groups/glassfish, default, disabled), apache.snapshots (http://repository.apache.org/snapshots, default, snapshots), central (http://repo.maven.apache.org/maven2, default, releases), conjars (http://conjars.org/repo, default, releases+snapshots)] -> [Help 