### PR TITLE
Modification of NGSIElasticsearchSink

### DIFF
--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIElasticsearchSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIElasticsearchSink.java
@@ -760,7 +760,7 @@ public class NGSIElasticsearchSink extends NGSISink {
             } // if else
 
             v.recvTimeDt = new Date(v.recvTimeTs);
-            v.idx = this.index + "-" + this.indexDateFormatter.format(v.recvTimeDt);
+            v.idx = this.index;
             return v;
         } // getTimeRelatedValues
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_elasticsearch_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_elasticsearch_sink.md
@@ -61,7 +61,6 @@ So `NGSIElasticsearchSink` constructs the index name according to the following 
 4. when you use `Column-like storing`, append a hash string calculated by the attribute names to be stored
     * MD5 hash is calculated by concatinated attribute names such as  `attrName1:attrName2:...`.
 5. when it starts with `-, _, +`, append 'idx' at the beggning of the base string.
-6. append the created &lt;date&gt; such as `yyyy.mm.dd`.
 
 According to the above rules, `NGSIElasticsearchSink` can handle the multiple subscriptions with different attributes of the same entity.
 


### PR DESCRIPTION
Changes in the NGSIElasticsearchSink to not append the date at the end of the index created. This was done due to the limit of 1000 shards per node of elasticsearch. Since each index by default needs 2 shards, in long term scenarios all the shards would be full leading to a stop in the storage. Thus, the addition of the date in the index does not provide useful information due to each attribute contains the hour and the date when it was created. 

The documentation has also been modified to change the specification of this Sink.