### PR TITLE
Create config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -1,0 +1,22 @@
+{
+    "enabler": "CanisMajor - FIWARE DLT Adaptor",
+    "chapter": "core",
+    "academy": "core/cygnus",
+    "readthedocs": "fiware-cygnus",
+    "helpdesk": "",
+    "coveralls": "",
+    "github": ["telefonicaid/fiware-cygnus"],
+    "dockerregistry": ["hub.docker.com"],
+    "docker": ["telefonicaiot/fiware-cygnus", "telefonicaiot/fiware-cygnus-ld"],
+    "email": "",
+    "status": "full",
+    "compose": "",
+    "exclude": [""],
+    "stackexchange": ["fiware-cygnus"],
+    "unit-test": "",
+    "smoke-test": "",
+    "dockerfile": [
+      "https://github.com/telefonicaid/fiware-cygnus/blob/master/docker/cygnus-ngsi/Dockerfile"
+      "https://github.com/telefonicaid/fiware-cygnus/blob/master/docker/cygnus-ngsi-ld/Dockerfile",
+    ]
+}


### PR DESCRIPTION
The FIWARE Foundation need a simple JSON file available in a standard location in each repo to be able to continue to make FIWARE Releases and improve the degree of cross-product integration testing that can occur. This change has been agreed by the TSC and has been added to the contribution requirements.

Please suggest or amend values where known.