### PR TITLE
FIX migrate Dockefile to Debian

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- [cygnus-ngsi] Upgrade Dockerfile base image from centos8.4.2105 to Debian 11.2-slim

--- a/docker/cygnus-common/Dockerfile
+++ b/docker/cygnus-common/Dockerfile
@@ -16,6 +16,10 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
+# FIXME: this PR is based in CentOS 8, which has reached End of Life. It should be migrated to Debian,
+# as we did with cygnus-ngsi Dockerfile. Basically, the changes done in PR https://github.com/telefonicaid/fiware-cygnus/pull/2152
+# should be also applied here
+
 FROM centos:centos8.4.2105
 
 MAINTAINER Francisco Romero Bueno <francisco.romerobueno@telefonica.com>

--- a/docker/cygnus-ngsi-ld/Dockerfile
+++ b/docker/cygnus-ngsi-ld/Dockerfile
@@ -16,6 +16,10 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
+# FIXME: this PR is based in CentOS 8, which has reached End of Life. It should be migrated to Debian,
+# as we did with cygnus-ngsi Dockerfile. Basically, the changes done in PR https://github.com/telefonicaid/fiware-cygnus/pull/2152
+# should be also applied here
+
 FROM centos:centos8.4.2105
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=fiware-cygnus

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -332,6 +332,11 @@ RUN \
     cd ${CYGNUS_HOME}/cygnus-ngsi && \
     ${MVN_HOME}/bin/mvn ${MAVEN_ARGS} clean && \
     rm -rf /root/.m2 && rm -rf ${MVN_HOME} && rm -rf ${FLUME_HOME}/docs && rm -rf ${CYGNUS_HOME}/doc && rm -f /*.tar.gz && \
+    # Cleanup
+    apt-get clean && \
+    apt-get -y remove python2 git && \
+    apt-get -y autoremove --purge && \
+    # FIXME: from now on, old cleanup in CentOS 8. Should be reviewed...
     # FIXME #2113: Fix java errors and warnings. Original script was breaking in CentOS 8
     #echo "INFO: Java runtime not needs JAVA_HOME... Unsetting..." && \
     #unset JAVA_HOME && \

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -16,7 +16,7 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
-FROM centos:centos8.4.2105
+FROM debian:11.2-slim
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=fiware-cygnus
 
@@ -276,15 +276,15 @@ RUN ls -lsrt
 
 # Install
 RUN \
-    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
-    # This is just a temporal solution so the build doesn't break while we find a new distro to use
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
-    yum upgrade -y && \
+    # openjdk-8-jdk is not included in Debian 11 repositories, so we need to add jessie-backports for it
+    echo 'deb http://httpredir.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list.d/jessie-backports.list && \
+    apt-get -y update && \
+    apt-get -y upgrade && \
+    # Install dependencies
+    apt-get -y install openjdk-8-jdk curl git python2 && \
     # Add Cygnus user
     adduser ${CYGNUS_USER} && \
-    yum -y install nc java-${JAVA_VERSION}-openjdk-devel git python2 && \
-    export JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk && \
+    export JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk-amd64 && \
     export MAVEN_OPTS="-Xmx2048M -Xss128M -XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=2048M -Dfile.encoding=UTF-8 -Dproject.build.sourceEncoding=UTF-8 -Dmaven.compiler.useIncrementalCompilation=false -DdependencyLocationsEnabled=false -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled" && \
     export MAVEN_ARGS="-B -T8" && \
     # For debug Maven
@@ -336,15 +336,16 @@ RUN \
     #echo "INFO: Java runtime not needs JAVA_HOME... Unsetting..." && \
     #unset JAVA_HOME && \
     #yum erase -y git java-${JAVA_VERSION}-openjdk-devel python2 && \
-    yum erase -y git python2 && \
-    rpm -qa redhat-logos gtk2 pulseaudio-libs libvorbis jpackage* groff alsa* atk cairo libX* | xargs -r rpm -e --nodeps && \
+    #yum erase -y git python2 && \
+    #rpm -qa redhat-logos gtk2 pulseaudio-libs libvorbis jpackage* groff alsa* atk cairo libX* | xargs -r rpm -e --nodeps && \
     # FIXME #2113: disabled step 'rpm --rebuilddb', doesn't work in CentOS8 ?
     #yum clean all && rpm --rebuilddb && rm -rf /var/lib/yum/yumdb && rm -rf /var/lib/yum/history && \
-    yum clean all && rm -rf /var/lib/yum/yumdb && rm -rf /var/lib/yum/history && \
+    #yum clean all && rm -rf /var/lib/yum/yumdb && rm -rf /var/lib/yum/history && \
     find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en_US' ! -name 'locale.alias' | xargs -r rm -r && rm -f /var/log/*log && \
     bash -c 'localedef --list-archive | grep -v -e "en_US" | xargs localedef --delete-from-archive' && \
     /bin/cp -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
-    build-locale-archive && find ${CYGNUS_HOME} -name '.[^.]*' 2>/dev/null | xargs -r rm -rf && echo "INFO: END build"
+    #build-locale-archive && find ${CYGNUS_HOME} -name '.[^.]*' 2>/dev/null | xargs -r rm -rf && \
+    echo "INFO: END build"
 
 
 COPY docker/cygnus-ngsi/cygnus-entrypoint.sh /

--- a/docker/cygnus-twitter/Dockerfile
+++ b/docker/cygnus-twitter/Dockerfile
@@ -16,6 +16,10 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
+# FIXME: this PR is based in CentOS 8, which has reached End of Life. It should be migrated to Debian,
+# as we did with cygnus-ngsi Dockerfile. Basically, the changes done in PR https://github.com/telefonicaid/fiware-cygnus/pull/2152
+# should be also applied here
+
 FROM centos:centos8.4.2105
 
 MAINTAINER Javi Palanca <jpalanca@dsic.upv.es>


### PR DESCRIPTION
Comparing with the CentOS8-based image the improvement in vulnerability fixing is **huge**:

![imagen](https://user-images.githubusercontent.com/1534240/163198988-29f5511f-8e0f-4b7d-a5b6-e87766a64b40.png)
