### PR TITLE
use servicePath from event

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- [cygnus-ngsi]  Fix aggregate using event servicepath (#2185)
 - [cygnus-common][MySQLBackend] Upgrade mysql-connector-java from 8.0.27 to 8.0.28
 - [cygnus-ngsi] Upgrade Debian version from 11.2 to 11.3 in Dockerfile

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -77,6 +77,8 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
     public void aggregate(NGSIEvent event) {
         // Number of previous values
         int numPreviousValues = getAggregation().get(NGSIConstants.FIWARE_SERVICE_PATH).size();
+        // get the servicePath from event
+        String eventServicePath = event.getServicePathForData();
         // Get the event headers
         long recvTimeTs = event.getRecvTimeTs();
         long currentTS = 0;
@@ -110,7 +112,7 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
         LinkedHashMap<String, ArrayList<JsonElement>> aggregation = getAggregation();
         aggregation.get(NGSIConstants.RECV_TIME_TS+"C").add(new JsonPrimitive(Long.toString(recvTimeTs)));
         aggregation.get(NGSIConstants.RECV_TIME).add(new JsonPrimitive(recvTime));
-        aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).add(new JsonPrimitive(getServicePathForData()));
+        aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).add(new JsonPrimitive(eventServicePath));
         aggregation.get(NGSIConstants.ENTITY_ID).add(new JsonPrimitive(entityId));
         aggregation.get(NGSIConstants.ENTITY_TYPE).add(new JsonPrimitive(entityType));
         for (NotifyContextRequest.ContextAttribute contextAttribute : contextAttributes) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericRowAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericRowAggregator.java
@@ -57,6 +57,8 @@ public class NGSIGenericRowAggregator extends NGSIGenericAggregator{
     @Override
     public void aggregate(NGSIEvent event) {
         LinkedHashMap<String, ArrayList<JsonElement>> aggregation = getAggregation();
+        // get the servicePath from event
+        String eventServicePath = event.getServicePathForData();
         // get the getRecvTimeTs headers
         long recvTimeTs = event.getRecvTimeTs();
         String recvTime = CommonUtils.getHumanReadable(recvTimeTs, isEnableUTCRecvTime());
@@ -93,7 +95,7 @@ public class NGSIGenericRowAggregator extends NGSIGenericAggregator{
             // aggregate the attribute information
             aggregation.get(NGSIConstants.RECV_TIME_TS).add(new JsonPrimitive(Long.toString(recvTimeTs)));
             aggregation.get(NGSIConstants.RECV_TIME).add(new JsonPrimitive(recvTime));
-            aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).add(new JsonPrimitive(getServicePathForData()));
+            aggregation.get(NGSIConstants.FIWARE_SERVICE_PATH).add(new JsonPrimitive(eventServicePath));
             aggregation.get(NGSIConstants.ENTITY_ID).add(new JsonPrimitive(entityId));
             aggregation.get(NGSIConstants.ENTITY_TYPE).add(new JsonPrimitive(entityType));
             aggregation.get(NGSIConstants.ATTR_NAME).add(new JsonPrimitive(attrName));


### PR DESCRIPTION
possible fix for issue #2185

Aggregator subservice is filled with first event subservice

Aggregator::aggregate should use current event servicePath because not all events of the same aggregation (which shares destinatino) has the same servicePath.