### PR TITLE
Task/oracle sink: fix for geo:json and oracle 12c

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
@@ -518,7 +518,7 @@ public class SQLQueryUtils {
                     stringValue = value.getAsString();
                 }else {
                     if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                        value.toString().contains("SDO_GEOMETRY") || value.contains("sdo_util.from_geojson")) {
+                        value.toString().contains("SDO_GEOMETRY") || value.toString().contains("sdo_util.from_geojson")) {
                         stringValue = value.getAsString().replace("\\", "");
                     } else {
                         stringValue = quotationMark + value.getAsString() + quotationMark;
@@ -530,7 +530,7 @@ public class SQLQueryUtils {
         } else {
             if (value != null && value.isJsonPrimitive()) {
                 if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                    value.toString().contains("SDO_GEOMETRY") || value.contains("sdo_util.from_geojson")) {
+                    value.toString().contains("SDO_GEOMETRY") || value.toString().contains("sdo_util.from_geojson")) {
                     stringValue = value.getAsString().replace("\\", "");
                 } else {
                     stringValue = quotationMark + value.getAsString() + quotationMark;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
@@ -518,7 +518,7 @@ public class SQLQueryUtils {
                     stringValue = value.getAsString();
                 }else {
                     if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                        value.toString().contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
+                        value.toString().contains("SDO_GEOMETRY") || value.contains("sdo_util.from_geojson")) {
                         stringValue = value.getAsString().replace("\\", "");
                     } else {
                         stringValue = quotationMark + value.getAsString() + quotationMark;
@@ -530,7 +530,7 @@ public class SQLQueryUtils {
         } else {
             if (value != null && value.isJsonPrimitive()) {
                 if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                    value.toString().contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
+                    value.toString().contains("SDO_GEOMETRY") || value.contains("sdo_util.from_geojson")) {
                     stringValue = value.getAsString().replace("\\", "");
                 } else {
                     stringValue = quotationMark + value.getAsString() + quotationMark;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
@@ -436,7 +436,7 @@ public class SQLQueryUtils {
                             } else {
                                 String stringValue = value.getAsString();
                                 if (stringValue.contains("ST_GeomFromGeoJSON") || stringValue.contains("ST_SetSRID") ||
-                                    stringValue.contains("SDO_GEOMETRY")) {
+                                    stringValue.contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
                                     preparedStatement.setObject(position, stringValue);
                                     LOGGER.debug("[SQLQueryUtils.addJsonValues] " + "Added postgis Function " + stringValue + " as Object");
                                     position++;
@@ -456,7 +456,7 @@ public class SQLQueryUtils {
                     if (value != null && value.isJsonPrimitive()) {
                         String stringValue = value.getAsString();
                         if (stringValue.contains("ST_GeomFromGeoJSON") || stringValue.contains("ST_SetSRID") ||
-                            stringValue.contains("SDO_GEOMETRY")) {
+                            stringValue.contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
                             preparedStatement.setObject(position, stringValue);
                             LOGGER.debug("[SQLQueryUtils.addJsonValues] " + "Added postgis Function " + stringValue + " as Object");
                             position++;
@@ -518,7 +518,7 @@ public class SQLQueryUtils {
                     stringValue = value.getAsString();
                 }else {
                     if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                        value.toString().contains("SDO_GEOMETRY")) {
+                        value.toString().contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
                         stringValue = value.getAsString().replace("\\", "");
                     } else {
                         stringValue = quotationMark + value.getAsString() + quotationMark;
@@ -530,7 +530,7 @@ public class SQLQueryUtils {
         } else {
             if (value != null && value.isJsonPrimitive()) {
                 if (value.toString().contains("ST_GeomFromGeoJSON") || value.toString().contains("ST_SetSRID") ||
-                    value.toString().contains("SDO_GEOMETRY")) {
+                    value.toString().contains("SDO_GEOMETRY") || stringValue.contains("sdo_util.from_geojson")) {
                     stringValue = value.getAsString().replace("\\", "");
                 } else {
                     stringValue = quotationMark + value.getAsString() + quotationMark;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -73,7 +73,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_FORMAT = "YYYY-MM-DD HH24:MI:SS.FF6";
     private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_TZ_FORMAT = "YYYY-MM-DD\"T\"HH24:MI:SS.FF6 TZR";
     private static final String DEFAULT_ORACLE_LOCATOR = "false";
-    private static final String DEFAULT_ORACLE_MAJOR_VERSION = "11";
+    private static final int DEFAULT_ORACLE_MAJOR_VERSION = 11;
 
     private static final CygnusLogger LOGGER = new CygnusLogger(NGSIOracleSQLSink.class);
     private String oracleHost;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -73,6 +73,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_FORMAT = "YYYY-MM-DD HH24:MI:SS.FF6";
     private static final String DEFAULT_ORACLE_NLS_TIMESTAMP_TZ_FORMAT = "YYYY-MM-DD\"T\"HH24:MI:SS.FF6 TZR";
     private static final String DEFAULT_ORACLE_LOCATOR = "false";
+    private static final String DEFAULT_ORACLE_MAJOR_VERSION = "11";
 
     private static final CygnusLogger LOGGER = new CygnusLogger(NGSIOracleSQLSink.class);
     private String oracleHost;
@@ -96,6 +97,8 @@ public class NGSIOracleSQLSink extends NGSISink {
     private String nlsTimestampFormat;
     private String nlsTimestampTzFormat;
     private boolean oracleLocator;
+    private int oracleMajorVersion;
+    private int oracleMaxNameLength;
 
     /**
      * Constructor.
@@ -306,6 +309,14 @@ public class NGSIOracleSQLSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] Invalid configuration (oracle_locator="
                 + oracleLocatorStr + ") -- Must be 'true' or 'false'");
         } // if else
+
+        oracleMajorVersion = context.getInteger("oracle_major_version", DEFAULT_ORACLE_MAJOR_VERSION);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_major_version=" + oracleMajorVersion + ")");
+        if (oracleMajorVersion) {
+            oracleMaxNameLength = NGSIConstants.ORACLE11_MAX_NAME_LEN;
+        } else {
+            oracleMaxNameLength = NGSIConstants.ORACLE12_MAX_NAME_LEN;
+        }
 
         maxLatestErrors = context.getInteger("max_latest_errors", DEFAULT_MAX_LATEST_ERRORS);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (max_latest_errors=" + maxLatestErrors + ")");
@@ -551,9 +562,9 @@ public class NGSIOracleSQLSink extends NGSISink {
                     name = oracleDatabase;
             }
         } // if else
-        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
+        if (name.length() > this.oracleMaxNameLength) {
             throw new CygnusBadConfiguration("Building database name '" + name
-                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
+                    + "' and its length is greater than " + this.oracleMaxNameLength);
         } // if
 
         return name;
@@ -590,9 +601,9 @@ public class NGSIOracleSQLSink extends NGSISink {
             }
         } // if else
 
-        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
+        if (name.length() > this.oracleMaxNameLength) {
             throw new CygnusBadConfiguration("Building schema name '" + name
-                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
+                    + "' and its length is greater than " + this.oracleMaxNameLength);
         } // if
 
         return name;
@@ -672,9 +683,9 @@ public class NGSIOracleSQLSink extends NGSISink {
             } // switch
         } // if else
 
-        if (name.length() > NGSIConstants.ORACLE_MAX_NAME_LEN) {
+        if (name.length() > this.oracleMaxNameLength) {
             throw new CygnusBadConfiguration("Building table name '" + name
-                    + "' and its length is greater than " + NGSIConstants.ORACLE_MAX_NAME_LEN);
+                    + "' and its length is greater than " + this.oracleMaxNameLength);
         } // if
 
         return name;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -312,7 +312,7 @@ public class NGSIOracleSQLSink extends NGSISink {
 
         oracleMajorVersion = context.getInteger("oracle_major_version", DEFAULT_ORACLE_MAJOR_VERSION);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_major_version=" + oracleMajorVersion + ")");
-        if (oracleMajorVersion) {
+        if (oracleMajorVersion < 12) {
             oracleMaxNameLength = NGSIConstants.ORACLE11_MAX_NAME_LEN;
         } else {
             oracleMaxNameLength = NGSIConstants.ORACLE12_MAX_NAME_LEN;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIConstants.java
@@ -97,6 +97,7 @@ public final class NGSIConstants {
 
     // NGSIOracleSQLSink specific constants
     // https://docs.oracle.com/en/database/oracle/oracle-database/21/odpnt/EFCoreIdentifier.html
-    public static final int ORACLE_MAX_NAME_LEN = 30;    
+    public static final int ORACLE11_MAX_NAME_LEN = 30;
+    public static final int ORACLE12_MAX_NAME_LEN = 128;
 
 } // NGSIConstants

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
@@ -28,7 +28,7 @@ Content:
     * [Authentication and authorization](#section3.2)
 
 ## <a name="section1"></a>Functionality
-`com.iot.telefonica.cygnus.sinks.NGSIOracleSQLSink`, or simply `NGSIOracleSQLSink` is a sink designed to persist NGSI-like context data events within a [Oracle server](https://www.oracle.com/). Usually, such a context data is notified by a [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance, but could be any other system speaking the <i>NGSI language</i>.
+`com.iot.telefonica.cygnus.sinks.NGSIOracleSQLSink`, or simply `NGSIOracleSQLSink` is a sink designed to persist NGSI-like context data events within a [Oracle server](https://www.oracle.com/) 11g and 12c legacy versions. Usually, such a context data is notified by a [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance, but could be any other system speaking the <i>NGSI language</i>.
 
 Independently of the data generator, NGSI context data is always transformed into internal `NGSIEvent` objects at Cygnus sources. In the end, the information within these events must be mapped into specific Oracle data structures.
 
@@ -249,6 +249,7 @@ If `attr_persistence=colum` then `NGSIOracleSQLSink` will persist the data withi
 | attr\_native\_types | no | false | if the attribute value will be native <i>true</i> or stringfy or <i>false</i>. When set to true, in case batch option is activated, insert null values for those attributes that doesn't exist in some of the entities to be inserted. If set to false, '' value is inserted for missing attributes. |
 | persist\_errors | no | true | if there is an exception when trying to persist data into storage then error is persisted into a table |
 | oracle_locator | no | false | if there is avaiable of [Oracle locator feature](https://docs.oracle.com/database/121/SPATL/sdo_locator.htm#SPATL340) which is just avaible since oracle 12c. THis imples if a geo:json is in converted a SDO_GEOMETRY or just leave in string format. |
+| oracle_major_version | no | 11 | Major version of Oracle (it defines some values like max name length for identifiers, whichs is 30 for versions prior to 12)
 | nls_timestamp_format | no | `YYYY-MM-DD HH24:MI:SS.FF6` | defines the default timestamp format to use with the TO_CHAR and TO_TIMESTAMP functions [nls_timestamp_format](https://docs.oracle.com/cd/B19306_01/server.102/b14237/initparams132.htm#REFRN10131) |
 | nls_timestamp_tz_format | no | `YYYY-MM-DD"T"HH24:MI:SS.FF6 TZR` | NLS_TIMESTAMP_TZ_FORMAT defines the default timestamp with time zone format to use with the TO_CHAR and TO_TIMESTAMP_TZ functions [nls_timestamp_tz_format](https://docs.oracle.com/database/121/REFRN/GUID-A340C735-BA5A-4704-B24C-AC2C2380BA9E.htm#REFRN10132)|
 


### PR DESCRIPTION
Tested with oracle 12c:

```
iot-oracle:
  container_name: iot-oracle
  hostname: iot-oracle
  # https://github.com/MaksymBilenko/docker-oracle-12c
  image: quay.io/maksymbilenko/oracle-12c
  ports:
   - 1521:1521
   - 8050:8080
   - 5500:5500   
  environment:
   - ORACLE_ALLOW_REMOTE=true
   - ORACLE_DISABLE_ASYNCH_IO=true
   - ORACLE_ENABLE_XDB=true
   - DBCA_TOTAL_MEMORY=1024
   - NLS_TIMESTAMP_FORMAT=YYYY-MM-DD HH24:MI:SS.FF6
   - NLS_TIMESTAMP_TZ_FORMAT=YYYY-MM-DD"T"HH24:MI:SS.FF6 TZR
   - NLS_DATE_FORMAT=YYYY-MM-DD HH24:MI:SS
   - NLS_LANG=SPANISH_SPAIN.UTF8
   # Oracle 12c:  user/password: system/oracle and databasename: xe
  log_driver: json-file
  log_opt:
    max-size: "250m"
```


and this table:

```
CREATE TABLE thing (
    entityid varchar2(40) NOT NULL,
    entitytype varchar2(40) NOT NULL,
    recvtime timestamp,
    timeinstant timestamp with time zone,
    timeinstant_md varchar2(40),
    fiwareservicepath varchar2(40) NOT NULL,
    st1 varchar2(40),
    st1_md varchar2(40),
    st2 varchar2(40),
    st2_md varchar2(40),
    location SDO_GEOMETRY,
    location_md varchar2(40),
    CONSTRAINT tmp1_pk PRIMARY KEY (entityid, entitytype, recvtime)
);
```

cygnus produces this kind of insertions:
```
INSERT ALL  INTO thing (entityId,entityType,fiwareServicePath,recvTime,st1,st1_md,location,location_md,TimeInstant,TimeInstant_md) VALUES ('thing:disp1','thing','/','2022-12-05 07:56:41.369','st1value2','[]',sdo_util.from_geojson('{"type":"Point","coordinates":[-3.890584,40.486976]}'),'[]','2022-12-05T06:56:43.917Z','[]') SELECT * FROM dual
```