### PR TITLE
PostgreSQL sink creates table when entity id contains special characters

### DIFF
--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -616,32 +616,32 @@ public class NGSIPostgreSQLSink extends NGSISink {
                                 + "dm-by-service-path data model");
                     } // if
                     
-                    name = NGSIUtils.encode(servicePath, true, false);
+                    name = NGSIUtils.encodePostgresTable(servicePath);
                     break;
                 case DMBYENTITYDATABASE:
                 case DMBYENTITYDATABASESCHEMA:
                 case DMBYENTITY:
-                    String truncatedServicePath = NGSIUtils.encode(servicePath, true, false);
+                    String truncatedServicePath = NGSIUtils.encodePostgresTable(servicePath);
                     name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
-                            + NGSIUtils.encode(entity, false, true);
+                            + NGSIUtils.encodePostgresTable(entity);
                     break;
                 case DMBYENTITYTYPEDATABASE:
                 case DMBYENTITYTYPEDATABASESCHEMA:
                 case DMBYENTITYTYPE:
-                    truncatedServicePath = NGSIUtils.encode(servicePath, true, false);
+                    truncatedServicePath = NGSIUtils.encodePostgresTable(servicePath);
                     name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
-                            + NGSIUtils.encode(entityType, false, true);
+                            + NGSIUtils.encodePostgresTable(entityType);
                     break;
                 case DMBYATTRIBUTE:
-                    truncatedServicePath = NGSIUtils.encode(servicePath, true, false);
+                    truncatedServicePath = NGSIUtils.encodePostgresTable(servicePath);
                     name = (truncatedServicePath.isEmpty() ? "" : truncatedServicePath + '_')
-                            + NGSIUtils.encode(entity, false, true)
-                            + '_' + NGSIUtils.encode(attribute, false, true);
+                            + NGSIUtils.encodePostgresTable(entity)
+                            + '_' + NGSIUtils.encodePostgresTable(attribute);
                     break;
                 case DMBYFIXEDENTITYTYPEDATABASE:
                 case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
                 case DMBYFIXEDENTITYTYPE:
