### PR TITLE
FIX upgrade Debian version from 11.2 to 11.3 in Dockerfile

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi] Upgrade Debian version from 11.2 to 11.3 in Dockerfile

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -16,7 +16,7 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
-FROM debian:11.2-slim
+FROM debian:11.3-slim
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=fiware-cygnus
 


### PR DESCRIPTION
Note that apart from cygnus-ngsi, other Dockefiles has not been migrated yet to Debian (FIXME mark there are pending), so this change doesn't apply to them.