### PR TITLE
handle mongo hosts with or without port

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,3 +8,4 @@
 [cygnus-common][cygnus-twitter][cygnus-ngsi][cygnus-ngsi-ld] Upgrade log4j from v1 (1.2.17) to v2 (2.17.2) series (#1592)
 [cygnus-ngsi] OracleSQL ngsi sink added (for OracleS 11g and 12c) (#2195)
 [cygnus-ngsi] Removes "_" in schema name for DM -schema family (#2201)
+[cygnus-common] Added support for MongoDB hosts without a port (#2219)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -568,11 +568,13 @@ public class MongoBackendImpl implements MongoBackend {
         for (String uri: uris) {
             String[] uriParts = uri.split(":");
             if (uriParts.length == 2) {
+                LOGGER.debug("Adding 2-part Mongo ServerAddress: Host=" + uriParts[0] + " Port=" + uriParts[1]);
                 servers.add(new ServerAddress(uriParts[0], new Integer(uriParts[1])));
             } else {
-                LOGGER.error("Bad server uri: " + uri);
+                LOGGER.debug("Adding 1-part Mongo ServerAddress: Host=" + uri);
+                servers.add(new ServerAddress(uri));
             }
-        } // for
+        }
 
         // create a Mongo client
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -573,8 +573,8 @@ public class MongoBackendImpl implements MongoBackend {
             } else {
                 LOGGER.debug("Adding 1-part Mongo ServerAddress: Host=" + uri);
                 servers.add(new ServerAddress(uri));
-            }
-        }
+            } // if else
+        } // for
 
         // create a Mongo client
 


### PR DESCRIPTION
Following up #2219 , I made a small change to the function that was causing the issue. Instead of flagging "portless" hosts as "bad server uri", I now add them as a ServerAddress object without a port. I tested this on Docker with a `host:port` address and on Kubernetes with a plain `host` (without a port) and it works fine in both cases! Additionally, I added debug-level log messages to make the developer aware of how the given URL is handled.

So now it's only a matter of providing the correct mongo URL that can actually resolve. I hope you are satisfied with my suggestion. :)