-                    name = NGSIUtils.encode(entityType, false, true);
+                    name = NGSIUtils.encodePostgresTable(entityType);
                     break;
                 default:
                     throw new CygnusBadConfiguration("Unknown data model '" + dataModel.toString()

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSICharsets.java
@@ -41,9 +41,9 @@ public final class NGSICharsets {
             char c = in.charAt(i);
             int code = c;
             
-            if (code >= 97 && code <= 119) { // a-w --> a-w
+            if (code >= 97 && code <= 119 || code >= 65 && code <= 87) { // a-w--> a-w,A-W-->A-W
                 out += c;
-            } else if (c == 'x') {
+            } else if (c == 'x'|| c == 'X') {
                 String next4;
             
                 if (i + 4 < in.length()) {
@@ -57,7 +57,7 @@ public final class NGSICharsets {
                 } else { // x --> x
                     out += c;
                 } // if else
-            } else if (code == 121 || code == 122) { // yz --> yz
+            } else if (code == 121 || code == 122 || code ==89 || code == 90) { // yz --> yz,YZ-->YZ
                 out += c;
             } else if (code >= 48 && code <= 57) { // 0-9 --> 0-9
                 out += c;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -42,6 +42,7 @@ public final class NGSIUtils {
     private static final Pattern ENCODEHIVEPATTERN = Pattern.compile("[^a-zA-Z0-9]");
     private static final Pattern ENCODESTHDBPATTERN = Pattern.compile("[=\\/\\\\.\\$\" ]");
     private static final Pattern ENCODESTHCOLLECTIONPATTERN = Pattern.compile("[=\\$]");
+    private static final Pattern ENCODEPOSTGRESTABLEPATTERN=Pattern.compile("[^a-zA-Z0-9\\.]");
     
     /**
      * Constructor. It is private since utility classes should not have a public or default constructor.
@@ -71,6 +72,20 @@ public final class NGSIUtils {
             return ENCODEPATTERNSLASH.matcher(in).replaceAll("_");
         } // if else
     } // encode
+    
+    /**
+     * Encodes a string replacing all '/', '\', '.', ' ', '"', '-'and '$' by '_'.
+     * @param in
+     * @return The encoded version of the input string
+     */
+     
+    public static String encodePostgresTable(String in) {
+        if(in.startsWith("/")) {
+                return ENCODEPOSTGRESTABLEPATTERN.matcher(in.substring(1)).replaceAll("_");
+            }else {
+                return ENCODEPOSTGRESTABLEPATTERN.matcher(in).replaceAll("_");
+            }
+            }
 
     /**
      * Encodes a string replacing all '/', '\', '.', ' ', '"' and '$' by '_'.

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSICartoDBSinkTest.java
@@ -991,7 +991,7 @@ public class NGSICartoDBSinkTest {
         
         try {
             String builtSchemaName = sink.buildSchemaName(service);
-            String expectedSchemaName = "somex0053ervice";
+            String expectedSchemaName = "someService";
         
             try {
                 assertEquals(expectedSchemaName, builtSchemaName);
@@ -1042,7 +1042,7 @@ public class NGSICartoDBSinkTest {
         
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
-            String expecetedTableName = "x002fsomex0050ath";
+            String expecetedTableName = "x002fsomePath";
         
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1096,7 +1096,7 @@ public class NGSICartoDBSinkTest {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
         
             try {
-                assertEquals("x002fsomex0050athxffffsomex0049dxffffsomex0054ype", builtTableName);
+                assertEquals("x002fsomePathxffffsomeIdxffffsomeType", builtTableName);
                 System.out.println(getTestTraceHead("[NGSICartoDBSink.buildTableName]")
                         + "-  OK  - '" + builtTableName + "' is equals to the lower case of "
                         + "x002f<servicePath>xffff<entityId>xffff<entityType>");
@@ -1198,7 +1198,7 @@ public class NGSICartoDBSinkTest {
         
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, attribute);
-            String expectedTableName = "x002fxffffsomex0049dxffffsomex0054ype";
+            String expectedTableName = "x002fxffffsomeIdxffffsomeType";
         
             try {
                 assertEquals(expectedTableName, builtTableName);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSinkTest.java
@@ -325,7 +325,7 @@ public class NGSIOracleSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildSchemaName(service, servicePath);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -557,7 +557,7 @@ public class NGSIOracleSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildDbName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -604,7 +604,7 @@ public class NGSIOracleSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildDbName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -706,7 +706,7 @@ public class NGSIOracleSQLSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050ath";
+            String expecetedTableName = "x002fsomePath";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSinkTest.java
@@ -476,7 +476,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtSchemaName = sink.buildSchemaName(service, servicePath);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -568,7 +568,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtSchemaName = sink.buildDBName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -615,7 +615,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtSchemaName = sink.buildDBName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -715,7 +715,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050ath";
+            String expecetedTableName = "x002fsomePath";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -821,7 +821,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050athxffffsomex0049dxffffsomex0054ype";
+             String expecetedTableName = "x002fsomePathxffffsomeIdxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -929,7 +929,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050athxffffsomex0054ype";
+            String expecetedTableName = "x002fsomePathxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1031,7 +1031,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "somex0054ype";
+            String expecetedTableName = "someType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1225,7 +1225,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fxffffsomex0049dxffffsomex0054ype";
+             String expecetedTableName = "x002fxffffsomeIdxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1323,7 +1323,7 @@ public class NGSIPostgisSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fxffffsomex0054ype";
+             String expecetedTableName = "x002fxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSinkTest.java
@@ -332,7 +332,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildSchemaName(service, servicePath);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -564,7 +564,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildDBName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -611,7 +611,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtSchemaName = sink.buildDBName(service);
-            String expectedDBName = "somex0053ervice";
+            String expectedDBName = "someService";
 
             try {
                 assertEquals(expectedDBName, builtSchemaName);
@@ -713,7 +713,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050ath";
+             String expecetedTableName = "x002fsomePath";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -819,7 +819,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fsomex0050athxffffsomex0049dxffffsomex0054ype";
+            String expecetedTableName = "x002fsomePathxffffsomeIdxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1031,7 +1031,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "somex0054ype";
+            String expecetedTableName = "someType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);
@@ -1227,7 +1227,7 @@ public class NGSIPostgreSQLSinkTest {
 
         try {
             String builtTableName = sink.buildTableName(servicePath, entity, entityType, attribute);
-            String expecetedTableName = "x002fxffffsomex0049dxffffsomex0054ype";
+            String expecetedTableName = "x002fxffffsomeIdxffffsomeType";
 
             try {
                 assertEquals(expecetedTableName, builtTableName);

--- a/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
+++ b/cygnus-ngsi/src/test/java/com/telefonica/iot/cygnus/utils/NGSICharsetsTest.java
@@ -52,8 +52,7 @@ public class NGSICharsetsTest {
         System.out.println(getTestTraceHead("[NGSICharsets.encodePostgreSQL]")
                 + "-------- Upper case not accented characters are encoded");
         String in = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        String expected = "x0041x0042x0043x0044x0045x0046x0047x0048x0049x004ax004bx004cx004dx004ex004f"
-                + "x0050x0051x0052x0053x0054x0055x0056x0057x0058x0059x005a";
+         String expected = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         String out = NGSICharsets.encodePostgreSQL(in);
         
         try {


### PR DESCRIPTION
This PR  fixes [issue#1977](https://github.com/telefonicaid/fiware-cygnus/issues/1977) i.e case1 and case2
**CASE 1: Encoding is enabled**
Postgresql sink creates table for all datamodel. But found bug in table name of some data model as shown below: 

|     **Data model**     |**Table name** |**Expected Table name**|
|-------------|-------------|------------------------|
|dm-by-attribute| _x002fkajalxffffurnx003angsix002dldxffffx0052oomxfffftemperature_|_x002fkajalxffffurnx003angsix002dldxffffroomxfffftemperature_|
|dm-by-entity|	_x002fkajalxffffurnx003angsix002dldxffffx0052oom_|_x002fkajalxffffurnx003angsix002dldxffffroom_|
|dm-by-entity-database| _x002fkajalxffffurnx003angsix002dldxffffx0052oom_| _x002fkajalxffffurnx003angsix002dldxffffroom_|
|dm-by-fixed-entity-type |	_x0052oom_	|**room**|
|dm-by-fixed-entity-type-database	|_x0052oom_	|_room_|
|dm-by-entity-database-schema|_x002fkajalxffffurnx003angsix002dldxffffx0052oom_	| _x002fkajalxffffurnx003angsix002dldxffffroom_|
|dm-by-fixed-entity-type-database-schema|	_x0052oom_	|	_room_|

**CASE 2: Encoding is disabled**
In this case, postgresql sink create table only for below data models:

- dm-by-fixed-entity-type-database-schema
- dm-by-entity-type-database-schema
- dm-by-fixed-entity-type-database
- dm-by-fixed-entity-type
- dm-by-entity-type-database
- dm-by-entity-type
- dm-by-service-path

and for other data models (dm-by-entity,dm-by-attribute,dm-by-entity-database,dm-by-entity-database-schema) it does not create tables.

