### PR TITLE
try batch retries one by one

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,5 @@
+-[cygnus-ngsi][NGSISink] Perform batch retries one by one (#2059)
+-[cygnus-ngsi][NGSISink] Try retries when an event batch is in CygnusBadConfiguration, CygnusBadContextData, CygnusRuntimeError (#2059)
 -[cygnus-ngsi][NGSIPostgis, NGSIPostgreSQL] fix create error_log table (#2061)
 -[cygnus-ngsi][NGSISink] Add destination (which is composed using srv and subsrv fields) to all log about batches
 -[cygnus-ngsi][GenericRowAggregator] Fix generic row aggregator name used in logs

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -395,7 +395,6 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
             String destination = batch.getNextDestination();
             ArrayList<NGSIEvent> events = batch.getNextEvents();
             for (NGSIEvent event : events) {
-
                 NGSIBatch batchToPersist = new NGSIBatch();
                 batchToPersist.addEvent(destination, event);
                 transactionIds.append(event.getHeaders().get(CommonConstants.HEADER_CORRELATOR_ID)).append(", ");
@@ -419,14 +418,12 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                 } catch (Exception e) {
                     updateServiceMetrics(batchToPersist, true);
                     LOGGER.error(e.getMessage() + "Stack trace: " + Arrays.toString(e.getStackTrace()));
-                    for (NGSIEvent event : batchToPersist.getNextEvents()) {
-                        rollbackBatch.addEvent(destination, event);
-                    }
+                    rollbackBatch.addEvent(destination, event); // there is just one event
                 } finally {
                     batch.setNextPersisted(true);
                 }
-            } // for
-        }
+            } // for (NGSIEvent event : events)
+        } // while (batch.hasNext())
         if (rollbackBatch.getNumEvents() > 0) {
             Accumulator rollbackAccumulator = new Accumulator();
             rollbackAccumulator.initialize(rollbackedAccumulation.getAccStartDate());
@@ -620,7 +617,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                     } finally {
                         batch.setNextPersisted(true);
                     }
-                }
+                } // while (batch.hasNext())
                 if (rollbackBatch.getNumEvents() > 0) {
                     Accumulator rollbackAccumulator = new Accumulator();
                     rollbackAccumulator.initialize(accumulator.getAccStartDate());

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -391,7 +391,6 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
         StringBuffer transactionIds = new StringBuffer();
         batch.startIterator();
         while (batch.hasNext()) {
-            //NGSIBatch batchToPersist = new NGSIBatch();
             String destination = batch.getNextDestination();
             ArrayList<NGSIEvent> events = batch.getNextEvents();
             for (NGSIEvent event : events) {


### PR DESCRIPTION
https://github.com/telefonicaid/fiware-cygnus/issues/2059

Related with https://github.com/telefonicaid/fiware-cygnus/pull/1970/

Some errors like CygnusBadConfiguration errors are not recoverables, so there is no point in perform retries, but it that king of events are in the same batch that other valid events  then we must try to insert these valid event. 