### PR TITLE
[WIP] Task/do not cache error table

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -306,7 +306,12 @@ public class SQLBackendImpl implements SQLBackend{
 
         // get a connection to the given destination
         Connection con = driver.getConnection(dataBase);
-        String query = "select " + selection + " from `" + tableName + "` order by recvTime";
+        String query = "";
+        if (sqlInstance == SQLInstance.MYSQL) {
+            query = "select " + selection + " from `" + tableName + "` order by recvTime";
+        } else {
+            query = "select " + selection + " from " + tableName + " order by recvTime";
+        }
 
         try {
             stmt = con.createStatement();

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -552,10 +552,10 @@ public class SQLBackendImpl implements SQLBackend{
         if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
-        if (cache.isCachedTable(dataBase, errorTableName)) {
-            LOGGER.debug(sqlInstance.toString().toUpperCase() + " '" + errorTableName + "' is cached, thus it is not created");
-            return;
-        } // if
+        // if (cache.isCachedTable(dataBase, errorTableName)) {
+        //     LOGGER.debug(sqlInstance.toString().toUpperCase() + " '" + errorTableName + "' is cached, thus it is not created");
+        //     return;
+        // } // if
         String typedFieldNames = "(" +
                 "timestamp TIMESTAMP" +
                 ", error text" +
@@ -596,8 +596,10 @@ public class SQLBackendImpl implements SQLBackend{
 
         closeSQLObjects(con, stmt);
 
-        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + errorTableName + "' to the cache after table creation");
-        cache.addTable(dataBase, errorTableName);
+        // // TBD: Do not cache error table since always we are trying to insert and if fails then create it
+        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + errorTableName + "' to the cache after table creation");
+
+        // cache.addTable(dataBase, errorTableName); 
     } // createErrorTable
 
     /**
@@ -875,9 +877,9 @@ public class SQLBackendImpl implements SQLBackend{
             closeSQLObjects(con, preparedStatement);
         } // try catch
 
-        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + errorTableName + "' to the cache after insertion");
-        cache.addDataBase(dataBase);
-        cache.addTable(dataBase, errorTableName);
+        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + errorTableName + "' to the cache after insertion");
+        // cache.addDataBase(dataBase);
+        // cache.addTable(dataBase, errorTableName); 
     } // insertErrorLog
 
     private void persistError(String destination, String schema, String query, Exception exception) throws CygnusPersistenceError, CygnusRuntimeError {


### PR DESCRIPTION
When persist error first tries to persist in table and if fails then create it.

persistence_policy is based on recvTime which is not preset in error_table and make it incomparable; since if both are activated (error_log and persistence_policy) errors about recvTime not found in error_table happens.

Moreover error_table has its own persistence policy, since is purged periodically.