### PR TITLE
FIX Centos 8 repo list

### DIFF
--- a/docker/cygnus-common/Dockerfile
+++ b/docker/cygnus-common/Dockerfile
@@ -54,7 +54,13 @@ ENV JAVA_VERSION "1.8.0"
 RUN adduser ${CYGNUS_USER}
 
 # Install
-RUN yum -y install tar nc which git java-${JAVA_VERSION}-openjdk-devel && \
+RUN \
+    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+    # This is just a temporal solution so the build doesn't break while we find a new distro to use
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    yum upgrade -y && \
+    yum -y install tar nc which git java-${JAVA_VERSION}-openjdk-devel && \
     yum clean all && \
     export JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk && \
     curl --remote-name --location --insecure --silent --show-error "${MVN_URL}" && \

--- a/docker/cygnus-ngsi-ld/Dockerfile
+++ b/docker/cygnus-ngsi-ld/Dockerfile
@@ -276,6 +276,11 @@ RUN ls -lsrt
 
 # Install
 RUN \
+    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+    # This is just a temporal solution so the build doesn't break while we find a new distro to use
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    yum upgrade -y && \
     # Add Cygnus user
     adduser ${CYGNUS_USER} && \
     yum -y install nc java-${JAVA_VERSION}-openjdk-devel git python2 && \

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -276,6 +276,11 @@ RUN ls -lsrt
 
 # Install
 RUN \
+    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+    # This is just a temporal solution so the build doesn't break while we find a new distro to use
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    yum upgrade -y && \
     # Add Cygnus user
     adduser ${CYGNUS_USER} && \
     yum -y install nc java-${JAVA_VERSION}-openjdk-devel git python2 && \

--- a/docker/cygnus-twitter/Dockerfile
+++ b/docker/cygnus-twitter/Dockerfile
@@ -53,7 +53,13 @@ ENV JAVA_VERSION "1.8.0"
 RUN adduser ${CYGNUS_USER}
 
 # Install
-RUN yum -y install tar nc which git java-${JAVA_VERSION}-openjdk-devel && \
+RUN \
+    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+    # This is just a temporal solution so the build doesn't break while we find a new distro to use
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    yum upgrade -y && \
+    yum -y install tar nc which git java-${JAVA_VERSION}-openjdk-devel && \
     yum clean all && \
     export JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk && \
     curl --remote-name --location --insecure --silent --show-error "${MVN_URL}" && \


### PR DESCRIPTION
Due to Centos8 EOL, building the Dockerfile was failing. This PR add a change in the repository base URL in order to keep working it. It changes the URL from `http://mirrorlist.centos.org/?release=$ ... fra=$infra` to `http://vault.centos.org/?release=$relea ... fra=$infra`

Twin PR on Orion repo: https://github.com/telefonicaid/fiware-orion/pull/4054