### PR TITLE
check mongo uri format

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+[cygnus-common][Mongo] Check mongo uri format (#2046)
 [cygnus-ngsi][NGSIRestHandler] ngsiv2 initial notification not includes al list of subservices in servicePath header when is / (#2042)
 [cygnus-ngsi][MongoSink] Check access to element aggregation before cast to Date mongo type (#2038)
 [cygnus-common][MySQL, PostgreSQL, Postgis] Persit error about upsert

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -550,7 +550,11 @@ public class MongoBackendImpl implements MongoBackend {
 
         for (String uri: uris) {
             String[] uriParts = uri.split(":");
-            servers.add(new ServerAddress(uriParts[0], new Integer(uriParts[1])));
+            if (uriParts.length == 2) {
+                servers.add(new ServerAddress(uriParts[0], new Integer(uriParts[1])));
+            } else {
+                LOGGER.error("Bad server uri: " + uri);
+            }
         } // for
 
         // create a Mongo client


### PR DESCRIPTION
fix for https://github.com/telefonicaid/fiware-cygnus/issues/2046

time=2021-05-24T11:08:21.748Z | lvl=ERROR | corr=N/A | trans=N/A | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=getDatabase | msg=com.telefonica.iot.cygnus.backends.mongo.MongoBackendImpl[556] : Bad server uri: iot-mongo
time=2021-05-24T11:08:21.749Z | lvl=ERROR | corr=N/A | trans=N/A | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=processRollbackedBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[418] : CygnusPersistenceError. -, hosts list may not be empty. Stack trace: [com.telefonica.iot.cygnus.sinks.NGSIMongoSink.persistAggregation(NGSIMongoSink.java:302), com.telefonica.iot.cygnus.sinks.NGSIMongoSink.persistBatch(NGSIMongoSink.java:149), com.telefonica.iot.cygnus.sinks.NGSISink.processRollbackedBatches(NGSISink.java:402), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:375), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:67), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:145), java.lang.Thread.run(Thread.java:748)]