### PR TITLE
Oracle Sink (11g and 12c)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 [cygnus-common] Upgrade postgresql from 42.4.1 to 42.4.3
-[cygnus-ngsi] OracleSQL ngsi sink added
+[cygnus-ngsi] OracleSQL ngsi sink added (for OracleS 11g and 12c) (#2195)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,0 @@
-[cygnus-common] Upgrade postgresql from 42.4.1 to 42.4.3

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,2 @@
+[cygnus-common] Upgrade postgresql from 42.4.1 to 42.4.3
+[cygnus-ngsi] OracleSQL ngsi sink added

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 [cygnus-common] Upgrade postgresql from 42.4.1 to 42.4.3
+[cygnus-common] OracleSQL backend (#2195)
 [cygnus-ngsi] OracleSQL ngsi sink added (for OracleS 11g and 12c) (#2195)

--- a/cygnus-common/pom.xml
+++ b/cygnus-common/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
+            <version>42.4.3</version>
             <type>jar</type>
         </dependency>
         <!-- Required by OracleSQLBackendImpl at runtime -->

--- a/cygnus-common/pom.xml
+++ b/cygnus-common/pom.xml
@@ -75,8 +75,15 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.3</version>
+            <version>42.4.1</version>
             <type>jar</type>
+        </dependency>
+        <!-- Required by OracleSQLBackendImpl at runtime -->
+        <!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc6 -->
+        <dependency>
+          <groupId>com.oracle.database.jdbc</groupId>
+          <artifactId>ojdbc6</artifactId>
+          <version>11.2.0.4</version>
         </dependency>
         <!-- Required for logging -->
         <dependency>

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/Enum.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/Enum.java
@@ -31,6 +31,12 @@ public class Enum {
             public String toString() {
                 return "postgresql";
             }
+        },
+        ORACLE {
+            @Override
+            public String toString() {
+                return "oracle:thin";
+            }
         }
     }
 }

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -53,6 +53,8 @@ public class SQLBackendImpl implements SQLBackend{
     private final int maxLatestErrors;
     private static final String DEFAULT_ERROR_TABLE_SUFFIX = "_error_log";
     private static final int DEFAULT_MAX_LATEST_ERRORS = 100;
+    private String nlsTimestampFormat;
+    private String nlsTimestampTzFormat;
 
     /**
      * Constructor.
@@ -130,6 +132,28 @@ public class SQLBackendImpl implements SQLBackend{
         return driver;
     } // getDriver
 
+
+    /**
+     * Set NLS_TIMESTAMP_FORMAT and NLS_TIMESTAMP_TZ_FORMAT
+     *
+     * @param format
+     **/
+    public void setNlsTimestampFormat(String format) {
+        this.nlsTimestampFormat = format;
+    } // setNlsTimestampFormat
+
+    public String getNlsTimestampFormat() {
+        return nlsTimestampFormat;
+    } // getNlsTImestampFormat
+
+    public void setNlsTimestampTzFormat(String format) {
+        this.nlsTimestampTzFormat = format;
+    } // setNlsTimestampTzFormat
+
+    public String getNlsTimestampTzFormat() {
+        return nlsTimestampTzFormat;
+    } // getNlsTImestampTzFormat
+
     @Override
     public void createDestination(String destination) throws CygnusRuntimeError, CygnusPersistenceError {
         if (cache.isCachedDataBase(destination)) {
@@ -145,7 +169,7 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "create database if not exists `" + destination + "`";
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "CREATE SCHEMA IF NOT EXISTS " + destination;
         }
 
@@ -184,7 +208,7 @@ public class SQLBackendImpl implements SQLBackend{
     public void createTable(String dataBase, String schema, String table, String typedFieldNames)
             throws CygnusRuntimeError, CygnusPersistenceError {
         String tableName = table;
-        if (sqlInstance == SQLInstance.POSTGRESQL){
+        if (sqlInstance == SQLInstance.POSTGRESQL) {
             tableName = schema + "." + table;
         }
         if (cache.isCachedTable(dataBase, tableName)) {
@@ -199,8 +223,10 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "create table if not exists `" + tableName + "`" + typedFieldNames;
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "CREATE TABLE IF NOT EXISTS " + tableName + " " + typedFieldNames;
+        } else if (sqlInstance == SQLInstance.ORACLE) {
+            query = "CREATE TABLE " + tableName + " " + typedFieldNames; // TBD: oracle workaround for not exists?
         }
 
         try {
@@ -227,6 +253,8 @@ public class SQLBackendImpl implements SQLBackend{
         cache.addTable(dataBase, tableName);
     } // createTable
 
+
+    // TBD insertContextData Never used ?
     @Override
     public void insertContextData(String dataBase, String schema, String table, String fieldNames, String fieldValues)
             throws CygnusBadContextData, CygnusRuntimeError, CygnusPersistenceError {
@@ -239,8 +267,10 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "insert into `" + tableName + "` " + fieldNames + " values " + fieldValues;
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             tableName = schema + "." + table;
+            query = "INSERT INTO " + tableName + " " + fieldNames + " VALUES " + fieldValues;
+        } else if (sqlInstance == SQLInstance.ORACLE) {
             query = "INSERT INTO " + tableName + " " + fieldNames + " VALUES " + fieldValues;
         }
 
@@ -513,7 +543,7 @@ public class SQLBackendImpl implements SQLBackend{
             throws CygnusRuntimeError, CygnusPersistenceError {
         // the defaul table for error log will be called the same as the destination name
         String errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
-        if (sqlInstance == SQLInstance.POSTGRESQL){
+        if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
         if (cache.isCachedTable(dataBase, errorTableName)) {
@@ -524,6 +554,10 @@ public class SQLBackendImpl implements SQLBackend{
                 "timestamp TIMESTAMP" +
                 ", error text" +
                 ", query text)";
+        String typedFieldNamesOracle = "(" +
+                "timestamp TIMESTAMP" +
+                ", error clob" +
+                ", query clob)";
 
         Statement stmt = null;
         // get a connection to the given destination
@@ -532,8 +566,10 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "create table if not exists `" + errorTableName + "`" + typedFieldNames;
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
-            query = "create table if not exists " + errorTableName + " " + typedFieldNames;
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
+            query = "CREATE TABLE IF NOT EXISTS" + errorTableName + " " + typedFieldNames;
+        } else if (sqlInstance == SQLInstance.ORACLE) {
+            query = "CREATE TABLE " + errorTableName + " " + typedFieldNamesOracle; // TBD: oracle workaround for not exists?
         }
 
         try {
@@ -750,8 +786,10 @@ public class SQLBackendImpl implements SQLBackend{
             throws CygnusRuntimeError, CygnusPersistenceError {
         // the default table for error log will be called the same as the destination name
         String errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
-        if (sqlInstance == SQLInstance.POSTGRESQL){
+        if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
+        } else if (sqlInstance == SQLInstance.ORACLE) {
+            errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
         String limit = String.valueOf(maxLatestErrors);
 
@@ -762,8 +800,10 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "delete from `" + errorTableName + "` "  + "where timestamp not in (select timestamp from (select timestamp from `" + errorTableName + "` "  + "order by timestamp desc limit " + limit + " ) tmppurge )";
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "DELETE FROM " + errorTableName + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + errorTableName + " "  + "ORDER BY timestamp DESC LIMIT " + limit + " ) tmppurge )";
+        } else if (sqlInstance == SQLInstance.ORACLE) {
+            query = "DELETE FROM " + errorTableName + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + errorTableName + " "  + "ORDER BY timestamp DESC ) tmppurge )"; // TBD limit for oracle ?
         }
 
         try {
@@ -789,8 +829,8 @@ public class SQLBackendImpl implements SQLBackend{
         java.util.Date date = new Date();
         Timestamp timestamp = new Timestamp(date.getTime());
         String errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
-        if (sqlInstance == SQLInstance.POSTGRESQL){
-            errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
+        if (sqlInstance == SQLInstance.POSTGRESQL) {
+            errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;            
         }
         String fieldNames  = "(" +
                 "timestamp" +
@@ -803,7 +843,8 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "insert into `" + errorTableName + "` " + fieldNames + " values (?, ?, ?)";
-        } else if (sqlInstance == SQLInstance.POSTGRESQL){
+        } else if (sqlInstance == SQLInstance.POSTGRESQL ||
+                   sqlInstance == SQLInstance.ORACLE){
             query = "INSERT INTO " + errorTableName + " " + fieldNames + " VALUES (?, ?, ?)";
         }
 
@@ -919,6 +960,15 @@ public class SQLBackendImpl implements SQLBackend{
                     DataSource datasource = createConnectionPool(destination);
                     datasources.put(destination, datasource);
                     connection = datasource.getConnection();
+                    if (sqlInstance == SQLInstance.ORACLE) {
+                        // set proper NLS_TIMESTAMP formats for current session
+                        Statement alterStatement1 = connection.createStatement();
+                        alterStatement1.execute("ALTER SESSION SET NLS_TIMESTAMP_FORMAT='" + getNlsTimestampFormat() + "'");
+                        connection.commit();
+                        Statement alterStatement2 = connection.createStatement();
+                        alterStatement2.execute("ALTER SESSION SET NLS_TIMESTAMP_TZ_FORMAT='" + getNlsTimestampTzFormat() + "'");
+                        connection.commit();
+                    }
                 } // if
 
                 // Check Pool cache and log status
@@ -929,7 +979,6 @@ public class SQLBackendImpl implements SQLBackend{
                 }else{
                     LOGGER.error(sqlInstance.toString().toUpperCase() + " Can't find dabase in pool cache (" + destination + ")");
                 }
-
                 return connection;
             } catch (ClassNotFoundException e) {
                 throw new CygnusRuntimeError(sqlInstance.toString().toUpperCase() + " Connection error", "ClassNotFoundException", e.getMessage());
@@ -1018,7 +1067,7 @@ public class SQLBackendImpl implements SQLBackend{
                 String sep = (sqlOptions != null && !sqlOptions.trim().isEmpty()) ? "&" : "?";
                 String logJdbc = jdbcUrl + sep + "user=" + sqlUsername + "&password=XXXXXXXXXX";
 
-                LOGGER.debug(sqlInstance.toString().toUpperCase() + " Creating connection pool jdbc:" + logJdbc);
+                LOGGER.debug(sqlInstance.toString().toUpperCase() + " Creating connection pool jdbc: " + logJdbc);
                 ConnectionFactory cf = new DriverManagerConnectionFactory(jdbcUrl, sqlUsername, sqlPassword);
 
                 // Creates a PoolableConnectionFactory That Will Wraps the Connection Object Created by
@@ -1036,7 +1085,12 @@ public class SQLBackendImpl implements SQLBackend{
          */
         protected String generateJDBCUrl(String destination) {
             String jdbcUrl = "";
-            jdbcUrl = "jdbc:" + sqlInstance + "://" + sqlHost + ":" + sqlPort + "/" + destination;
+            if (sqlInstance == SQLInstance.ORACLE) {
+                jdbcUrl = "jdbc:" + sqlInstance + ":@" + sqlHost + ":" + sqlPort + ":" + destination;
+                //jdbcUrl = "jdbc:" + sqlInstance + ":@//" + sqlHost + ":" + sqlPort + "/" + destination;  // also should works!
+            } else { // PostgreSQL and MySQL
+                jdbcUrl = "jdbc:" + sqlInstance + "://" + sqlHost + ":" + sqlPort + "/" + destination;
+            }
             if (sqlOptions != null && !sqlOptions.trim().isEmpty()) {
                 jdbcUrl += "?" + sqlOptions;
             }

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -226,7 +226,8 @@ public class SQLBackendImpl implements SQLBackend{
         } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "CREATE TABLE IF NOT EXISTS " + tableName + " " + typedFieldNames;
         } else if (sqlInstance == SQLInstance.ORACLE) {
-            query = "CREATE TABLE " + tableName + " " + typedFieldNames; // TBD: oracle workaround for not exists?
+            // FIXME: Add an oracle workaround for "if not exists"
+            query = "CREATE TABLE " + tableName + " " + typedFieldNames;
         }
 
         try {
@@ -254,7 +255,7 @@ public class SQLBackendImpl implements SQLBackend{
     } // createTable
 
 
-    // TBD insertContextData Never used ?
+    // FXIME insertContextData Never used ?
     @Override
     public void insertContextData(String dataBase, String schema, String table, String fieldNames, String fieldValues)
             throws CygnusBadContextData, CygnusRuntimeError, CygnusPersistenceError {
@@ -569,7 +570,8 @@ public class SQLBackendImpl implements SQLBackend{
         } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "CREATE TABLE IF NOT EXISTS" + errorTableName + " " + typedFieldNames;
         } else if (sqlInstance == SQLInstance.ORACLE) {
-            query = "CREATE TABLE " + errorTableName + " " + typedFieldNamesOracle; // TBD: oracle workaround for not exists?
+            // FIXME: Add an oracle workaround for "if not exists"
+            query = "CREATE TABLE " + errorTableName + " " + typedFieldNamesOracle;
         }
 
         try {
@@ -803,7 +805,8 @@ public class SQLBackendImpl implements SQLBackend{
         } else if (sqlInstance == SQLInstance.POSTGRESQL) {
             query = "DELETE FROM " + errorTableName + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + errorTableName + " "  + "ORDER BY timestamp DESC LIMIT " + limit + " ) tmppurge )";
         } else if (sqlInstance == SQLInstance.ORACLE) {
-            query = "DELETE FROM " + errorTableName + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + errorTableName + " "  + "ORDER BY timestamp DESC ) tmppurge )"; // TBD limit for oracle ?
+            // FXIME: add limit
+            query = "DELETE FROM " + errorTableName + " "  + "WHERE timestamp NOT IN (SELECT timestamp FROM (SELECT timestamp FROM " + errorTableName + " "  + "ORDER BY timestamp DESC ) tmppurge )";
         }
 
         try {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -1090,7 +1090,6 @@ public class SQLBackendImpl implements SQLBackend{
             String jdbcUrl = "";
             if (sqlInstance == SQLInstance.ORACLE) {
                 jdbcUrl = "jdbc:" + sqlInstance + ":@" + sqlHost + ":" + sqlPort + ":" + destination;
-                //jdbcUrl = "jdbc:" + sqlInstance + ":@//" + sqlHost + ":" + sqlPort + "/" + destination;  // also should works!
             } else { // PostgreSQL and MySQL
                 jdbcUrl = "jdbc:" + sqlInstance + "://" + sqlHost + ":" + sqlPort + "/" + destination;
             }

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
@@ -54,7 +54,11 @@ public class SQLQueryUtils {
      * @param timestampKey    the timestamp key
      * @param timestampFormat the timestamp format
      * @param sqlInstance     the sql instance
+     * @param dataBase        the database
      * @param destination     the destination
+     * @param schema          the database schema
+     * @param attrNativeTypes flag attribute native types
+     *
      * @return the string buffer
      */
     protected static ArrayList<StringBuffer> sqlUpsertQuery(LinkedHashMap<String, ArrayList<JsonElement>> aggregation,
@@ -129,24 +133,27 @@ public class SQLQueryUtils {
             StringBuffer values = new StringBuffer("(");
             StringBuffer fields = new StringBuffer("(");
             StringBuffer updateSet = new StringBuffer();
+            String valuesSeparator = "";
+            String fieldsSeparator = "";
+            String updateSetSeparator = "";
             ArrayList<String> keys = new ArrayList<>(aggregation.keySet());
             for (int j = 0 ; j < keys.size() ; j++) {
-                if (lastData.get(keys.get(j)).get(i) != null) {
-                    JsonElement value = lastData.get(keys.get(j)).get(i);
-                    if (j == 0) {
-                        values.append(getStringValueFromJsonElement(value, "'", attrNativeTypes));
-                        fields.append(keys.get(j));
-                        if (!Arrays.asList(uniqueKey.split("\\s*,\\s*")).contains(keys.get(j))) {
-                            updateSet.append(keys.get(j)).append("=").append(postgisTempReference).append(".").append(keys.get(j));
-                        }
-                    } else {
-                        values.append(",").append(getStringValueFromJsonElement(value, "'", attrNativeTypes));
-                        fields.append(",").append(keys.get(j));
-                        if (!Arrays.asList(uniqueKey.split("\\s*,\\s*")).contains(keys.get(j))) {
-                            updateSet.append(", ").append(keys.get(j)).append("=").append(postgisTempReference).append(".").append(keys.get(j));
-                        }
-                    }
+                // values
+                JsonElement value = lastData.get(keys.get(j)).get(i);
+                String valueToAppend = value == null ? "null" : getStringValueFromJsonElement(value, "'", attrNativeTypes);
+                values.append(valuesSeparator).append(valueToAppend);
+                valuesSeparator = ",";
+
+                // fields
+                fields.append(fieldsSeparator).append(keys.get(j));
+                fieldsSeparator = ",";
+
+                // updateSet
+                if (!Arrays.asList(uniqueKey.split("\\s*,\\s*")).contains(keys.get(j))) {
+                    updateSet.append(updateSetSeparator).append(keys.get(j)).append("=").append(postgisTempReference).append(".").append(keys.get(j));
+                    updateSetSeparator = ",";
                 }
+
             }
             query.append("INSERT INTO ").append(postgisDestination).append(" ").append(fields).append(") ").
                     append("VALUES ").append(values).append(") ");
@@ -283,7 +290,9 @@ public class SQLQueryUtils {
      * @param aggregation     the aggregation
      * @param tableName       the table name
      * @param sqlInstance     the sql instance
-     * @param destination     the destination
+     * @param database        the database
+     * @param schema          the database schema
+     * @param attrNativeTypes
      * @return the string buffer
      */
     protected static StringBuffer sqlInsertQuery(LinkedHashMap<String, ArrayList<JsonElement>> aggregation,

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
@@ -192,6 +192,22 @@ public class SQLBackendImplTest {
     } // testJDBCUrlPostgreSQL
 
     @Test
+    public void testJDBCUrlOracleSQL() {
+        System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:oracle)");
+        String sqlHost = "localhost";
+        String sqlPort = "5432";
+        SQLInstance sqlInstance = SQLInstance.ORACLE;
+        String sqlDriverName = "oracle.jdbc.OracleDriver";
+        String destination = "dest";
+        String defaultDataBase = "default";
+
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl.SQLDriver driver = backend.getDriver();
+
+        assertEquals(driver.generateJDBCUrl(destination), "jdbc:oracle:oci://localhost:1521/default");
+    } // testJDBCUrlOracleeSQL    
+
+    @Test
     public void testJDBCUrlMySQLWithOptions() {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:useSSL=true&requireSSL=false)");
         String sqlHost = "localhost";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericAggregator.java
@@ -67,6 +67,8 @@ public abstract class NGSIGenericAggregator {
     private boolean enableEncoding;
     private boolean enableNameMappings;
     private boolean enableGeoParse;
+    private boolean enableGeoParseOracle;
+    private boolean enableGeoParseOracleLocator;
     private boolean attrMetadataStore;
     private boolean enableUTCRecvTime;
     private String lastDataMode;
@@ -392,6 +394,43 @@ public abstract class NGSIGenericAggregator {
     public void setEnableGeoParse(boolean enableGeoParse) {
         this.enableGeoParse = enableGeoParse;
     } //setEnableGeoParse
+
+    /**
+     * Is enable geo parse boolean. Oracle flag to process geometry types.
+     *
+     * @return the boolean
+     */
+    public boolean isEnableGeoParseOracle() {
+        return enableGeoParseOracle;
+    } //isEnableGeoParseOracle
+
+    /**
+     * Sets enable geo parse oracle
+     *
+     * @param enableGeoParse the enable geo parse
+     */
+    public void setEnableGeoParseOracle(boolean enableGeoParseOracle) {
+        this.enableGeoParseOracle = enableGeoParseOracle;
+    } //setEnableGeoParseOracle
+
+    /**
+     * Is enable geo parse boolean. Oracle flag to process geometry types.
+     *
+     * @return the boolean
+     */
+    public boolean isEnableGeoParseOracleLocator() {
+        return enableGeoParseOracleLocator;
+    } //isEnableGeoParseOracleLocator
+
+    /**
+     * Sets enable geo parse oracle locator (12.2.)
+     *
+     * @param enableGeoParseLocator the enable geo parse
+     */
+    public void setEnableGeoParseOracleLocator(boolean enableGeoParseOracleLocator) {
+        this.enableGeoParseOracleLocator = enableGeoParseOracleLocator;
+    } //setEnableGeoParseOracleLocator
+
 
     /**
      * Gets long timestamp of the record stored on the last data collection

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -170,6 +170,17 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
                 } catch (Exception e) {
                     LOGGER.error("[" + getName() + "] Processing context attribute (name=" + attrValue.toString());
                 }
+            } else if (isEnableGeoParseOracle() && (attrType.equals("geo:json") || attrType.equals("geo:point"))) {
+                try {
+                    //Process geometry if applyes
+                    ImmutablePair<String, Boolean> location = NGSIUtils.getGeometryOracle(attrValue.toString(), attrType, attrMetadata, swapCoordinates, isEnableGeoParseOracleLocator());
+                    if (location.right) {
+                        LOGGER.debug("location=" + location.getLeft());
+                        attrValue = new JsonPrimitive(location.getLeft());
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("[" + getName() + "] Processing context attribute (name=" + attrValue.toString());
+                }
             } else if (attrType.equals("TextUnrestricted")) {
                 attrValue = jsonParser.parse(getEscapedString(attrValue, "'"));
             }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSICKANSink.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonObject;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericAggregator;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericColumnAggregator;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericRowAggregator;
+import com.telefonica.iot.cygnus.backends.sql.SQLQueryUtils;
 import com.telefonica.iot.cygnus.backends.ckan.CKANBackendImpl;
 import com.telefonica.iot.cygnus.backends.ckan.CKANBackend;
 import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
@@ -296,7 +297,6 @@ public class NGSICKANSink extends NGSISink {
             for (NGSIEvent event : events) {
                 aggregator.aggregate(event);
             } // for
-
             // Persist the aggregation
             persistAggregation(aggregator, service, servicePath);
             batch.setNextPersisted(true);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -451,7 +451,8 @@ public class NGSIMySQLSink extends NGSISink {
                 // everything must be provisioned in advance
                 if (rowAttrPersistence) {
                     // This case will create a false error entry in error table
-                    String fieldsForCreate = SQLQueryUtils.getFieldsForCreate(aggregator.getAggregationToPersist());
+                    String fieldsForCreate = SQLQueryUtils.getFieldsForCreate(aggregator.getAggregationToPersist(),
+                                                                              MYSQL_INSTANCE_NAME);
                     try {
                         // Try to insert without create database before
                         mySQLPersistenceBackend.createTable(dbName, null, tableName, fieldsForCreate);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2014-2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-cygnus (FIWARE project).
  *
@@ -18,12 +18,21 @@
 
 package com.telefonica.iot.cygnus.sinks;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericAggregator;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericColumnAggregator;
 import com.telefonica.iot.cygnus.aggregation.NGSIGenericRowAggregator;
 import com.telefonica.iot.cygnus.backends.sql.SQLQueryUtils;
 import com.telefonica.iot.cygnus.backends.sql.SQLBackendImpl;
 import com.telefonica.iot.cygnus.backends.sql.Enum.SQLInstance;
+import com.telefonica.iot.cygnus.utils.CommonConstants;
+import com.telefonica.iot.cygnus.utils.NGSICharsets;
+import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import com.telefonica.iot.cygnus.utils.NGSIUtils;
+import org.apache.flume.Context;
+
 import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
 import com.telefonica.iot.cygnus.errors.CygnusBadContextData;
 import com.telefonica.iot.cygnus.errors.CygnusCappingError;
@@ -32,33 +41,27 @@ import com.telefonica.iot.cygnus.errors.CygnusPersistenceError;
 import com.telefonica.iot.cygnus.errors.CygnusRuntimeError;
 import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
 import com.telefonica.iot.cygnus.log.CygnusLogger;
-import com.telefonica.iot.cygnus.utils.*;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import org.apache.flume.Context;
 
 /**
- * The type Ngsi postgre sql sink.
  *
- * @author hermanjunge Detailed documentation can be found at:https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/design/NGSIPostgreSQLSink.md
+ * @author frb
+ * 
+ * Detailed documentation can be found at:
+ * https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/flume_extensions_catalogue/ngsi_oracle_sink.md
  */
-public class NGSIPostgreSQLSink extends NGSISink {
-
+public class NGSIOracleSQLSink extends NGSISink {
+    
     private static final String DEFAULT_ROW_ATTR_PERSISTENCE = "row";
-    private static final String DEFAULT_PASSWORD = "";
-    private static final String DEFAULT_PORT = "5432";
+    private static final String DEFAULT_PASSWORD = "oracle";
+    private static final String DEFAULT_PORT = "1521";
     private static final String DEFAULT_HOST = "localhost";
-    private static final String DEFAULT_USER_NAME = "postgres";
-    private static final String DEFAULT_DATABASE = "postgres";
-    private static final String DEFAULT_ENABLE_CACHE = "false";
+    private static final String DEFAULT_USER_NAME = "system";
+    private static final String DEFAULT_DATABASE = "xe";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
-    private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
-    private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
+    //private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.OracleDriver";
+    private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.driver.OracleDriver";    
+    private static final SQLInstance ORACLE_INSTANCE_NAME = SQLInstance.ORACLE;
     private static final String DEFAULT_FIWARE_SERVICE = "default";
     private static final String ESCAPED_DEFAULT_FIWARE_SERVICE = "default_service";
     private static final String DEFAULT_LAST_DATA_MODE = "insert";
@@ -67,20 +70,22 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private static final String DEFAULT_LAST_DATA_TIMESTAMP_KEY = NGSIConstants.RECV_TIME;
     private static final String DEFAULT_LAST_DATA_SQL_TS_FORMAT = "YYYY-MM-DD HH24:MI:SS.MS";
     private static final int DEFAULT_MAX_LATEST_ERRORS = 100;
+    private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_FORMAT = "YYYY-MM-DD HH24:MI:SS.FF6";
+    private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_TZ_FORMAT = "YYYY-MM-DD\"T\"HH24:MI:SS.FF6 TZR";
+    private static final String DEFAULT_ORACLE_LOCATOR = "false";
 
-    private static final CygnusLogger LOGGER = new CygnusLogger(NGSIPostgreSQLSink.class);
-    private String postgresqlHost;
-    private String postgresqlPort;
-    private String postgresqlDatabase;
-    private String postgresqlUsername;
-    private String postgresqlPassword;
+    private static final CygnusLogger LOGGER = new CygnusLogger(NGSIOracleSQLSink.class);
+    private String oracleHost;
+    private String oraclePort;
+    private String oracleUsername;
+    private String oraclePassword;
+    private String oracleDatabase;    
     private int maxPoolSize;
     private boolean rowAttrPersistence;
-    private SQLBackendImpl postgreSQLPersistenceBackend;
-    private boolean enableCache;
+    private SQLBackendImpl oracleSQLPersistenceBackend;
     private boolean attrNativeTypes;
     private boolean attrMetadataStore;
-    private String postgresqlOptions;
+    private String oracleOptions;
     private boolean persistErrors;
     private String lastDataMode;
     private String lastDataTableSuffix;
@@ -88,62 +93,57 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private String lastDataTimeStampKey;
     private String lastDataSQLTimestampFormat;
     private int maxLatestErrors;
+    private String nlsTimestampFormat;
+    private String nlsTimestampTzFormat;
+    private boolean oracleLocator;
 
     /**
      * Constructor.
      */
-    public NGSIPostgreSQLSink() {
+    public NGSIOracleSQLSink() {
         super();
-    } // NGSIPostgreSQLSink
-
-    /**
-     * Gets the PostgreSQL host. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL host
-     */
-    protected String getPostgreSQLHost() {
-        return postgresqlHost;
-    } // getPostgreSQLHost
+    } // NGSIOracleSQLSink
     
     /**
-     * Gets the PostgreSQL cache. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL cache state
+     * Gets the Oracle host. It is protected due to it is only required for testing purposes.
+     * @return The OracleSQL host
      */
-    protected boolean getEnableCache() {
-        return enableCache;
-    } // getPostgreSQLHost
+    protected String getOracleSQLHost() {
+        return oracleHost;
+    } // getOracleSQLHost
+    
+    /**
+     * Gets the OracleSQL port. It is protected due to it is only required for testing purposes.
+     * @return The OracleSQL port
+     */
+    protected String getOracleSQLPort() {
+        return oraclePort;
+    } // getOracleSQLPort
 
     /**
-     * Gets the PostgreSQL port. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL port
+     * Gets the oracle database. It is protected due to it is only required for testing purposes.
+     * @return The oracle database
      */
-    protected String getPostgreSQLPort() {
-        return postgresqlPort;
-    } // getPostgreSQLPort
+    protected String getOracleSQLDatabase() {
+        return oracleDatabase;
+    } // getOracleSQLDatabase
 
     /**
-     * Gets the PostgreSQL database. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL database
+     * Gets the OracleSQL username. It is protected due to it is only required for testing purposes.
+     * @return The OracleSQL username
      */
-    protected String getPostgreSQLDatabase() {
-        return postgresqlDatabase;
-    } // getPostgreSQLDatabase
-
+    protected String getOracleSQLUsername() {
+        return oracleUsername;
+    } // getOracleSQLUsername
+    
     /**
-     * Gets the PostgreSQL username. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL username
+     * Gets the OracleSQL password. It is protected due to it is only required for testing purposes.
+     * @return The OracleSQL password
      */
-    protected String getPostgreSQLUsername() {
-        return postgresqlUsername;
-    } // getPostgreSQLUsername
-
-    /**
-     * Gets the PostgreSQL password. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL password
-     */
-    protected String getPostgreSQLPassword() {
-        return postgresqlPassword;
-    } // getPostgreSQLPassword
-
+    protected String getOracleSQLPassword() {
+        return oraclePassword;
+    } // getOracleSQLPassword
+    
     /**
      * Returns if the attribute persistence is row-based. It is protected due to it is only required for testing
      * purposes.
@@ -154,14 +154,31 @@ public class NGSIPostgreSQLSink extends NGSISink {
     } // getRowAttrPersistence
 
     /**
-     * Gets the PostgreSQL options. It is protected due to it is only required for testing purposes.
-     * @return The PostgreSQL options
+     * Gets the OracleSQL options. It is protected due to it is only required for testing purposes.
+     * @return The OracleSQL options
      */
-    protected String getPostgreSQLOptions() {
-        return postgresqlOptions;
-    } // getPostgreSQLOptions
+    protected String getOracleSQLOptions() {
+        return oracleOptions;
+    } // getOracleSQLOptions
 
     /**
+     * Returns the persistence backend. It is protected due to it is only required for testing purposes.
+     * @return The persistence backend
+     */
+    protected SQLBackendImpl getPersistenceBackend() {
+        return oracleSQLPersistenceBackend;
+    } // getPersistenceBackend
+    
+    /**
+     * Sets the persistence backend. It is protected due to it is only required for testing purposes.
+     * @param persistenceBackend
+     */
+    protected void setPersistenceBackend(SQLBackendImpl persistenceBackend) {
+        this.oracleSQLPersistenceBackend = persistenceBackend;
+    } // setPersistenceBackend
+
+
+   /**
      * Returns if the attribute value will be native or stringfy. It will be stringfy due to backward compatibility
      * purposes.
      * @return True if the attribute value will be native, false otherwise
@@ -169,54 +186,32 @@ public class NGSIPostgreSQLSink extends NGSISink {
     protected boolean getNativeAttrTypes() {
         return attrNativeTypes;
     } // attrNativeTypes
-
-    /**
-     * Returns the persistence backend. It is protected due to it is only required for testing purposes.
-     * @return The persistence backend
-     */
-    protected SQLBackendImpl getPersistenceBackend() {
-        return postgreSQLPersistenceBackend;
-    } // getPersistenceBackend
-
-    /**
-     * Sets the persistence backend. It is protected due to it is only required for testing purposes.
-     * @param postgreSQLPersistenceBackend
-     */
-    protected void setPersistenceBackend(SQLBackendImpl postgreSQLPersistenceBackend) {
-        this.postgreSQLPersistenceBackend = postgreSQLPersistenceBackend;
-    } // setPersistenceBackend
-
+    
     @Override
     public void configure(Context context) {
-        // Read NGSISink general configuration
-        super.configure(context);
-        
-        // Impose enable lower case, since PostgreSQL only accepts lower case
-        enableLowercase = true;
-        
-        postgresqlHost = context.getString("postgresql_host", DEFAULT_HOST);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_host=" + postgresqlHost + ")");
-        postgresqlPort = context.getString("postgresql_port", DEFAULT_PORT);
-        int intPort = Integer.parseInt(postgresqlPort);
+        oracleHost = context.getString("oracle_host", DEFAULT_HOST);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_host=" + oracleHost + ")");
+        oraclePort = context.getString("oracle_port", DEFAULT_PORT);
+        int intPort = Integer.parseInt(oraclePort);
 
         if ((intPort <= 0) || (intPort > 65535)) {
             invalidConfiguration = true;
-            LOGGER.warn("[" + this.getName() + "] Invalid configuration (postgresql_port=" + postgresqlPort + ")"
-                    + " -- Must be between 0 and 65535");
+            LOGGER.warn("[" + this.getName() + "] Invalid configuration (oracle_port=" + oraclePort + ") "
+                    + "must be between 0 and 65535");
         } else {
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_port=" + postgresqlPort + ")");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_port=" + oraclePort + ")");
         }  // if else
 
-        postgresqlDatabase = context.getString("postgresql_database", DEFAULT_DATABASE);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_database=" + postgresqlDatabase + ")");
-        postgresqlUsername = context.getString("postgresql_username", DEFAULT_USER_NAME);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_username=" + postgresqlUsername + ")");
-        // FIXME: postgresqlPassword should be read as a SHA1 and decoded here
-        postgresqlPassword = context.getString("postgresql_password", DEFAULT_PASSWORD);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_password=" + postgresqlPassword + ")");
+        oracleDatabase = context.getString("oracle_database", DEFAULT_DATABASE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_database=" + oracleDatabase + ")");
+        oracleUsername = context.getString("oracle_username", DEFAULT_USER_NAME);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_username=" + oracleUsername + ")");
+        // FIXME: oraclePassword should be read encrypted and decoded here
+        oraclePassword = context.getString("oracle_password", DEFAULT_PASSWORD);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_password=" + oraclePassword + ")");
 
-        maxPoolSize = context.getInteger("postgresql_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolSize=" + maxPoolSize + ")");
+        maxPoolSize = context.getInteger("oracle_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_maxPoolSize=" + maxPoolSize + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -227,31 +222,18 @@ public class NGSIPostgreSQLSink extends NGSISink {
         } else {
             invalidConfiguration = true;
             LOGGER.warn("[" + this.getName() + "] Invalid configuration (attr_persistence="
-                + persistence + ") -- Must be 'row' or 'column'");
-        }  // if else
-                
-        String enableCacheStr = context.getString("backend.enable_cache", DEFAULT_ENABLE_CACHE);
-        
-        if (enableCacheStr.equals("true") || enableCacheStr.equals("false")) {
-            enableCache = Boolean.valueOf(enableCacheStr);
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (backend.enable_cache=" + enableCache + ")");
-        }  else {
-            invalidConfiguration = true;
-            LOGGER.warn("[" + this.getName() + "] Invalid configuration (backend.enable_cache="
-                + enableCache + ") -- Must be 'true' or 'false'");
+                + persistence + ") must be 'row' or 'column'");
         }  // if else
 
         String attrNativeTypesStr = context.getString("attr_native_types", DEFAULT_ATTR_NATIVE_TYPES);
         if (attrNativeTypesStr.equals("true") || attrNativeTypesStr.equals("false")) {
             attrNativeTypes = Boolean.valueOf(attrNativeTypesStr);
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_native_types=" + attrNativeTypes + ")");
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (attr_native_types=" + attrNativeTypesStr + ")");
         } else {
             invalidConfiguration = true;
-            LOGGER.warn("[" + this.getName() + "] Invalid configuration (attr_native_types="
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_native_types="
                 + attrNativeTypesStr + ") -- Must be 'true' or 'false'");
         } // if else
-
-
 
         String attrMetadataStoreStr = context.getString("attr_metadata_store", "true");
 
@@ -263,7 +245,22 @@ public class NGSIPostgreSQLSink extends NGSISink {
             invalidConfiguration = true;
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (attr_metadata_store="
                     + attrMetadataStoreStr + ") -- Must be 'true' or 'false'");
-        }
+        } // if else
+
+        oracleOptions = context.getString("oracle_options", null);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_options=" + oracleOptions + ")");
+
+        String persistErrorsStr = context.getString("persist_errors", "true");
+
+        if (persistErrorsStr.equals("true") || persistErrorsStr.equals("false")) {
+            persistErrors = Boolean.parseBoolean(persistErrorsStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (persist_errors="
+                    + persistErrors + ")");
+        } else {
+            invalidConfiguration = true;
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (persist_errors="
+                    + persistErrorsStr + ") -- Must be 'true' or 'false'");
+        } // if else
 
         lastDataMode = context.getString("last_data_mode", DEFAULT_LAST_DATA_MODE);
 
@@ -292,52 +289,60 @@ public class NGSIPostgreSQLSink extends NGSISink {
         LOGGER.debug("[" + this.getName() + "] Reading configuration (last_data_sql_timestamp_format="
                 + lastDataSQLTimestampFormat + ")");
 
-        postgresqlOptions = context.getString("postgresql_options", null);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_options=" + postgresqlOptions + ")");
+        nlsTimestampFormat = context.getString("nls_timestamp_format", DEFAULT_ORACLE_NLS_TIMESTAMP_FORMAT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (nls_timestamp_format="
+                + nlsTimestampFormat + ")");
 
-        String persistErrorsStr = context.getString("persist_errors", "true");
+        nlsTimestampTzFormat = context.getString("nls_timestamp_tz_format", DEFAULT_ORACLE_NLS_TIMESTAMP_TZ_FORMAT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (nls_timestamp_tz_format="
+                + nlsTimestampTzFormat + ")");
 
-        if (persistErrorsStr.equals("true") || persistErrorsStr.equals("false")) {
-            persistErrors = Boolean.parseBoolean(persistErrorsStr);
-            LOGGER.debug("[" + this.getName() + "] Reading configuration (persist_errors="
-                    + persistErrors + ")");
+        String oracleLocatorStr = context.getString("oracle_locator", DEFAULT_ORACLE_LOCATOR);
+        if (oracleLocatorStr.equals("true") || oracleLocatorStr.equals("false")) {
+            oracleLocator = Boolean.valueOf(oracleLocatorStr);
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_locator=" + oracleLocatorStr + ")");
         } else {
             invalidConfiguration = true;
-            LOGGER.debug("[" + this.getName() + "] Invalid configuration (persist_errors="
-                    + persistErrorsStr + ") -- Must be 'true' or 'false'");
+            LOGGER.debug("[" + this.getName() + "] Invalid configuration (oracle_locator="
+                + oracleLocatorStr + ") -- Must be 'true' or 'false'");
         } // if else
 
         maxLatestErrors = context.getInteger("max_latest_errors", DEFAULT_MAX_LATEST_ERRORS);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (max_latest_errors=" + maxLatestErrors + ")");
 
+        super.configure(context);
     } // configure
 
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, postgresqlOptions, persistErrors, maxLatestErrors);
-            LOGGER.debug("[" + this.getName() + "] Postgresql persistence backend created");
+            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, oracleOptions, persistErrors, maxLatestErrors);
+            LOGGER.debug("[" + this.getName() + "] OracleSQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " postgresqlHost " + postgresqlHost + " postgresqlPort " + postgresqlPort +
-                "  postgresqlUsername " + postgresqlUsername + " postgresqlPassword " + postgresqlPassword +
-                " maxPoolSize " +  maxPoolSize + " postgresqlOptions " +
-                postgresqlOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
-            LOGGER.error("Error while creating the Postgresql persistence backend. " +
+            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            LOGGER.error("Error while creating the OracleSQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
                          "Stack trace: " + Arrays.toString(e.getStackTrace()));
         } // try catch
-
+        
         super.start();
-        LOGGER.info("[" + this.getName() + "] Startup completed");
     } // start
+
+    @Override
+    public void stop() {
+        super.stop();
+        if (oracleSQLPersistenceBackend != null) oracleSQLPersistenceBackend.close();
+    } // stop
 
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
     private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
-        if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+        if (oracleSQLPersistenceBackend == null) {
+            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            oracleSQLPersistenceBackend.setNlsTimestampFormat(nlsTimestampFormat);
+            oracleSQLPersistenceBackend.setNlsTimestampTzFormat(nlsTimestampTzFormat);
         }
     }
 
@@ -348,7 +353,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
             return;
         } // if
-
+ 
         // Iterate on the destinations
         batch.startIterator();
         
@@ -357,10 +362,10 @@ public class NGSIPostgreSQLSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] Processing sub-batch regarding the "
                     + destination + " destination");
 
-            // get the sub-batch for this destination
+            // Get the events within the current sub-batch
             ArrayList<NGSIEvent> events = batch.getNextEvents();
-
-            // get an aggregator for this destination and initialize it
+            
+            // Get an aggregator for this destination and initialize it
             NGSIGenericAggregator aggregator = getAggregator(rowAttrPersistence);
             aggregator.setService(events.get(0).getServiceForNaming(enableNameMappings));
             aggregator.setServicePathForData(events.get(0).getServicePathForData());
@@ -369,23 +374,24 @@ public class NGSIPostgreSQLSink extends NGSISink {
             aggregator.setEntityType(events.get(0).getEntityTypeForNaming(enableNameMappings));
             aggregator.setAttribute(events.get(0).getAttributeForNaming(enableNameMappings));
             aggregator.setSchemeName(buildSchemaName(aggregator.getService(), aggregator.getServicePathForNaming()));
-            aggregator.setDbName(buildDBName(events.get(0).getServiceForNaming(enableNameMappings)));
+            aggregator.setDbName(buildDbName(aggregator.getService()));
             aggregator.setTableName(buildTableName(aggregator.getServicePathForNaming(), aggregator.getEntityForNaming(), aggregator.getEntityType(), aggregator.getAttribute()));
             aggregator.setAttrNativeTypes(attrNativeTypes);
             aggregator.setAttrMetadataStore(attrMetadataStore);
+            aggregator.setEnableGeoParseOracle(true);
+            aggregator.setEnableGeoParseOracleLocator(oracleLocator);
             aggregator.setEnableNameMappings(enableNameMappings);
             aggregator.setLastDataMode(lastDataMode);
-            aggregator.setLastDataTimestampKey(lastDataTimeStampKey);
             aggregator.setLastDataUniqueKey(lastDataUniqueKey);
+            aggregator.setLastDataTimestampKey(lastDataTimeStampKey);
             aggregator.initialize(events.get(0));
-
             for (NGSIEvent event : events) {
                 aggregator.aggregate(event);
             } // for
             LOGGER.debug("[" + getName() + "] adding event to aggregator object  (name=" +
-                         SQLQueryUtils.getFieldsForInsert(aggregator.getAggregation().keySet(), SQLQueryUtils.POSTGRES_FIELDS_MARK) + ", values=" +
+                         SQLQueryUtils.getFieldsForInsert(aggregator.getAggregation().keySet(), SQLQueryUtils.ORACLE_FIELDS_MARK) + ", values=" +
                          SQLQueryUtils.getValuesForInsert(aggregator.getAggregation(), attrNativeTypes) + ")");
-            // persist the fieldValues
+            // Persist the aggregation
             persistAggregation(aggregator);
             batch.setNextPersisted(true);
         } // for
@@ -393,20 +399,57 @@ public class NGSIPostgreSQLSink extends NGSISink {
     
     @Override
     public void capRecords(NGSIBatch batch, long maxRecords) throws CygnusCappingError {
+        if (batch == null) {
+            LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
+            return;
+        } // if
+
+        // Iterate on the destinations
+        batch.startIterator();
+        
+        while (batch.hasNext()) {
+            // Get the events within the current sub-batch
+            ArrayList<NGSIEvent> events = batch.getNextEvents();
+
+            // Get a representative from the current destination sub-batch
+            NGSIEvent event = events.get(0);
+            
+            // Do the capping
+            String service = event.getServiceForNaming(enableNameMappings);
+            String servicePathForNaming = event.getServicePathForNaming(enableNameMappings);
+            String entity = event.getEntityForNaming(enableNameMappings, enableEncoding);
+            String entityType = event.getEntityTypeForNaming(enableNameMappings);
+            String attribute = event.getAttributeForNaming(enableNameMappings);
+            
+            try {
+                String dbName = buildDbName(service);
+                String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
+                LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
+                        + dbName + ", tableName=" + tableName + ")");
+                oracleSQLPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+            } catch (CygnusBadConfiguration e) {
+                throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
+            } catch (CygnusRuntimeError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusRuntimeError", e.getMessage());
+            } catch (CygnusPersistenceError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusPersistenceError", e.getMessage());
+            } // try catch
+        } // while
     } // capRecords
 
     @Override
     public void expirateRecords(long expirationTime) throws CygnusExpiratingError {
         LOGGER.debug("[" + this.getName() + "] Expirating records (time=" + expirationTime + ")");
+        
         try {
-            postgreSQLPersistenceBackend.expirateRecordsCache(expirationTime);
+            oracleSQLPersistenceBackend.expirateRecordsCache(expirationTime);
         } catch (CygnusRuntimeError e) {
             throw new CygnusExpiratingError("Data expiration error", "CygnusRuntimeError", e.getMessage());
         } catch (CygnusPersistenceError e) {
             throw new CygnusExpiratingError("Data expiration error", "CygnusPersistenceError", e.getMessage());
         } // try catch
     } // expirateRecords
-
+    
     protected NGSIGenericAggregator getAggregator(boolean rowAttrPersistence) {
         if (rowAttrPersistence) {
             return new NGSIGenericRowAggregator();
@@ -414,11 +457,12 @@ public class NGSIPostgreSQLSink extends NGSISink {
             return new NGSIGenericColumnAggregator();
         } // if else
     } // getAggregator
-
-    private void persistAggregation(NGSIGenericAggregator aggregator) throws CygnusPersistenceError, CygnusRuntimeError, CygnusBadContextData {
+    
+    private void persistAggregation(NGSIGenericAggregator aggregator)
+        throws CygnusPersistenceError, CygnusRuntimeError, CygnusBadContextData {
 
         String schemaName = aggregator.getSchemeName(enableLowercase);
-        String databaseName = aggregator.getDbName(enableLowercase);
+        String dbName = aggregator.getDbName(enableLowercase);        
         String tableName = aggregator.getTableName(enableLowercase);
 
         // Escape a syntax error in SQL
@@ -429,46 +473,38 @@ public class NGSIPostgreSQLSink extends NGSISink {
         if (lastDataMode.equals("upsert") || lastDataMode.equals("both")) {
             if (rowAttrPersistence) {
                 LOGGER.warn("[" + this.getName() + "] no upsert due to row mode");
-            }  else {
-                postgreSQLPersistenceBackend.upsertTransaction(aggregator.getAggregationToPersist(),
-                                                               aggregator.getLastDataToPersist(),
-                                                               databaseName,
-                                                               schemaName,
-                                                               tableName,
-                                                               lastDataTableSuffix,
-                                                               lastDataUniqueKey,
-                                                               lastDataTimeStampKey,
-                                                               lastDataSQLTimestampFormat,
-                                                               attrNativeTypes);
+            } else {
+                LOGGER.warn("[" + this.getName() + "] no upsert or both mode avaiable for oracle");
             }
         }
-        if (lastDataMode.equals("insert") || lastDataMode.equals("both")) {
+
+        if (lastDataMode.equals("insert")) {
             try {
                 // Try to insert without create database and table before
-                postgreSQLPersistenceBackend.insertTransaction(aggregator.getAggregationToPersist(),
-                                                               databaseName,
-                                                               schemaName,
-                                                               tableName,
-                                                               attrNativeTypes);
+                oracleSQLPersistenceBackend.insertTransaction(aggregator.getAggregationToPersist(),
+                                                              dbName,
+                                                              schemaName,
+                                                              tableName,
+                                                              attrNativeTypes);
             } catch (CygnusPersistenceError | CygnusBadContextData | CygnusRuntimeError ex) {
                 // creating the database and the table has only sense if working in row mode, in column node
                 // everything must be provisioned in advance
                 if (rowAttrPersistence) {
                     // This case will create a false error entry in error table
                     String fieldsForCreate = SQLQueryUtils.getFieldsForCreate(aggregator.getAggregationToPersist(),
-                                                                              POSTGRESQL_INSTANCE_NAME);
-                     try {
-                         // Try to insert without create database before
-                         postgreSQLPersistenceBackend.createTable(databaseName, schemaName, tableName, fieldsForCreate);
-                     } catch (CygnusRuntimeError | CygnusPersistenceError ex2) {
-                         postgreSQLPersistenceBackend.createDestination(schemaName);
-                         postgreSQLPersistenceBackend.createTable(databaseName, schemaName, tableName, fieldsForCreate);
-                     } // catch
-                     postgreSQLPersistenceBackend.insertTransaction(aggregator.getAggregationToPersist(),
-                                                                    databaseName,
-                                                                    schemaName,
-                                                                    tableName,
-                                                                    attrNativeTypes);
+                                                                              ORACLE_INSTANCE_NAME);
+                    try {
+                        // Try to insert without create database before
+                        oracleSQLPersistenceBackend.createTable(dbName, schemaName, tableName, fieldsForCreate);
+                    } catch (CygnusRuntimeError | CygnusPersistenceError ex2) {
+                        oracleSQLPersistenceBackend.createDestination(schemaName);
+                        oracleSQLPersistenceBackend.createTable(dbName, schemaName, tableName, fieldsForCreate);
+                    } // catch
+                    oracleSQLPersistenceBackend.insertTransaction(aggregator.getAggregationToPersist(),
+                                                                  dbName,
+                                                                  schemaName,
+                                                                  tableName,
+                                                                  attrNativeTypes);
                 } else {
                     // column
                     throw ex;
@@ -476,14 +512,14 @@ public class NGSIPostgreSQLSink extends NGSISink {
             } // catch
         }
     } // persistAggregation
-
+    
     /**
-     * Creates a PostgreSQL DB name given the FIWARE service.
+     * Creates a OracleSQL DB name given the FIWARE service.
      * @param service
-     * @return The PostgreSQL DB name
+     * @return The OracleSQL DB name
      * @throws CygnusBadConfiguration
      */
-    public String buildDBName(String service) throws CygnusBadConfiguration {
+    protected String buildDbName(String service) throws CygnusBadConfiguration {
         String name = null;
 
         if (enableEncoding) {
@@ -495,10 +531,10 @@ public class NGSIPostgreSQLSink extends NGSISink {
                 case DMBYFIXEDENTITYTYPEDATABASE:
                 case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
                     if (service != null)
-                        name = NGSICharsets.encodePostgreSQL(service);
+                        name = NGSICharsets.encodeOracleSQL(service);
                     break;
                 default:
-                    name = postgresqlDatabase;
+                    name = oracleDatabase;
             }
         } else {
             switch(dataModel) {
@@ -512,21 +548,21 @@ public class NGSIPostgreSQLSink extends NGSISink {
                         name = NGSIUtils.encode(service, false, true);
                     break;
                 default:
-                    name = postgresqlDatabase;
+                    name = oracleDatabase;
             }
         } // if else
-        if (name.length() > NGSIConstants.POSTGRESQL_MAX_NAME_LEN) {
-            throw new CygnusBadConfiguration("Building DB name '" + name
-                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_NAME_LEN);
+        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
+            throw new CygnusBadConfiguration("Building database name '" + name
+                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
         } // if
 
         return name;
-    } // buildSchemaName
+    } // buildDbName
 
     /**
-     * Creates a PostgreSQL scheme name given the FIWARE service.
+     * Creates a OracleSQL scheme name given the FIWARE service.
      * @param service
-     * @return The PostgreSQL scheme name
+     * @return The oracleSQL scheme name
      * @throws CygnusBadConfiguration
      */
     public String buildSchemaName(String service, String subService) throws CygnusBadConfiguration {
@@ -537,10 +573,10 @@ public class NGSIPostgreSQLSink extends NGSISink {
                 case DMBYENTITYDATABASESCHEMA:
                 case DMBYENTITYTYPEDATABASESCHEMA:
                 case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
-                    name = NGSICharsets.encodePostgreSQL(subService);
+                    name = NGSICharsets.encodeOracleSQL(subService);
                     break;
                 default:
-                    name = NGSICharsets.encodePostgreSQL(service);
+                    name = NGSICharsets.encodeOracleSQL(service);
             }
         } else {
             switch(dataModel) {
@@ -554,62 +590,56 @@ public class NGSIPostgreSQLSink extends NGSISink {
             }
         } // if else
 
-        if (name.length() > NGSIConstants.POSTGRESQL_MAX_NAME_LEN) {
+        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building schema name '" + name
-                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_NAME_LEN);
+                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
         } // if
 
         return name;
     } // buildSchemaName
-
+    
     /**
-     * Creates a PostgreSQL table name given the FIWARE service path, the entity and the attribute.
+     * Creates a OracleSQL table name given the FIWARE service path, the entity and the attribute.
      * @param servicePath
      * @param entity
      * @param attribute
-     * @return The PostgreSQL table name
+     * @return The OracleSQL table name
      * @throws CygnusBadConfiguration
      */
-    public String buildTableName(String servicePath, String entity, String entityType, String attribute) throws CygnusBadConfiguration {
+    protected String buildTableName(String servicePath, String entity, String entityType, String attribute)
+            throws CygnusBadConfiguration {
         String name;
 
         if (enableEncoding) {
-            switch(dataModel) {
+            switch (dataModel) {
                 case DMBYSERVICEPATH:
-                    name = NGSICharsets.encodePostgreSQL(servicePath);
+                    name = NGSICharsets.encodeOracleSQL(servicePath);
                     break;
-                case DMBYENTITYDATABASE:
-                case DMBYENTITYDATABASESCHEMA:
                 case DMBYENTITY:
-                    name = NGSICharsets.encodePostgreSQL(servicePath)
+                case DMBYENTITYDATABASE:
+                    name = NGSICharsets.encodeOracleSQL(servicePath)
                             + CommonConstants.CONCATENATOR
-                            + NGSICharsets.encodePostgreSQL(entity);
+                            + NGSICharsets.encodeOracleSQL(entity);
                     break;
-                case DMBYENTITYTYPEDATABASE:
-                case DMBYENTITYTYPEDATABASESCHEMA:
                 case DMBYENTITYTYPE:
-                    name = NGSICharsets.encodeMySQL(servicePath)
+                case DMBYENTITYTYPEDATABASE:
+                    name = NGSICharsets.encodeOracleSQL(servicePath)
                             + CommonConstants.CONCATENATOR
-                            + NGSICharsets.encodeMySQL(entityType);
+                            + NGSICharsets.encodeOracleSQL(entityType);
                     break;
                 case DMBYATTRIBUTE:
-                    name = NGSICharsets.encodePostgreSQL(servicePath)
+                    name = NGSICharsets.encodeOracleSQL(servicePath)
                             + CommonConstants.CONCATENATOR
-                            + NGSICharsets.encodePostgreSQL(entity)
+                            + NGSICharsets.encodeOracleSQL(entity)
                             + CommonConstants.CONCATENATOR
-                            + NGSICharsets.encodePostgreSQL(attribute);
-                    break;
-                case DMBYFIXEDENTITYTYPE:
-                case DMBYFIXEDENTITYTYPEDATABASE:
-                case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
-                    name = NGSICharsets.encodePostgreSQL(entityType);
+                            + NGSICharsets.encodeOracleSQL(attribute);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
-                            + "'. Please, use dm-by-service-path, dm-by-entity, dm-by-entity-database, dm-by-entity-database-schema, dm-by-entity-type, dm-by-entity-type-database, dm-by-entity-type-database-schema or dm-by-attribute");
+                            + "'. Please, use dm-by-service-path, dm-by-entity or dm-by-attribute");
             } // switch
         } else {
-            switch(dataModel) {
+            switch (dataModel) {
                 case DMBYSERVICEPATH:
                     if (servicePath.equals("/")) {
                         throw new CygnusBadConfiguration("Default service path '/' cannot be used with "
@@ -619,14 +649,12 @@ public class NGSIPostgreSQLSink extends NGSISink {
                     name = NGSIUtils.encode(servicePath, true, false);
                     break;
                 case DMBYENTITYDATABASE:
-                case DMBYENTITYDATABASESCHEMA:
                 case DMBYENTITY:
                     String truncatedServicePath = NGSIUtils.encode(servicePath, true, false);
                     name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
                             + NGSIUtils.encode(entity, false, true);
                     break;
                 case DMBYENTITYTYPEDATABASE:
-                case DMBYENTITYTYPEDATABASESCHEMA:
                 case DMBYENTITYTYPE:
                     truncatedServicePath = NGSIUtils.encode(servicePath, true, false);
                     name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
@@ -638,23 +666,18 @@ public class NGSIPostgreSQLSink extends NGSISink {
                             + NGSIUtils.encode(entity, false, true)
                             + '_' + NGSIUtils.encode(attribute, false, true);
                     break;
-                case DMBYFIXEDENTITYTYPEDATABASE:
-                case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
-                case DMBYFIXEDENTITYTYPE:
-                    name = NGSIUtils.encode(entityType, false, true);
-                    break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()
-                            + "'. Please, use DMBYSERVICEPATH, DMBYENTITYDATABASE, DMBYENTITYDATABASESCHEMA, DMBYENTITY, DMBYENTITYTYPEDATABASE, DMBYENTITYTYPEDATABASESCHEMA, DMBYENTITYTYPE, DMBYFIXEDENTITYTYPE, DMBYFIXEDENTITYTYPEDATABASE, DMBYFIXEDENTITYTYPEDATABASESCHEMA or DMBYATTRIBUTE");
+                            + "'. Please, use DMBYSERVICEPATH, DMBYENTITY, DMBYENTITYTYPE or DMBYATTRIBUTE");
             } // switch
         } // if else
 
-        if (name.length() > NGSIConstants.POSTGRESQL_MAX_NAME_LEN) {
+        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
             throw new CygnusBadConfiguration("Building table name '" + name
-                    + "' and its length is greater than " + NGSIConstants.POSTGRESQL_MAX_NAME_LEN);
+                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
         } // if
 
         return name;
     } // buildTableName
 
-} // NGSIPostgreSQLSink
+} // NGSIOracleSQLSink

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -462,7 +462,8 @@ public class NGSIPostgisSink extends NGSISink {
                 // everything must be provisioned in advance
                 if (rowAttrPersistence) {
                     // This case will create a false error entry in error table
-                    String fieldsForCreate = SQLQueryUtils.getFieldsForCreate(aggregator.getAggregationToPersist());
+                    String fieldsForCreate = SQLQueryUtils.getFieldsForCreate(aggregator.getAggregationToPersist(),
+                                                                              POSTGIS_INSTANCE_NAME);
                     try {
                         // Try to insert without create database before
                         postgisPersistenceBackend.createTable(dataBaseName, schemaName, tableName, fieldsForCreate);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -73,6 +73,15 @@ public final class NGSICharsets {
         
         return out;
     } // encodePostgreSQL
+
+    /**
+     * Encodes a string for oracleSQL. Just use postgreSQL encoder.
+     * @param in
+     * @return The encoded string
+     */
+    public static String encodeOracleSQL(String in) {
+        return encodePostgreSQL(in);
+    }
     
     /**
      * Encodes a string for HDFS.

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
@@ -95,4 +95,8 @@ public final class NGSIConstants {
     // http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
     public static final int POSTGRESQL_MAX_NAME_LEN = 63;
 
+    // NGSIOracleSQLSink specific constants
+    // https://docs.oracle.com/en/database/oracle/oracle-database/21/odpnt/EFCoreIdentifier.html
+    public static final int ORACLE_MAX_NAME_LEN = 30;    
+
 } // NGSIConstants

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -198,7 +198,7 @@ public class NGSIOracleSQLSinkTest {
     @Test
     public void testConfigureSQLOptionsIsNull() {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                + "-------- postgresqlOptions is null when postgresql_options is not configured");
+                + "-------- oracleOptions is null when oracle_options is not configured");
         String attrPersistence = null;
         String batchSize = null; // default
         String batchTime = null; // default
@@ -217,7 +217,7 @@ public class NGSIOracleSQLSinkTest {
 
         assertNull(sink.getOracleSQLOptions());
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                + "-  OK  - postgresqlOptions is null when it is not configured");
+                + "-  OK  - oracleOptions is null when it is not configured");
     } // testConfigureSQLOptionsIsNull
 
     /**
@@ -226,7 +226,7 @@ public class NGSIOracleSQLSinkTest {
     @Test
     public void testConfigureSQLOptionsHasValue() {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                + "-------- postgresqlOptions has value when postgresql_options is configured");
+                + "-------- oracleOptions has value when oracle_options is configured");
         String attrPersistence = null;
         String batchSize = null; // default
         String batchTime = null; // default
@@ -246,7 +246,7 @@ public class NGSIOracleSQLSinkTest {
 
         assertEquals(sqlOptions, sink.getOracleSQLOptions());
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                + "-  OK  - postgresqlOptions has value when it is configured");
+                + "-  OK  - oracleOptions has value when it is configured");
     } // testConfigureSQLOptionsHasValue
 
     /**
@@ -464,7 +464,7 @@ public class NGSIOracleSQLSinkTest {
         try {
             String builtSchemaName = sink.buildDbName(service);
             // The default vale for the DB name
-            String expectedDBName = "postgres";
+            String expectedDBName = "xe";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -510,7 +510,7 @@ public class NGSIOracleSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildDbName(service);
-            String expectedDBName = "postgres";
+            String expectedDBName = "xe";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -1584,10 +1584,10 @@ public class NGSIOracleSQLSinkTest {
         context.put("data_model", dataModel);
         context.put("enable_encoding", enableEncoding);
         context.put("enable_lowercase", enableLowercase);
-        context.put("postgresql_host", host);
-        context.put("postgresql_password", password);
-        context.put("postgresql_port", port);
-        context.put("postgresql_username", username);
+        context.put("oracle_host", host);
+        context.put("oracle_password", password);
+        context.put("oracle_port", port);
+        context.put("oracle_username", username);
         context.put("backend.enable_cache", cache);
         return context;
     } // createContext
@@ -1603,12 +1603,12 @@ public class NGSIOracleSQLSinkTest {
         context.put("data_model", dataModel);
         context.put("enable_encoding", enableEncoding);
         context.put("enable_lowercase", enableLowercase);
-        context.put("postgresql_host", host);
-        context.put("postgresql_password", password);
-        context.put("postgresql_port", port);
-        context.put("postgresql_username", username);
+        context.put("oracle_host", host);
+        context.put("oracle_password", password);
+        context.put("oracle_port", port);
+        context.put("oracle_username", username);
         context.put("backend.enable_cache", cache);
-        context.put("postgresql_options", sqlOptions);
+        context.put("oracle_options", sqlOptions);
         return context;
     } // createContext
 
@@ -1623,10 +1623,10 @@ public class NGSIOracleSQLSinkTest {
         context.put("data_model", dataModel);
         context.put("enable_encoding", enableEncoding);
         context.put("enable_lowercase", enableLowercase);
-        context.put("postgresql_host", host);
-        context.put("postgresql_password", password);
-        context.put("postgresql_port", port);
-        context.put("postgresql_username", username);
+        context.put("oracle_host", host);
+        context.put("oracle_password", password);
+        context.put("oracle_port", port);
+        context.put("oracle_username", username);
         context.put("backend.enable_cache", cache);
         context.put("attr_native_types", attrNativeTypes);
         return context;

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -370,7 +370,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             String expectedDBName = "someService";
 
             try {
@@ -416,7 +416,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             String expectedDBName = "someService";
 
             try {
@@ -462,7 +462,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             // The default vale for the DB name
             String expectedDBName = "postgres";
 
@@ -509,7 +509,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             String expectedDBName = "postgres";
 
             try {
@@ -556,7 +556,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             String expectedDBName = "somex0053ervice";
 
             try {
@@ -603,7 +603,7 @@ public class NGSIOracleSQLSinkTest {
         String service = "someService";
 
         try {
-            String builtSchemaName = sink.buildDBName(service);
+            String builtSchemaName = sink.buildDbName(service);
             String expectedDBName = "somex0053ervice";
 
             try {

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -913,14 +913,14 @@ public class NGSIOracleSQLSinkTest {
         NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
                 enableLowercase, host, password, port, username, cache));
-        String servicePath = "/somePath";
-        String entity = "someId=someType";
-        String entityType = "someType"; // irrelevant for this test
+        String servicePath = "/somepath";
+        String entity = "someId=someType"; // irrelevant for this test
+        String entityType = "sometype";
         String attribute = null; // irrelevant for this test
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomePathxffffsomeType";
+            String expecetedTableName = "x002fsomepathxffffsometype";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -1,0 +1,1789 @@
+/**
+ * Copyright 2015-2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-cygnus (FIWARE project).
+ *
+ * fiware-cygnus is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * fiware-cygnus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-cygnus. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+
+package com.telefonica.iot.cygnus.sinks;
+
+import static org.junit.Assert.*; // this is required by "fail" like assertions
+
+import com.google.gson.JsonPrimitive;
+import com.telefonica.iot.cygnus.aggregation.NGSIGenericAggregator;
+import com.telefonica.iot.cygnus.containers.NotifyContextRequest;
+import static com.telefonica.iot.cygnus.utils.CommonUtilsForTests.getTestTraceHead;
+import com.telefonica.iot.cygnus.backends.sql.SQLQueryUtils;
+import com.telefonica.iot.cygnus.errors.CygnusBadConfiguration;
+import com.telefonica.iot.cygnus.interceptors.NGSIEvent;
+import com.telefonica.iot.cygnus.utils.CommonConstants;
+import com.telefonica.iot.cygnus.utils.NGSIConstants;
+import com.telefonica.iot.cygnus.utils.NGSIUtils;
+import org.apache.flume.Context;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author 
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class NGSIOracleSQLSinkTest {
+
+    /**
+     * Constructor.
+     */
+    public NGSIOracleSQLSinkTest() {
+        LogManager.getRootLogger().setLevel(Level.FATAL);
+    } // NGSIOracleSQLSinkTest
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- enable_encoding can only be 'true' or 'false'.
+     */
+    @Test
+    public void testConfigureEnableEncoding() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- enable_encoding can only be 'true' or 'false'");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "falso";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "-  OK  - 'enable_encoding=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "- FAIL - 'enable_encoding=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEnableEncoding
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- enable_lowercase can only be 'true' or 'false'.
+     */
+    @Test
+    public void testConfigureEnableLowercase() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- enable_lowercase can only be 'true' or 'false'");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableLowercase = "falso";
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "-  OK  - 'enable_lowercase=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "- FAIL - 'enable_lowercase=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEnableLowercase
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- data_model can only be 'dm-by-service-path' or 'dm-by-entity'.
+     */
+    // TBD: check for dataModel values in NGSIOracleSQLSink and uncomment this test.
+    // @Test
+    public void testConfigureDataModel() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- data_model can only be 'dm-by-service-path' or 'dm-by-entity'");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service";
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "-  OK  - 'data_model=dm-by-service' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "- FAIL - 'data_model=dm-by-service' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureDataModel
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- attr_persistence can only be 'row' or 'column'.
+     */
+    @Test
+    public void testConfigureAttrPersistence() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- attr_persistence can only be 'row' or 'column'");
+        String attrPersistence = "fila";
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "-  OK  - 'attr_persistence=fila' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "- FAIL - 'attr_persistence=fila' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureAttrPersistence
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- sqlOptions is null when it is not configured.
+     */
+    @Test
+    public void testConfigureSQLOptionsIsNull() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- postgresqlOptions is null when postgresql_options is not configured");
+        String attrPersistence = null;
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        assertNull(sink.getOracleSQLOptions());
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-  OK  - postgresqlOptions is null when it is not configured");
+    } // testConfigureSQLOptionsIsNull
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- sqlOptions has value when it is configured.
+     */
+    @Test
+    public void testConfigureSQLOptionsHasValue() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- postgresqlOptions has value when postgresql_options is configured");
+        String attrPersistence = null;
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        String sqlOptions = "sslmode=require";
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache, sqlOptions));
+
+        assertEquals(sqlOptions, sink.getOracleSQLOptions());
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-  OK  - postgresqlOptions has value when it is configured");
+    } // testConfigureSQLOptionsHasValue
+
+    /**
+     * [NGSIOracleSQLSink.buildDBName] -------- The schema name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildSchemaNameOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameOldEncoding]")
+                + "-------- The schema name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+        String servicePath = "someServicePath";
+
+        try {
+            String builtSchemaName = sink.buildSchemaName(service, servicePath);
+            String expectedDBName = "someService";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameOldEncoding]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameOldEncoding]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameOldEncoding]")
+                    + "- FAIL - There was some problem when building the DB name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildDBName] -------- The schema name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildSchemaNameNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameNewEncoding]")
+                + "-------- The schema name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+        String servicePath = "someServicePath";
+
+        try {
+            String builtSchemaName = sink.buildSchemaName(service, servicePath);
+            String expectedDBName = "somex0053ervice";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameNewEncoding]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameNewEncoding]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildSchemaNameNewEncoding]")
+                    + "- FAIL - There was some problem when building the DB name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNewEncoding
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameOldEncodingDatabaseDataModel] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameOldEncodingDatabaseDataModel() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingDatabaseDataModel]")
+                + "-------- The db name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-database"; // default
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            String expectedDBName = "someService";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingDatabaseDataModel]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingDatabaseDataModel]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingDatabaseDataModel]")
+                    + "- FAIL - There was some problem when building the Schema name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameOldEncodingDatabaseDataModel
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameOldEncodingEntityTypeDatabaseDataModel] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameOldEncodingEntityTypeDatabaseDataModel() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingEntityTypeDatabaseDataModel]")
+                + "-------- The db name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type-database"; // default
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            String expectedDBName = "someService";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingEntityTypeDatabaseDataModel]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingEntityTypeDatabaseDataModel]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncodingEntityTypeDatabaseDataModel]")
+                    + "- FAIL - There was some problem when building the Schema name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameOldEncodingEntityTypeDatabaseDataModel
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameOldEncoding] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncoding]")
+                + "-------- The db name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            // The default vale for the DB name
+            String expectedDBName = "postgres";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncoding]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncoding]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameOldEncoding]")
+                    + "- FAIL - There was some problem when building the Schema name");
+            throw e;
+        } // try catch          } // try catch
+    } // testBuildDBNameOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameNewEncoding] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncoding]")
+                + "-------- The DB name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            String expectedDBName = "postgres";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncoding]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncoding]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncoding]")
+                    + "- FAIL - There was some problem when building the DB name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNewEncoding
+
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameNewEncodingDatabaseDataModel] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNewEncodingDatabaseDataModel() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingDatabaseDataModel]")
+                + "-------- The DB name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-database-schema"; // default
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            String expectedDBName = "somex0053ervice";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingDatabaseDataModel]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingDatabaseDataModel]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingDatabaseDataModel]")
+                    + "- FAIL - There was some problem when building the DB name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNewEncodingDatabaseDataModel
+
+
+    /**
+     * [NGSIOracleSQLSink.testBuildDBNameNewEncodingEntityTypeDatabaseDataModel] -------- The DB name is equals to the encoding of the notified/defaulted
+     * service.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildDBNameNewEncodingEntityTypeDatabaseDataModel() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingEntityTypeDatabaseDataModel]")
+                + "-------- The DB name is equals to the encoding of the notified/defaulted service");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type-database-schema"; // default
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "someService";
+
+        try {
+            String builtSchemaName = sink.buildDBName(service);
+            String expectedDBName = "somex0053ervice";
+
+            try {
+                assertEquals(expectedDBName, builtSchemaName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingEntityTypeDatabaseDataModel]")
+                        + "-  OK  - '" + expectedDBName + "' is equals to the encoding of <service>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingEntityTypeDatabaseDataModel]")
+                        + "- FAIL - '" + expectedDBName + "' is not equals to the encoding of <service>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testBuildDBNameNewEncodingEntityTypeDatabaseDataModel]")
+                    + "- FAIL - There was some problem when building the DB name");
+            throw e;
+        } // try catch
+    } // testBuildDBNameNewEncodingEntityTypeDatabaseDataModel
+
+
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the OracleSQL table name is the encoding of <service-path>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByServicePathOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of <service-path>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service-path";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = null; // irrelevant for this test
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "somePath";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByServicePathOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the OracleSQL table name is the encoding of <service-path>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByServicePathNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of <service-path>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service-path";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = null; // irrelevant for this test
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002fsomex0050ath";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByServicePathNewEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entity_id\> and \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByEntityOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entityType = null; // irrelevant for this test
+        String entity = "someId=someType";
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "somePath_someId_someType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>, <entityId> "
+                        + "and <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>, "
+                        + "<entityId> and <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entity_id\> and \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByEntityNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = "someId=someType";
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002fsomex0050athxffffsomex0049dxffffsomex0054ype";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>, <entityId> "
+                        + "and <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>, "
+                        + "<entityId> and <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityNewEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entity_id\> and \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByEntityTypeOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "somePath_someType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>, <entityId> "
+                        + "and <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>, "
+                        + "<entityId> and <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entity_id\> and \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByEntityTypeNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002fsomePathxffffsomeType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>, <entityId> "
+                        + "and <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>, "
+                        + "<entityId> and <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeNewEncoding
+
+
+    // NEW
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByFixedEntityTypeOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-fixed-entity-type";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "someType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
+     * data_model is 'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of \<entity_type\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameNonRootServicePathDataModelByFixedEntityTypeNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a non root service-path is notified/defaulted and data_model is "
+                + "'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-fixed-entity-type";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/somePath";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "somex0054ype";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <entityType>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <entityType>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeNewEncoding
+
+    // NEW END
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the OracleSQL table name cannot be built.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByServicePathOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name cannot be built");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service-path";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = null; // irrelevant for this test
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            sink.buildTableName(servicePath, entity, entityType, attribute);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - The root service path was not detected as not valid");
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "-  OK  - The root service path was detected as not valid");
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByServicePathOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-service-path' the OracleSQL table name is the encoding of \<service-path\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByServicePathNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of <service-path>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service-path";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = null; // irrelevant for this test
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002f";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByServicePathNewEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entityId\> and \<entityType\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByEntityOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = "someId=someType";
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "someId_someType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByEntityOldencoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entityId\> and \<entityType\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByEntityNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-service-path' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = "someId=someType";
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002fxffffsomex0049dxffffsomex0054ype";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByEntityNewEncoding
+
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByEntityTypeOldEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type";
+        String enableEncoding = "false";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "someType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByEntityTypeOldEncoding
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
+     * data_model is 'dm-by-entity' the OracleSQL table name is the encoding of the concatenation of \<service-path\>,
+     * \<entityId\> and \<entityType\>.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameRootServicePathDataModelByEntityTypeNewEncoding() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When a root service-path is notified/defaulted and data_model is "
+                + "'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
+                + "<entityId> and <entityType>");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type";
+        String enableEncoding = "true";
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/";
+        String entity = "someId=someType";
+        String entityType = "someType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
+            String expecetedTableName = "x002fxffffsomeType";
+
+            try {
+                assertEquals(expecetedTableName, builtTableName);
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+            } catch (AssertionError e) {
+                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                throw e;
+            } // try catch
+        } catch (Exception e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - There was some problem when building the table name");
+            throw e;
+        } // try catch
+    } // testBuildTableNameRootServicePathDataModelByEntityTypeNewEncoding
+    /**
+     * [NGSIOracleSQLSink.buildSchemaName] -------- A schema name length greater than 63 characters is detected.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildSchemaNameLength() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
+                + "-------- A schema name length greater than 63 characters is detected");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String service = "tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongService";
+        String servicePath = "someServicePath";
+
+        try {
+            sink.buildSchemaName(service, servicePath);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
+                    + "- FAIL - A schema name length greater than 63 characters has not been detected");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
+                    + "-  OK  - A schema name length greater than 63 characters has been detected");
+        } // try catch
+    } // testBuildSchemaNameLength
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When data model is by service path, a table name length greater
+     * than 63 characters is detected.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameLengthDataModelByServicePath() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When data model is by service path, a table name length greater than 63 characters is "
+                + "detected");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-service-path";
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/tooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongServicePath";
+        String entity = null; // irrelevant for this test
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            sink.buildTableName(servicePath, entity, entityType, attribute);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "-  OK  - A table name length greater than 63 characters has been detected");
+        } // try catch
+    } // testBuildTableNameLengthDataModelByServicePath
+
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When data model is by entity, a table name length greater than 63
+     * characters is detected.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameLengthDataModelByEntity() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When data model is by entity, a table name length greater than 63 characters is detected");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity";
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/tooLooooooooooooooooooooongServicePath";
+        String entity = "tooLooooooooooooooooooooooooooongEntity";
+        String entityType = null; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            sink.buildTableName(servicePath, entity, entityType, attribute);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "-  OK  - A table name length greater than 63 characters has been detected");
+        } // try catch
+    } // testBuildTableNameLengthDataModelByEntity
+
+    /**
+     * [NGSIOracleSQLSink.buildTableName] -------- When data model is by entity, a table name length greater than 63
+     * characters is detected.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameLengthDataModelByEntityType() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When data model is by entity, a table name length greater than 63 characters is detected");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-entity-type";
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/tooLooooooooooooooooooooongServicePath";
+        String entity = "tooLooooooooooooooooooooooooooongEntity";
+        String entityType = "tooLooooooooooooooooooooooooooongEntityType"; // irrelevant for this test
+        String attribute = null; // irrelevant for this test
+
+        try {
+            sink.buildTableName(servicePath, entity, entityType, attribute);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "-  OK  - A table name length greater than 63 characters has been detected");
+        } // try catch
+    } // testBuildTableNameLengthDataModelByEntityType
+
+    /**
+     * [NGSICartoDBSink.buildTableName] -------- When data model is by attribute, a table name length greater than 63
+     * characters is detected.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testBuildTableNameLengthDataModelByAttribute() throws Exception {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                + "-------- When data model is by atribute, a table name length greater than 63 characters is "
+                + "detected");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = "dm-by-attribute";
+        String enableEncoding = null; // default
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = null; // default
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+        String servicePath = "/tooLooooooooooooooongServicePath";
+        String entity = "tooLooooooooooooooooooongEntity";
+        String entityType = null; // irrelevant for this test
+        String attribute = "tooLooooooooooooongAttribute";
+
+        try {
+            sink.buildTableName(servicePath, entity, entityType, attribute);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
+                    + "-  OK  - A table name length greater than 63 characters has been detected");
+        } // try catch
+    } // testBuildTableNameLengthDataModelByAttribute
+
+    /**
+     * [NGSIOracleSQLSink.configure] -------- cache can only be 'true' or 'false'.
+     */
+    @Test
+    public void testConfigureCache() {
+        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                + "-------- cache can only be 'true' or 'false'");
+        String attrPersistence = null; // default
+        String batchSize = null; // default
+        String batchTime = null; // default
+        String batchTTL = null; // default
+        String dataModel = null; // default
+        String enableEncoding = null;
+        String enableLowercase = null; // default
+        String host = null; // default
+        String password = null; // default
+        String port = null; // default
+        String username = null; // default
+        String cache = "falso";
+        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
+        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
+                enableLowercase, host, password, port, username, cache));
+
+        try {
+            assertTrue(sink.getInvalidConfiguration());
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "-  OK  - 'enable_cache=falso' was detected");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
+                    + "- FAIL - 'enable_cache=falso' was not detected");
+            throw e;
+        } // try catch
+    } // testConfigureEnableEncoding
+
+    private Context createContext(String attrPersistence, String batchSize, String batchTime, String batchTTL,
+            String dataModel, String enableEncoding, String enableLowercase, String host,
+            String password, String port, String username, String cache) {
+        Context context = new Context();
+        context.put("attr_persistence", attrPersistence);
+        context.put("batch_size", batchSize);
+        context.put("batch_time", batchTime);
+        context.put("batch_ttl", batchTTL);
+        context.put("data_model", dataModel);
+        context.put("enable_encoding", enableEncoding);
+        context.put("enable_lowercase", enableLowercase);
+        context.put("postgresql_host", host);
+        context.put("postgresql_password", password);
+        context.put("postgresql_port", port);
+        context.put("postgresql_username", username);
+        context.put("backend.enable_cache", cache);
+        return context;
+    } // createContext
+
+    private Context createContext(String attrPersistence, String batchSize, String batchTime, String batchTTL,
+            String dataModel, String enableEncoding, String enableLowercase, String host,
+            String password, String port, String username, String cache, String sqlOptions) {
+        Context context = new Context();
+        context.put("attr_persistence", attrPersistence);
+        context.put("batch_size", batchSize);
+        context.put("batch_time", batchTime);
+        context.put("batch_ttl", batchTTL);
+        context.put("data_model", dataModel);
+        context.put("enable_encoding", enableEncoding);
+        context.put("enable_lowercase", enableLowercase);
+        context.put("postgresql_host", host);
+        context.put("postgresql_password", password);
+        context.put("postgresql_port", port);
+        context.put("postgresql_username", username);
+        context.put("backend.enable_cache", cache);
+        context.put("postgresql_options", sqlOptions);
+        return context;
+    } // createContext
+
+    private Context createContextforNativeTypes(String attrPersistence, String batchSize, String batchTime, String batchTTL,
+                                                String dataModel, String enableEncoding, String enableLowercase, String host,
+                                                String password, String port, String username, String cache, String attrNativeTypes) {
+        Context context = new Context();
+        context.put("attr_persistence", attrPersistence);
+        context.put("batch_size", batchSize);
+        context.put("batch_time", batchTime);
+        context.put("batch_ttl", batchTTL);
+        context.put("data_model", dataModel);
+        context.put("enable_encoding", enableEncoding);
+        context.put("enable_lowercase", enableLowercase);
+        context.put("postgresql_host", host);
+        context.put("postgresql_password", password);
+        context.put("postgresql_port", port);
+        context.put("postgresql_username", username);
+        context.put("backend.enable_cache", cache);
+        context.put("attr_native_types", attrNativeTypes);
+        return context;
+    } // createContextforNativeTypes
+
+    private NotifyContextRequest.ContextElement createContextElementForNativeTypes() {
+        NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
+        NotifyContextRequest.ContextMetadata contextMetadata = new NotifyContextRequest.ContextMetadata();
+        contextMetadata.setName("someString");
+        contextMetadata.setType("string");
+        ArrayList<NotifyContextRequest.ContextMetadata> metadata = new ArrayList<>();
+        metadata.add(contextMetadata);
+        NotifyContextRequest.ContextAttribute contextAttribute1 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute1.setName("someNumber");
+        contextAttribute1.setType("number");
+        contextAttribute1.setContextValue(new JsonPrimitive(2));
+        contextAttribute1.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute2 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute2.setName("somneBoolean");
+        contextAttribute2.setType("Boolean");
+        contextAttribute2.setContextValue(new JsonPrimitive(true));
+        contextAttribute2.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute3 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute3.setName("someDate");
+        contextAttribute3.setType("DateTime");
+        contextAttribute3.setContextValue(new JsonPrimitive("2016-09-21T01:23:00.00Z"));
+        contextAttribute3.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute4 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute4.setName("someGeoJson");
+        contextAttribute4.setType("geo:json");
+        contextAttribute4.setContextValue(new JsonPrimitive("{\"type\": \"Point\",\"coordinates\": [-0.036177,39.986159]}"));
+        contextAttribute4.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute5 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute5.setName("someJson");
+        contextAttribute5.setType("json");
+        contextAttribute5.setContextValue(new JsonPrimitive("{\"String\": \"string\"}"));
+        contextAttribute5.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute6 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute6.setName("someString");
+        contextAttribute6.setType("string");
+        contextAttribute6.setContextValue(new JsonPrimitive("foo"));
+        contextAttribute6.setContextMetadata(null);
+        NotifyContextRequest.ContextAttribute contextAttribute7 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute7.setName("someString2");
+        contextAttribute7.setType("string");
+        contextAttribute7.setContextValue(new JsonPrimitive(""));
+        contextAttribute7.setContextMetadata(null);
+        ArrayList<NotifyContextRequest.ContextAttribute> attributes = new ArrayList<>();
+        attributes.add(contextAttribute1);
+        attributes.add(contextAttribute2);
+        attributes.add(contextAttribute3);
+        attributes.add(contextAttribute4);
+        attributes.add(contextAttribute5);
+        attributes.add(contextAttribute6);
+        attributes.add(contextAttribute7);
+        NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
+        contextElement.setId("someId");
+        contextElement.setType("someType");
+        contextElement.setIsPattern("false");
+        contextElement.setAttributes(attributes);
+        return contextElement;
+    } // createContextElementForNativeTypes
+
+    @Test
+    public void testNativeTypeColumnBatch() throws CygnusBadConfiguration{
+        String attr_native_types = "true"; // default
+        NGSIOracleSQLSink ngsiOracleSQLSink = new NGSIOracleSQLSink();
+        ngsiOracleSQLSink.configure(createContextforNativeTypes("column", null, null, null, null,  null, null, null, null, null, null, null, attr_native_types));
+        // Create a NGSIEvent
+        String timestamp = "1461136795801";
+        String correlatorId = "123456789";
+        String transactionId = "123456789";
+        String originalService = "someService";
+        String originalServicePath = "somePath";
+        String mappedService = "newService";
+        String mappedServicePath = "newPath";
+        String destination = "someDestination";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(NGSIConstants.FLUME_HEADER_TIMESTAMP, timestamp);
+        headers.put(CommonConstants.HEADER_CORRELATOR_ID, correlatorId);
+        headers.put(NGSIConstants.FLUME_HEADER_TRANSACTION_ID, transactionId);
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE, originalService);
+        headers.put(CommonConstants.HEADER_FIWARE_SERVICE_PATH, originalServicePath);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE, mappedService);
+        headers.put(NGSIConstants.FLUME_HEADER_MAPPED_SERVICE_PATH, mappedServicePath);
+        NotifyContextRequest.ContextElement contextElement = createContextElementForNativeTypes();
+        NotifyContextRequest.ContextElement contextElement2 = createContextElement();
+        NGSIEvent ngsiEvent = new NGSIEvent(headers, contextElement.toString().getBytes(), contextElement, null);
+        NGSIEvent ngsiEvent2 = new NGSIEvent(headers, contextElement2.toString().getBytes(), contextElement2, null);
+        NGSIBatch batch = new NGSIBatch();
+        batch.addEvent(destination, ngsiEvent);
+        batch.addEvent(destination, ngsiEvent2);
+        try {
+            batch.startIterator();
+            while (batch.hasNext()) {
+                destination = batch.getNextDestination();
+                ArrayList<NGSIEvent> events = batch.getNextEvents();
+                NGSIGenericAggregator aggregator = ngsiOracleSQLSink.getAggregator(false);
+                aggregator.setService(events.get(0).getServiceForNaming(false));
+                aggregator.setServicePathForData(events.get(0).getServicePathForData());
+                aggregator.setServicePathForNaming(events.get(0).getServicePathForNaming(false));
+                aggregator.setEntityForNaming(events.get(0).getEntityForNaming(false, false));
+                aggregator.setEntityType(events.get(0).getEntityTypeForNaming(false));
+                aggregator.setAttribute(events.get(0).getAttributeForNaming(false));
+                aggregator.setSchemeName(ngsiOracleSQLSink.buildSchemaName(aggregator.getService(), aggregator.getServicePathForNaming()));
+                aggregator.setTableName(ngsiOracleSQLSink.buildTableName(aggregator.getServicePathForNaming(), aggregator.getEntityForNaming(), aggregator.getEntityType(), aggregator.getAttribute()));
+                aggregator.setAttrNativeTypes(true);
+                aggregator.setAttrMetadataStore(true);
+                aggregator.setEnableNameMappings(true);
+                aggregator.setLastDataMode("insert");
+                aggregator.initialize(events.get(0));
+                for (NGSIEvent event : events) {
+                    aggregator.aggregate(event);
+                }
+                String correctBatch = "('someId','someType','somePath','2016-04-20 07:19:55.801',2,'[]',TRUE,'[]','2016-09-21T01:23:00.00Z','[]','{\"type\": \"Point\",\"coordinates\": [-0.036177,39.986159]}','[]','{\"String\": \"string\"}','[]','foo','[]','','[]',NULL,NULL,NULL,NULL),('someId','someType','somePath','2016-04-20 07:19:55.801',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'-3.7167, 40.3833','[{\"name\":\"location\",\"type\":\"string\",\"value\":\"WGS84\"}]','someValue2','[]')";
+                String valuesForInsert = SQLQueryUtils.getValuesForInsert(aggregator.getAggregationToPersist(), aggregator.isAttrNativeTypes());
+                if (valuesForInsert.equals(correctBatch)) {
+                    System.out.println(getTestTraceHead("[NGSIOracleSQLSink.testNativeTypesColumnBatch]")
+                            + "-  OK  - NativeTypesOK");
+                    assertTrue(true);
+                } else {
+                    assertFalse(true);
+                }
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            assertFalse(true);
+        }
+    }
+
+    private NotifyContextRequest.ContextElement createContextElement() {
+        NotifyContextRequest notifyContextRequest = new NotifyContextRequest();
+        NotifyContextRequest.ContextMetadata contextMetadata = new NotifyContextRequest.ContextMetadata();
+        contextMetadata.setName("location");
+        contextMetadata.setType("string");
+        contextMetadata.setContextMetadata(new JsonPrimitive("WGS84"));
+        ArrayList<NotifyContextRequest.ContextMetadata> metadata = new ArrayList<>();
+        metadata.add(contextMetadata);
+        NotifyContextRequest.ContextAttribute contextAttribute1 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute1.setName("someName1");
+        contextAttribute1.setType("geo:point");
+        contextAttribute1.setContextValue(new JsonPrimitive("-3.7167, 40.3833"));
+        contextAttribute1.setContextMetadata(metadata);
+        NotifyContextRequest.ContextAttribute contextAttribute2 = new NotifyContextRequest.ContextAttribute();
+        contextAttribute2.setName("someName2");
+        contextAttribute2.setType("someType2");
+        contextAttribute2.setContextValue(new JsonPrimitive("someValue2"));
+        contextAttribute2.setContextMetadata(null);
+        ArrayList<NotifyContextRequest.ContextAttribute> attributes = new ArrayList<>();
+        attributes.add(contextAttribute1);
+        attributes.add(contextAttribute2);
+        NotifyContextRequest.ContextElement contextElement = new NotifyContextRequest.ContextElement();
+        contextElement.setId("someId");
+        contextElement.setType("someType");
+        contextElement.setIsPattern("false");
+        contextElement.setAttributes(attributes);
+        return contextElement;
+    } // createContextElement
+
+} // NGSIOracleSQLSinkTest

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -1188,17 +1188,17 @@ public class NGSIOracleSQLSinkTest {
      * @throws java.lang.Exception
      */
     @Test
-    public void testBuildTableNameRootServicePathDataModelByEntityTypeNewEncoding() throws Exception {
+    public void testBuildTableNameRootServicePathDataModelByEntityTypeNoEncoding() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
                 + "-------- When a root service-path is notified/defaulted and data_model is "
-                + "'dm-by-entity-type' the OracleSQL table name is the encoding of the concatenation of <service-path>, "
-                + "<entityId> and <entityType>");
+                + "'dm-by-entity-type' and no encoding the OracleSQL table name is the concatenation of <service-path>, "
+                + "<entityType>");
         String attrPersistence = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
         String batchTTL = null; // default
         String dataModel = "dm-by-entity-type";
-        String enableEncoding = "true";
+        String enableEncoding = "false";
         String enableLowercase = null; // default
         String host = null; // default
         String password = null; // default
@@ -1209,21 +1209,21 @@ public class NGSIOracleSQLSinkTest {
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
                 enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
-        String entity = "someId=someType";
-        String entityType = "someType"; // irrelevant for this test
+        String entity = "someId";
+        String entityType = "someType";
         String attribute = null; // irrelevant for this test
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fxffffsomeType";
+            String expecetedTableName = "someType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
                 System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <service-path>");
+                        + "-  OK  - '" + builtTableName + "' is equals to " + expecetedTableName);
             } catch (AssertionError e) {
                 System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <service-path>");
+                        + "- FAIL - '" + builtTableName + "' is not equals to " + expecetedTableName);
                 throw e;
             } // try catch
         } catch (Exception e) {
@@ -1231,15 +1231,15 @@ public class NGSIOracleSQLSinkTest {
                     + "- FAIL - There was some problem when building the table name");
             throw e;
         } // try catch
-    } // testBuildTableNameRootServicePathDataModelByEntityTypeNewEncoding
+    } // testBuildTableNameRootServicePathDataModelByEntityTypeNoEncoding
     /**
-     * [NGSIOracleSQLSink.buildSchemaName] -------- A schema name length greater than 63 characters is detected.
+     * [NGSIOracleSQLSink.buildSchemaName] -------- A schema name length greater than 30 characters is detected.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildSchemaNameLength() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
-                + "-------- A schema name length greater than 63 characters is detected");
+                + "-------- A schema name length greater than 30 characters is detected");
         String attrPersistence = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
@@ -1261,24 +1261,24 @@ public class NGSIOracleSQLSinkTest {
         try {
             sink.buildSchemaName(service, servicePath);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
-                    + "- FAIL - A schema name length greater than 63 characters has not been detected");
+                    + "- FAIL - A schema name length greater than 30 characters has not been detected");
             assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildSchemaName]")
-                    + "-  OK  - A schema name length greater than 63 characters has been detected");
+                    + "-  OK  - A schema name length greater than 30 characters has been detected");
         } // try catch
     } // testBuildSchemaNameLength
 
     /**
      * [NGSIOracleSQLSink.buildTableName] -------- When data model is by service path, a table name length greater
-     * than 63 characters is detected.
+     * than 30 characters is detected.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildTableNameLengthDataModelByServicePath() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When data model is by service path, a table name length greater than 63 characters is "
+                + "-------- When data model is by service path, a table name length greater than 30 characters is "
                 + "detected");
         String attrPersistence = null; // default
         String batchSize = null; // default
@@ -1303,24 +1303,24 @@ public class NGSIOracleSQLSinkTest {
         try {
             sink.buildTableName(servicePath, entity, entityType, attribute);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+                    + "- FAIL - A table name length greater than 30 characters has not been detected");
             assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "-  OK  - A table name length greater than 63 characters has been detected");
+                    + "-  OK  - A table name length greater than 30 characters has been detected");
         } // try catch
     } // testBuildTableNameLengthDataModelByServicePath
 
     /**
-     * [NGSICartoDBSink.buildTableName] -------- When data model is by entity, a table name length greater than 63
+     * [NGSICartoDBSink.buildTableName] -------- When data model is by entity, a table name length greater than 30
      * characters is detected.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildTableNameLengthDataModelByEntity() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When data model is by entity, a table name length greater than 63 characters is detected");
+                + "-------- When data model is by entity, a table name length greater than 30 characters is detected");
         String attrPersistence = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
@@ -1344,24 +1344,24 @@ public class NGSIOracleSQLSinkTest {
         try {
             sink.buildTableName(servicePath, entity, entityType, attribute);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+                    + "- FAIL - A table name length greater than 30 characters has not been detected");
             assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "-  OK  - A table name length greater than 63 characters has been detected");
+                    + "-  OK  - A table name length greater than 30 characters has been detected");
         } // try catch
     } // testBuildTableNameLengthDataModelByEntity
 
     /**
-     * [NGSIOracleSQLSink.buildTableName] -------- When data model is by entity, a table name length greater than 63
+     * [NGSIOracleSQLSink.buildTableName] -------- When data model is by entity, a table name length greater than 30
      * characters is detected.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildTableNameLengthDataModelByEntityType() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When data model is by entity, a table name length greater than 63 characters is detected");
+                + "-------- When data model is by entity, a table name length greater than 30 characters is detected");
         String attrPersistence = null; // default
         String batchSize = null; // default
         String batchTime = null; // default
@@ -1385,24 +1385,24 @@ public class NGSIOracleSQLSinkTest {
         try {
             sink.buildTableName(servicePath, entity, entityType, attribute);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+                    + "- FAIL - A table name length greater than 30 characters has not been detected");
             assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "-  OK  - A table name length greater than 63 characters has been detected");
+                    + "-  OK  - A table name length greater than 30 characters has been detected");
         } // try catch
     } // testBuildTableNameLengthDataModelByEntityType
 
     /**
-     * [NGSICartoDBSink.buildTableName] -------- When data model is by attribute, a table name length greater than 63
+     * [NGSICartoDBSink.buildTableName] -------- When data model is by attribute, a table name length greater than 30
      * characters is detected.
      * @throws java.lang.Exception
      */
     @Test
     public void testBuildTableNameLengthDataModelByAttribute() throws Exception {
         System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When data model is by atribute, a table name length greater than 63 characters is "
+                + "-------- When data model is by atribute, a table name length greater than 30 characters is "
                 + "detected");
         String attrPersistence = null; // default
         String batchSize = null; // default
@@ -1427,12 +1427,12 @@ public class NGSIOracleSQLSinkTest {
         try {
             sink.buildTableName(servicePath, entity, entityType, attribute);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - A table name length greater than 63 characters has not been detected");
+                    + "- FAIL - A table name length greater than 30 characters has not been detected");
             assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
             System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "-  OK  - A table name length greater than 63 characters has been detected");
+                    + "-  OK  - A table name length greater than 30 characters has been detected");
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
 

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -1436,39 +1436,6 @@ public class NGSIOracleSQLSinkTest {
         } // try catch
     } // testBuildTableNameLengthDataModelByAttribute
 
-    /**
-     * [NGSIOracleSQLSink.configure] -------- cache can only be 'true' or 'false'.
-     */
-    @Test
-    public void testConfigureCache() {
-        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                + "-------- cache can only be 'true' or 'false'");
-        String attrPersistence = null; // default
-        String batchSize = null; // default
-        String batchTime = null; // default
-        String batchTTL = null; // default
-        String dataModel = null; // default
-        String enableEncoding = null;
-        String enableLowercase = null; // default
-        String host = null; // default
-        String password = null; // default
-        String port = null; // default
-        String username = null; // default
-        String cache = "falso";
-        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableLowercase, host, password, port, username, cache));
-
-        try {
-            assertTrue(sink.getInvalidConfiguration());
-            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                    + "-  OK  - 'enable_cache=falso' was detected");
-        } catch (AssertionError e) {
-            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.configure]")
-                    + "- FAIL - 'enable_cache=falso' was not detected");
-            throw e;
-        } // try catch
-    } // testConfigureEnableEncoding
 
     private Context createContext(String attrPersistence, String batchSize, String batchTime, String batchTTL,
             String dataModel, String enableEncoding, String enableLowercase, String host,

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -805,14 +805,14 @@ public class NGSIOracleSQLSinkTest {
         NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
                 enableLowercase, host, password, port, username, cache));
-        String servicePath = "/somePath";
-        String entity = "someId=someType";
+        String servicePath = "/somepath";
+        String entity = "id=type";
         String entityType = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050athxffffsomex0049dxffffsomex0054ype";
+            String expecetedTableName = "x002fsomepathxffffidxfffftype";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -940,109 +940,6 @@ public class NGSIOracleSQLSinkTest {
         } // try catch
     } // testBuildTableNameNonRootServicePathDataModelByEntityTypeNewEncoding
 
-
-    // NEW
-    /**
-     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
-     * data_model is 'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of \<entity_type\>.
-     * @throws java.lang.Exception
-     */
-    @Test
-    public void testBuildTableNameNonRootServicePathDataModelByFixedEntityTypeOldEncoding() throws Exception {
-        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When a non root service-path is notified/defaulted and data_model is "
-                + "'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of <entityType>");
-        String attrPersistence = null; // default
-        String batchSize = null; // default
-        String batchTime = null; // default
-        String batchTTL = null; // default
-        String dataModel = "dm-by-fixed-entity-type";
-        String enableEncoding = "false";
-        String enableLowercase = null; // default
-        String host = null; // default
-        String password = null; // default
-        String port = null; // default
-        String username = null; // default
-        String cache = null; // default
-        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableLowercase, host, password, port, username, cache));
-        String servicePath = "/somePath";
-        String entity = "someId=someType";
-        String entityType = "someType"; // irrelevant for this test
-        String attribute = null; // irrelevant for this test
-
-        try {
-            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "someType";
-
-            try {
-                assertEquals(expecetedTableName, builtTableName);
-                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <entityType>");
-            } catch (AssertionError e) {
-                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <entityType>");
-                throw e;
-            } // try catch
-        } catch (Exception e) {
-            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - There was some problem when building the table name");
-            throw e;
-        } // try catch
-    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeOldEncoding
-
-    /**
-     * [NGSIOracleSQLSink.buildTableName] -------- When a non root service-path is notified/defaulted and
-     * data_model is 'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of \<entity_type\>.
-     * @throws java.lang.Exception
-     */
-    @Test
-    public void testBuildTableNameNonRootServicePathDataModelByFixedEntityTypeNewEncoding() throws Exception {
-        System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                + "-------- When a non root service-path is notified/defaulted and data_model is "
-                + "'dm-by-fixed-entity-type' the OracleSQL table name is the encoding of <entityType>");
-        String attrPersistence = null; // default
-        String batchSize = null; // default
-        String batchTime = null; // default
-        String batchTTL = null; // default
-        String dataModel = "dm-by-fixed-entity-type";
-        String enableEncoding = "true";
-        String enableLowercase = null; // default
-        String host = null; // default
-        String password = null; // default
-        String port = null; // default
-        String username = null; // default
-        String cache = null; // default
-        NGSIOracleSQLSink sink = new NGSIOracleSQLSink();
-        sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
-                enableLowercase, host, password, port, username, cache));
-        String servicePath = "/somePath";
-        String entity = "someId=someType";
-        String entityType = "someType"; // irrelevant for this test
-        String attribute = null; // irrelevant for this test
-
-        try {
-            String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "somex0054ype";
-
-            try {
-                assertEquals(expecetedTableName, builtTableName);
-                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "-  OK  - '" + builtTableName + "' is equals to the encoding of <entityType>");
-            } catch (AssertionError e) {
-                System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                        + "- FAIL - '" + builtTableName + "' is not equals to the encoding of <entityType>");
-                throw e;
-            } // try catch
-        } catch (Exception e) {
-            System.out.println(getTestTraceHead("[NGSIOracleSQLSink.buildTableName]")
-                    + "- FAIL - There was some problem when building the table name");
-            throw e;
-        } // try catch
-    } // testBuildTableNameNonRootServicePathDataModelByEntityTypeNewEncoding
-
-    // NEW END
 
     /**
      * [NGSIOracleSQLSink.buildTableName] -------- When a root service-path is notified/defaulted and
@@ -1214,13 +1111,13 @@ public class NGSIOracleSQLSinkTest {
         sink.configure(createContext(attrPersistence, batchSize, batchTime, batchTTL, dataModel, enableEncoding,
                 enableLowercase, host, password, port, username, cache));
         String servicePath = "/";
-        String entity = "someId=someType";
+        String entity = "someid=sometype";
         String entityType = null; // irrelevant for this test
         String attribute = null; // irrelevant for this test
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fxffffsomex0049dxffffsomex0054ype";
+            String expecetedTableName = "x002fxffffsomeidxffffsometype";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);

--- a/doc/cygnus-common/backends_catalogue/sql_backend.md
+++ b/doc/cygnus-common/backends_catalogue/sql_backend.md
@@ -1,16 +1,16 @@
 # SQL backend
-## `SQLBackend` interface	
-This class enumerates the methods any backend implementation must expose. In this case, the following ones:	
+## `SQLBackend` interface
+This class enumerates the methods any backend implementation must expose. In this case, the following ones:
 
-    void createDatabase(String destination) throws Exception;	
+    void createDatabase(String destination) throws Exception;
 
-> Creates a database/scheme, given its name, if not existing.	
+> Creates a database/scheme, given its name, if not existing.
 
-    void createTable(String destination, String tableName, String fieldNames) throws Exception;	
+    void createTable(String destination, String tableName, String fieldNames) throws Exception;
 
-> Creates a table, given its name, if not existing within the given database/scheme. The field names are given as well.	
+> Creates a table, given its name, if not existing within the given database/scheme. The field names are given as well.
 
-    insertContextData(String destination, String tableName, String fieldNames, String fieldValues) throws Exception;	
+    insertContextData(String destination, String tableName, String fieldNames, String fieldValues) throws Exception;
 
 > Persists the accumulated context data (in the form of the given field values) regarding an entity within the given table. This table belongs to the given database/scheme. The field names are given as well to ensure the right insert of the field values.
 
@@ -24,6 +24,7 @@ This class also has methods to execute any SQL query.
 
 - [PostgreSQL JDBC driver](https://jdbc.postgresql.org/).
 - [MySQL JDBC driver](https://dev.mysql.com/downloads/connector/j/).
+- [Oracle JDBC driver](https://www.oracle.com/database/technologies/appdev/jdbc.html).
 
 It must be said this backend implementation enforces UTF-8 encoding through the usage of `charSet=UTF-8` property when getting a connection via the JDBC driver.
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/README.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/README.md
@@ -16,6 +16,7 @@
         * [Last Data Functionality](./last_data_function.md)
     * [NGSIPostGISSink](./ngsi_postgis_sink.md)
         * [Last Data Functionality](./last_data_function.md)
+    * [NGSIOracleSQLSink](./ngsi_oracle_sink.md)
     * [NGSISTHSink](./ngsi_sth_sink.md)
     * [NGSIOrionSink](./ngsi_orion_sink.md)
     * [NGSIElasticsearchSink](./ngsi_elasticsearch_sink.md)

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
@@ -1,0 +1,381 @@
+# <a name="top"></a>NGSIOracleSQLSink
+Content:
+
+* [Functionality](#section1)
+    * [Mapping NGSI events to `NGSIEvent` objects](#section1.1)
+    * [Mapping `NGSIEvent`s to Oracle data structures](#section1.2)
+        * [Oracle databases naming conventions](#section1.2.1)
+        * [Oracle tables naming conventions](#section1.2.2)
+        * [Row-like storing](#section1.2.3)
+        * [Column-like storing](#section1.2.4)
+        * [Native attribute type](#section1.2.5)
+    * [Example](#section1.3)
+        * [`NGSIEvent`](#section1.3.1)
+        * [Database and table names](#section1.3.2)
+        * [Row-like storing](#section1.3.3)
+        * [Column-like storing](#section1.3.4)
+* [Administration guide](#section2)
+    * [Configuration](#section2.1)
+    * [Use cases](#section2.2)
+    * [Important notes](#section2.3)
+        * [About the persistence mode](#section2.3.2)
+        * [About batching](#section2.3.3)
+        * [Time zone information](#section2.3.4)
+        * [About the encoding](#section2.3.5)
+        * [About capping resources/expirating records](#section2.3.6)
+* [Programmers guide](#section3)
+    * [`NGSIOracleSQLSink` class](#section3.1)
+    * [Authentication and authorization](#section3.2)
+
+## <a name="section1"></a>Functionality
+`com.iot.telefonica.cygnus.sinks.NGSIOracleSQLSink`, or simply `NGSIOracleSQLSink` is a sink designed to persist NGSI-like context data events within a [Oracle server](https://www.oracle.com/). Usually, such a context data is notified by a [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance, but could be any other system speaking the <i>NGSI language</i>.
+
+Independently of the data generator, NGSI context data is always transformed into internal `NGSIEvent` objects at Cygnus sources. In the end, the information within these events must be mapped into specific Oracle data structures.
+
+Next sections will explain this in detail.
+
+[Top](#top)
+
+### <a name="section1.1"></a>Mapping NGSI events to `NGSIEvent` objects
+Notified NGSI events (containing context data) are transformed into `NGSIEvent` objects (for each context element a `NGSIEvent` is created; such an event is a mix of certain headers and a `ContextElement` object), independently of the NGSI data generator or the final backend where it is persisted.
+
+This is done at the cygnus-ngsi Http listeners (in Flume jergon, sources) thanks to [`NGSIRestHandler`](/ngsi_rest_handler.md). Once translated, the data (now, as `NGSIEvent` objects) is put into the internal channels for future consumption (see next section).
+
+[Top](#top)
+
+### <a name="section1.2"></a>Mapping `NGSIEvent`s to Oracle data structures
+Oracle organizes the data in databases that contain tables of data rows. Such organization is exploited by `NGSIOracleSQLSink` each time a `NGSIEvent` is going to be persisted.
+
+[Top](#top)
+
+#### <a name="section1.2.1"></a>Oracle databases naming conventions
+A database named as the notified `fiware-service` header value (or, in absence of such a header, the defaulted value for the FIWARE service) is created (if not existing yet).
+
+It must be said Oracle [only accepts](https://docs.oracle.com/cd/E92917_01/PDF/8.1.x.x/common/HTML/DM_Naming/2_Table_and_Column_Naming_Standards.htm) alphanumerics `$`, `_` and `#`. This leads to certain [encoding](#section2.3.3) is applied depending on the `enable_encoding` configuration parameter.
+
+Oracle prior version to 12.2 [databases name length](https://docs.oracle.com/en/database/oracle/oracle-database/21/odpnt/EFCoreIdentifier.html) is limited to 30 characters.
+
+[Top](#top)
+
+#### <a name="section1.2.2"></a>Oracle tables naming conventions
+The name of these tables depends on the configured data model (see the [Configuration](#section2.1) section for more details):
+
+* Data model by service path (`data_model=dm-by-service-path`). As the data model name denotes, the notified FIWARE service path (or the configured one as default in [`NGSIRestHandler`](./ngsi_rest_handler.md) is used as the name of the table. This allows the data about all the NGSI entities belonging to the same service path is stored in this unique table. The only constraint regarding this data model is the FIWARE service path cannot be the root one (`/`).
+* Data model by entity (`data_model=dm-by-entity`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity ID and type in order to compose the table name. The concatenation character is `_` (underscore). If the FIWARE service path is the root one (`/`) then only the entity ID and type are concatenated.
+* Data model by entity type (`data_model=dm-by-entity-type`). For each entity, the notified/default FIWARE service path is concatenated to the notified entity type in order to compose the table name. The concatenation character is `_` (underscore). If the FIWARE service path is the root one (`/`) then only the entity type is concatenated.
+
+It must be said Oracle [only accepts](https://docs.oracle.com/cd/E92917_01/PDF/8.1.x.x/common/HTML/DM_Naming/2_Table_and_Column_Naming_Standards.htm) alphanumerics `$`, `_` and `#`. This leads to certain [encoding](#section2.3.3) is applied depending on the `enable_encoding` configuration parameter.
+
+Oracle prior version to 12.2 [databases name length](https://docs.oracle.com/en/database/oracle/oracle-database/21/odpnt/EFCoreIdentifier.html) is limited to 30 characters.
+
+
+The following table summarizes the table name composition (old encoding):
+
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-entity-type` |
+|---|---|---|---|
+| `/` | N/A | `<entityId>_<entityType>` | `<entityType>` |
+| `/<svcPath>` | `<svcPath>` | `<svcPath>_<entityId>_<entityType>` | `<svcPath>_<entityType>` |
+
+The following table summarizes the table name composition (new encoding):
+
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-entity-type` |
+|---|---|---|---|
+| `/` | `x002f` | `x002fxffff<entityId>xffff<entityType>` | `x002fxffff<entityType>` |
+| `/<svcPath>` | `x002f<svcPath>` | `x002f<svcPath>xffff<entityId>xffff<entityType>` |`x002f<svcPath>xffff<entityType>` |
+
+Please observe the concatenation of entity ID and type is already given in the `notified_entities` header value within the `NGSIEvent`.
+
+[Top](#top)
+
+#### <a name="section1.2.3"></a>Row-like storing
+Regarding the specific data stored within the above table, if `attr_persistence` parameter is set to `row` (default storing mode) then the notified data is stored attribute by attribute, composing an insert for each one of them. Each insert contains the following fields:
+
+* `recvTimeTs`: UTC timestamp expressed in miliseconds.
+* `recvTime`: UTC timestamp in human-readable format ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601)).
+* `fiwareServicePath`: Notified fiware-servicePath, or the default configured one if not notified.
+* `entityId`: Notified entity identifier.
+* `entityType`: Notified entity type.
+* `attrName`: Notified attribute name.
+* `attrType`: Notified attribute type.
+* `attrValue`: In its simplest form, this value is just a string, but since Orion 0.11.0 it can be Json object or Json array.
+* `attrMd`: It contains a string serialization of the metadata array for the attribute in Json (if the attribute hasn't metadata, an empty array `[]` is inserted). Will be stored only if it was configured to (attr_metadata_store set to true in the configuration file ngsi_agent.conf). It is a Json object.
+
+[Top](#top)
+
+#### <a name="section1.2.4"></a>Column-like storing
+Regarding the specific data stored within the above table, if `attr_persistence` parameter is set to `column` then a single line is composed for the whole notified entity, containing the following fields:
+
+* `recvTime`: Timestamp in human-readable format (Similar to [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601), but avoiding the `Z` character denoting UTC, since all Oracle timestamps are supposed to be in UTC format).
+* `fiwareServicePath`: The notified one or the default one.
+* `entityId`: Notified entity identifier.
+* `entityType`: Notified entity type.
+*  For each notified attribute, a field named as the attribute is considered. This field will store the attribute values along the time.
+*  For each notified attribute, a field named as the concatenation of the attribute name and `_md` is considered. This field will store the attribute's metadata values along the time.
+
+[Top](#top)
+
+
+
+#### <a name="section1.2.5">Native types
+
+Regarding the specific data stored within the above table, if `attr_native_types` parameter is set to `true` then attribute is inserted using its native type (according with the following table), if `false` then will be stringify.
+
+Type json     | Type
+------------- | --------------------------------------- 
+string        | varchar, varchar2, clob
+number        | NUMBER(precision, scale)
+boolean       | boolean (TRUE, FALSE, YES, NO, ON, OFF)
+DateTime      | timestamp, timestamp with time zone, timestamp without time zone
+json          | varchar, varchar2, clob - it`s treated as String
+null          | NULL
+
+This only applies to Column mode.
+
+[Top](#top)
+
+### <a name="section1.3"></a>Example
+#### <a name="section1.3.1"></a>`NGSIEvent`
+Assuming the following `NGSIEvent` is created from a notified NGSI context data (the code below is an <i>object representation</i>, not any real data format):
+
+    ngsi-event={
+        headers={
+             content-type=application/json,
+             timestamp=1429535775,
+             transactionId=1429535775-308-0000000000,
+             correlationId=1429535775-308-0000000000,
+             fiware-service=vehicles,
+             fiware-servicepath=/4wheels,
+             <name_mappings_interceptor_headers>
+        },
+        body={
+            entityId=car1,
+            entityType=car,
+            attributes=[
+                {
+                    attrName=speed,
+                    attrType=float,
+                    attrValue=112.9
+                },
+                {
+                    attrName=oil_level,
+                    attrType=float,
+                    attrValue=74.6
+                }
+            ]
+        }
+    }
+
+[Top](#top)
+
+#### <a name="section1.3.2"></a>Database and table names
+The Oracle database name will always be `vehicles`.
+
+The Oracle table names will be, depending on the configured data model, the following ones (old encoding):
+
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-entity-type` |
+|---|---|---|---|
+| `/` | N/A | `car1_car` | `car` |
+| `/4wheels` | `4wheels` | `4wheels_car1_car` | `4wheels_car` |
+
+Using the new encoding:
+
+| FIWARE service path | `dm-by-service-path` | `dm-by-entity` | `dm-by-entity` |
+|---|---|---|---|
+| `/` | `x002f` | `x002fxffffcar1xffffcar` | `x002fxffffcar` |
+| `/wheels` | `x002f4wheels` | `x002f4wheelsxffffcar1xffffcar` | `x002f4wheelsxffffcar` |
+
+[Top](#top)
+
+#### <a name="section1.3.3"></a>Row-like storing
+Assuming `attr_persistence=row` as configuration parameter, then `NGSIOracleSQLSink` will persist the data within the body as:
+
+    sqlplus> select * from 4wheels_car1_car;
+    +------------+----------------------------+-------------------+----------+------------+-------------+-----------+-----------+--------+
+    | recvTimeTs | recvTime                   | fiwareServicePath | entityId | entityType | attrName    | attrType  | attrValue | attrMd |
+    +------------+----------------------------+-------------------+----------+------------+-------------+-----------+-----------+--------+
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | 4wheels           | car1     | car        |  speed      | float     | 112.9     | []     |
+    | 1429535775 | 2015-04-20T12:13:22.41.124 | 4wheels           | car1     | car        |  oil_level  | float     | 74.6      | []     |
+    +------------+----------------------------+-------------------+----------+------------+-------------+-----------+-----------+--------+
+    2 row in set (0.00 sec)
+
+[Top](#top)
+
+#### <a name="section1.3.4"></a>Column-like storing
+If `attr_persistence=colum` then `NGSIOracleSQLSink` will persist the data within the body as:
+
+    sqlplus> select * from 4wheels_car1_car;
+    +----------------------------+-------------------+----------+------------+-------+----------+-----------+--------------+
+    | recvTime                   | fiwareServicePath | entityId | entityType | speed | speed_md | oil_level | oil_level_md |
+    +----------------------------+-------------------+----------+------------+-------+----------+-----------+--------------+
+    | 2015-04-20T12:13:22.41.124 | 4wheels           | car1     | car        | 112.9 | []       |  74.6     | []           |
+    +----------------------------+-------------------+----------+------------+-------+----------+-----------+--------------+
+    1 row in set (0.00 sec)
+
+[Top](#top)
+
+## <a name="section2"></a>Administration guide
+### <a name="section2.1"></a>Configuration
+`NGSIOracleSQLSink` is configured through the following parameters:
+
+| Parameter | Mandatory | Default value | Comments |
+|---|---|---|---|
+| type | yes | N/A | Must be <i>com.telefonica.iot.cygnus.sinks.NGSIOracleSQLSink</i> |
+| channel | yes | N/A ||
+| enable_encoding | no | false | <i>true</i> or <i>false</i>, <i>true</i> applies the new encoding, <i>false</i> applies the old encoding. ||
+| enable\_name\_mappings | no | false | <i>true</i> or <i>false</i>. Check this [link](./ngsi_name_mappings_interceptor.md) for more details. ||
+| enable\_lowercase | no | false | <i>true</i> or <i>false</i>. |
+| last\_data\_mode | no | insert | <i>insert</i>  to set last data mode. Check this [link](./last_data_function.md) for more details. In oracle sink <i>both</i> and <i>upsert</i> are not avaiable |
+| last\_data\_table\_suffix | no | false | This suffix will be added to the table name in order to know where Cygnus will store the last record of an entity. Check this [link](./last_data_function.md) for more details. |
+| last\_data\_unique\_key | no | entityId | This must be a unique key on the database to find when a previous record exists. Check this [link](./last_data_function.md) for more details. |
+| last\_data\_timestamp\_key | no | recvTime | This must be a timestamp key on the aggregation to know which record is older. Check this [link](./last_data_function.md) for more details. |
+| last\_data\_sql_timestamp\_format | no | YYYY-MM-DD HH24:MI:SS.MS | This must be a timestamp format to cast [SQL Text to timestamp](https://dev.oracle.com/doc/refman/8.0/en/date-and-time-functions.html). Check this [link](./last_data_function.md) for more details. |
+| data\_model | no | dm-by-entity | <i>dm-by-service-path</i>, <i>dm-by-entity</i> or <i>dm-by-entity-type</i>. <i>dm-by-service</i> and <dm-by-attribute</i> are not currently supported. |
+| oracle\_host | no | localhost | FQDN/IP address where the Oracle server runs |
+| oracle\_port | no | 1521 ||
+| oracle\_username | no |  system | `system` is the default username that is created automatically |
+| oracle\_password | no | oracle | `oracle` is the default for default username |
+| oracle\_database | no | xe | `xe` is the default database avaiable in oracle 11g XE (express edition) |
+| oracle\_maxPoolSize | no | 3 | Max number of connections per database pool |
+| oracle\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `useSSL=true&requireSSL=false` is set to `oracle_options`, jdbc url will become like <b>jdbc:oracle://oracle.example.com:3306/fiwareservice?useSSL=true&requireSSL=false</b>|
+| attr\_persistence | no | row | <i>row</i> or <i>column</i>
+| attr\_metadata\_store | no | false | <i>true</i> or <i>false</i>. |
+| batch\_size | no | 1 | Number of events accumulated before persistence. |
+| batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
+| batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
+| batch\_retry\_intervals | no | 5000 | Comma-separated list of intervals (in miliseconds) at which the retries regarding not persisted batches will be done. First retry will be done as many miliseconds after as the first value, then the second retry will be done as many miliseconds after as second value, and so on. If the batch\_ttl is greater than the number of intervals, the last interval is repeated. |
+| persistence\_policy.max_records | no | -1 | Maximum number of records allowed for a table before it is capped. `-1` disables this policy. |
+| persistence\_policy.expiration_time | no | -1 | Maximum number of seconds a record is maintained in a table before expiration. `-1` disables this policy. |
+| persistence\_policy.checking_time | no | 3600 | Frequency (in seconds) at which the sink checks for record expiration. |
+| attr\_native\_types | no | false | if the attribute value will be native <i>true</i> or stringfy or <i>false</i>. When set to true, in case batch option is activated, insert null values for those attributes that doesn't exist in some of the entities to be inserted. If set to false, '' value is inserted for missing attributes. |
+| persist\_errors | no | true | if there is an exception when trying to persist data into storage then error is persisted into a table |
+| oracle_locator | no | false | if there is avaiable of [Oracle locator feature](https://docs.oracle.com/database/121/SPATL/sdo_locator.htm#SPATL340) which is just avaible since oracle 12c. THis imples if a geo:json is in converted a SDO_GEOMETRY or just leave in string format. |
+| nls_timestamp_format | no | `YYYY-MM-DD HH24:MI:SS.FF6` | defines the default timestamp format to use with the TO_CHAR and TO_TIMESTAMP functions [nls_timestamp_format](https://docs.oracle.com/cd/B19306_01/server.102/b14237/initparams132.htm#REFRN10131) |
+| nls_timestamp_tz_format | no | `YYYY-MM-DD"T"HH24:MI:SS.FF6 TZR` | NLS_TIMESTAMP_TZ_FORMAT defines the default timestamp with time zone format to use with the TO_CHAR and TO_TIMESTAMP_TZ functions [nls_timestamp_tz_format](https://docs.oracle.com/database/121/REFRN/GUID-A340C735-BA5A-4704-B24C-AC2C2380BA9E.htm#REFRN10132)|
+
+A configuration example could be:
+
+    cygnus-ngsi.sinks = oracle-sink
+    cygnus-ngsi.channels = oracle-channel
+    ...
+    cygnus-ngsi.sinks.oracle-sink.type = com.telefonica.iot.cygnus.sinks.NGSIOracleSQLSink
+    cygnus-ngsi.sinks.oracle-sink.channel = oracle-channel
+    cygnus-ngsi.sinks.oracle-sink.enable_encoding = false
+    cygnus-ngsi.sinks.oracle-sink.enable_lowercase = false
+    cygnus-ngsi.sinks.oracle-sink.enable_name_mappings = false
+    cygnus-ngsi.sinks.oracle-sink.data_model = dm-by-entity
+    cygnus-ngsi.sinks.oracle-sink.oracle_host = 192.168.80.34
+    cygnus-ngsi.sinks.oracle-sink.oracle_port = 1521
+    cygnus-ngsi.sinks.oracle-sink.oracle_database = xe
+    cygnus-ngsi.sinks.oracle-sink.oracle_username = system
+    cygnus-ngsi.sinks.oracle-sink.oracle_password = oracle
+    cygnus-ngsi.sinks.oracle-sink.oracle_locator = false
+    cygnus-ngsi.sinks.oracle-sink.nl_timestamp_format = YYYY-MM-DD HH24:MI:SS.FF6
+    cygnus-ngsi.sinks.oracle-sink.nl_timestamp_tz_format = YYYY-MM-DD\"T\"HH24:MI:SS.FF6 TZR
+    cygnus-ngsi.sinks.oracle-sink.oracle_maxPoolSize = 3
+    cygnus-ngsi.sinks.oracle-sink.attr_persistence = column
+    cygnus-ngsi.sinks.oracle-sink.attr_native_types = false
+    cygnus-ngsi.sinks.oracle-sink.batch_size = 100
+    cygnus-ngsi.sinks.oracle-sink.batch_timeout = 30
+    cygnus-ngsi.sinks.oracle-sink.batch_ttl = 10
+    cygnus-ngsi.sinks.oracle-sink.batch_retry_intervals = 5000
+    cygnus-ngsi.sinks.oracle-sink.persistence_policy.max_records = 5
+    cygnus-ngsi.sinks.oracle-sink.persistence_policy.expiration_time = 86400
+    cygnus-ngsi.sinks.oracle-sink.persistence_policy.checking_time = 600
+    cygnus-ngsi.sinks.oracle-sink.persist_errors = true
+
+[Top](#top)
+
+### <a name="section2.2"></a>Use cases
+Use `NGSIOracleSQLSink` if you are looking for a database storage not growing so much in the mid-long term.
+
+[Top](#top)
+
+### <a name="section2.3"></a>Important notes
+
+#### <a name="section2.3.2"></a>About the persistence mode
+Please observe not always the same number of attributes is notified; this depends on the subscription made to the NGSI-like sender. This is not a problem for the `row` persistence mode, since fixed 8-fields data rows are inserted for each notified attribute. Nevertheless, the `column` mode may be affected by several data rows of different lengths (in term of fields). Thus, the `column` mode is only recommended if your subscription is designed for always sending the same attributes, event if they were not updated since the last notification.
+
+In addition, when running in `column` mode, due to the number of notified attributes (and therefore the number of fields to be written within the Datastore) is unknown by Cygnus, the table can not be automatically created, and must be provisioned previously to the Cygnus execution. That's not the case of the `row` mode since the number of fields to be written is always constant, independently of the number of notified attributes.
+
+[Top](#top)
+
+#### <a name="section2.3.3"></a>About batching
+As explained in the [programmers guide](#section3), `NGSIOracleSQLSink` extends `NGSISink`, which provides a built-in mechanism for collecting events from the internal Flume channel. This mechanism allows extending classes have only to deal with the persistence details of such a batch of events in the final backend.
+
+What is important regarding the batch mechanism is it largely increases the performance of the sink, because the number of writes is dramatically reduced. Let's see an example, let's assume a batch of 100 `NGSIEvent`s. In the best case, all these events regard to the same entity, which means all the data within them will be persisted in the same Oracle table. If processing the events one by one, we would need 100 inserts into Oracle; nevertheless, in this example only one insert is required. Obviously, not all the events will always regard to the same unique entity, and many entities may be involved within a batch. But that's not a problem, since several sub-batches of events are created within a batch, one sub-batch per final destination Oracle table. In the worst case, the whole 100 entities will be about 100 different entities (100 different Oracle tables), but that will not be the usual scenario. Thus, assuming a realistic number of 10-15 sub-batches per batch, we are replacing the 100 inserts of the event by event approach with only 10-15 inserts.
+
+The batch mechanism adds an accumulation timeout to prevent the sink stays in an eternal state of batch building when no new data arrives. If such a timeout is reached, then the batch is persisted as it is.
+
+Regarding the retries of not persisted batches, a couple of parameters is used. On the one hand, a Time-To-Live (TTL) is used, specifing the number of retries Cygnus will do before definitely dropping the event. On the other hand, a list of retry intervals can be configured. Such a list defines the first retry interval, then se second retry interval, and so on; if the TTL is greater than the length of the list, then the last retry interval is repeated as many times as necessary.
+
+By default, `NGSIOracleSQLSink` has a configured batch size and batch accumulation timeout of 1 and 30 seconds, respectively. Nevertheless, as explained above, it is highly recommended to increase at least the batch size for performance purposes. Which are the optimal values? The size of the batch it is closely related to the transaction size of the channel the events are got from (it has no sense the first one is greater then the second one), and it depends on the number of estimated sub-batches as well. The accumulation timeout will depend on how often you want to see new data in the final storage. A deeper discussion on the batches of events and their appropriate sizing may be found in the [performance document](https://github.com/telefonicaid/fiware-cygnus/blob/master/doc/cygnus-ngsi/installation_and_administration_guide/performance_tips.md).
+
+[Top](#top)
+
+#### <a name="section2.3.4"></a>Time zone information
+Timezone in oracle is defiend by NLS_LANG environment variable of database instance.
+Timestamp and timestampTZ formats are defined by NLS_TIMESTAMP_FORMAT and NLS_TIMESTAMP_TZ_FORMAT environment variables of database instance as well as each connection session.
+More about [time tonze information](https://docs.oracle.com/cd/E11882_01/server.112/e10729/ch4datetime.htm#NLSPG004).
+
+[Top](#top)
+
+#### <a name="section2.3.5"></a>About the encoding
+Until version 1.2.0 (included), Cygnus applied a very simple encoding:
+
+* All non alphanumeric characters were replaced by underscore, `_`.
+* The underscore was used as concatenator character as well.
+* The slash, `/`, in the FIWARE service paths is ignored.
+
+From version 1.3.0 (included), Cygnus applies this specific encoding tailored to Oracle data structures:
+
+* Alphanumeric characters are not encoded.
+* Numeric characters are not encoded.
+* Underscore character, `_`, is not encoded.
+* Equals character, `=`, is encoded as `xffff`.
+* All other characters, including the slash in the FIWARE service paths, are encoded as a `x` character followed by the [Unicode](http://unicode-table.com) of the character.
+* User defined strings composed of a `x` character and a Unicode are encoded as `xx` followed by the Unicode.
+* All the other characters are not encoded.
+* `xffff` is used as concatenator character.
+    
+Despite the old encoding will be deprecated in the future, it is possible to switch the encoding type through the `enable_encoding` parameter as explained in the [configuration](#section2.1) section.
+
+[Top](#top)
+
+#### <a name="section2.3.6"></a>About capping resources and expirating records
+Capping and expiration are disabled by default. Nevertheless, if desired, this can be enabled:
+
+* Capping by the number of records. This allows the resource growing up until certain configured maximum number of records is reached (`persistence_policy.max_records`), and then maintains such a constant number of records.
+* Expirating by time the records. This allows the resource growing up until records become old, i.e. exceed certain configured expiration time (`persistence_policy.expiration_time`).
+
+[Top](#top)
+
+## <a name="section3"></a>Programmers guide
+### <a name="section3.1"></a>`NGSIOracleSQLSink` class
+As any other NGSI-like sink, `NGSIOracleSQLSink` extends the base `NGSISink`. The methods that are extended are:
+
+    void persistBatch(Batch batch) throws Exception;
+
+A `Batch` contains a set of `NGSIEvent` objects, which are the result of parsing the notified context data events. Data within the batch is classified by destination, and in the end, a destination specifies the Oracle table where the data is going to be persisted. Thus, each destination is iterated in order to compose a per-destination data string to be persisted thanks to any `OracleBackend` implementation.
+
+    void capRecords(NGSIBatch batch, long maxRecords) throws EventDeliveryException;
+    
+This method is always called immediatelly after `persistBacth()`. The same destination tables that were upserted are now checked in terms of number of records: if the configured maximum (`persistence_policy.max_records`) is exceeded for any of the updated tables, then as many oldest records are deleted as required until the maximum number of records is reached.
+    
+    void expirateRecords(long expirationTime);
+    
+This method is called in a periodical way (based on `persistence_policy.checking_time`), and if the configured expiration time (`persistence_policy.expiration_time`) is exceeded for any of the records within any of the tables, then it is deleted.
+
+    public void start();
+
+An implementation of `OracleBackend` is created. This must be done at the `start()` method and not in the constructor since the invoking sequence is `NGSIOracleSQLSink()` (contructor), `configure()` and `start()`.
+
+    public void configure(Context);
+
+A complete configuration as the described above is read from the given `Context` instance.
+
+[Top](#top)
+
+### <a name="section3.2"></a>Authentication and authorization
+Current implementation of `NGSIOracleSQLSink` relies on the username and password credentials created at the Oracle endpoint as well as database name.
+
+[Top](#top)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ pages:
           - 'NGSIMySQLSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md'
           - 'NGSIPostgreSQLSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md'
           - 'NGSIPostGISSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_postgis_sink.md'
+          - 'NGSIOracleSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md'
           - 'NGSISTHSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink.md'
           - 'NGSIOrionSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_orion_sink.md'
           - 'NGSIElasticsearchSink': 'cygnus-ngsi/flume_extensions_catalogue/ngsi_elasticsearch_sink.md'


### PR DESCRIPTION
issue https://github.com/telefonicaid/fiware-cygnus/issues/2195

This new sinks is based on SQL and implements:
- [x] Column support (no upsert mode support for lastdata, just insert)
- [x] Geo:Point support
- [x] Geo:json support (uses oracle 12c locator (spatial) feature https://docs.oracle.com/database/121/SPATL/sdo_locator.htm#SPATL340)
- [x] Doc about new sink: https://github.com/telefonicaid/fiware-cygnus/blob/task/oracle_sink/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
- [x] Uses ojdbc6 : Oracle JDBC Driver compatible with JDK6, JDK7, and JDK8 which implements JDBC 4.0 spec (https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcvers.htm#BCFFIFAD) valid for oracle 11g and oracle 12c (https://docs.oracle.com/en/database/oracle/oracle-database/12.2/jjdbc/JDBC-standards-support.html#GUID-0ABBC622-2FC8-4713-810F-F1417200C361)


Tested using this instance: Oracle Database 11g Express Edition Release 11.2.0.2.0 - 64bit Production

```
iot-oracle:
  container_name: iot-oracle
  hostname: iot-oracle
  image: oracleinanutshell/oracle-xe-11g:latest
  ports:
   - 1521:1521
   - 5500:8080
  environment:
   - ORACLE_ALLOW_REMOTE=true
   - ORACLE_DISABLE_ASYNCH_IO=true
   - ORACLE_ENABLE_XDB=true
   - NLS_TIMESTAMP_FORMAT=YYYY-MM-DD HH24:MI:SS.FF6
   - NLS_TIMESTAMP_TZ_FORMAT=YYYY-MM-DD"T"HH24:MI:SS.FF6 TZR
   - NLS_DATE_FORMAT=YYYY-MM-DD HH24:MI:SS
   - NLS_LANG=SPANISH_SPAIN.UTF8   
   #system/oracle
   # databasename: xe
  log_driver: json-file
  log_opt:
    max-size: "250m"
```


Typical oracle-sink config:

```
# # NGSIOracleSink configuration
cygnus-ngsi.sinks.oracle-sink.type = com.telefonica.iot.cygnus.sinks.NGSIOracleSQLSink
cygnus-ngsi.sinks.oracle-sink.channel = oracle-channel
#cygnus-ngsi.sinks.oracle-sink.enable_encoding = false
cygnus-ngsi.sinks.oracle-sink.enable_grouping = false
cygnus-ngsi.sinks.oracle-sink.enable_name_mappings = true
#cygnus-ngsi.sinks.oracle-sink.enable_lowercase = false
cygnus-ngsi.sinks.oracle-sink.data_model = dm-by-entity-type
cygnus-ngsi.sinks.oracle-sink.oracle_host = iot-oracle
cygnus-ngsi.sinks.oracle-sink.oracle_port = 1521
cygnus-ngsi.sinks.oracle-sink.oracle_database = xe
cygnus-ngsi.sinks.oracle-sink.oracle_username = system
cygnus-ngsi.sinks.oracle-sink.oracle_password = oracle
cygnus-ngsi.sinks.oracle-sink.attr_persistence = column
cygnus-ngsi.sinks.oracle-sink.attr_native_types = true
cygnus-ngsi.sinks.oracle-sink.batch_size = 1
cygnus-ngsi.sinks.oracle-sink.batch_timeout = 10
```


New optional sink configuration options:
```
cygnus-ngsi.sinks.oracle-sink.nls_timestamp_format=YYYY-MM-DD HH24:MI:SS.FF6
cygnus-ngsi.sinks.oracle-sink.nls_timestamp_tz_format=YYYY-MM-DDTHH24:MI:SS.FF6 TZR
cygnus-ngsi.sinks.oracle-sink.oracle_locator=false 
```

Example of table creation for column and dm-by-entity-type:

```
CREATE TABLE thing (
    entityid varchar2(40) NOT NULL,
    entitytype varchar2(40) NOT NULL,
    recvtime timestamp,
    timeinstant timestamp with time zone,
    timeinstant_md varchar2(40),
    fiwareservicepath varchar2(40) NOT NULL,
    st1 varchar2(40),
    st1_md varchar2(40),
    st2 varchar2(40),
    st2_md varchar2(40),
    location SDO_GEOMETRY,
    location_md varchar2(40),
    CONSTRAINT tmp1_pk PRIMARY KEY (entityid, entitytype, recvtime)
);
```



