### PR TITLE
fix expiration records in non mysql instances

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances
+- [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances (2242) 
 - [cygnus-common] [sql] Exclude error table from persist policy (cap records is based on recvtime which is non used by persistError)
 - [cygnus-common] [sql] Add missed capRecords implementation for PSQL backends

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances (2242) 
+- [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances (#2242) 
 - [cygnus-common] [sql] Exclude error table from persist policy (cap records is based on recvtime which is non used by persistError)
 - [cygnus-common] [sql] Add missed capRecords implementation for PSQL backends

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,3 @@
 - [cygnus-common] [sql] Fix sql syntax for expiration records (select, delete, filters) in non mysql instances
+- [cygnus-common] [sql] Exclude error table from persist policy (cap records is based on recvtime which is non used by persistError)
+- [cygnus-common] [sql] Add missed capRecords implementation for PSQL backends

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackend.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackend.java
@@ -61,12 +61,13 @@ public interface SQLBackend {
     /**
      * Caps records from the given table within the given database according to the given maximum number.
      * @param dataBase
+     * @param schemaName
      * @param tableName
      * @param maxRecords
      * @throws com.telefonica.iot.cygnus.errors.CygnusRuntimeError
      * @throws com.telefonica.iot.cygnus.errors.CygnusPersistenceError
      */
-    void capRecords(String dataBase, String tableName, long maxRecords) throws CygnusRuntimeError, CygnusPersistenceError;
+    void capRecords(String dataBase, String schemaName, String tableName, long maxRecords) throws CygnusRuntimeError, CygnusPersistenceError;
 
     /**
      * Expirates records within all the cached tables based on the expiration time.

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -306,7 +306,12 @@ public class SQLBackendImpl implements SQLBackend{
 
         // get a connection to the given destination
         Connection con = driver.getConnection(dataBase);
-        String query = "select " + selection + " from `" + tableName + "` order by recvTime";
+        String query = "";
+        if (sqlInstance == SQLInstance.MYSQL) {
+            query = "select " + selection + " from `" + tableName + "` order by recvTime";
+        } else {
+            query = "select " + selection + " from " + tableName + " order by recvTime";
+        }
 
         try {
             stmt = con.createStatement();

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -552,10 +552,10 @@ public class SQLBackendImpl implements SQLBackend{
         if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
-        if (cache.isCachedTable(dataBase, errorTableName)) {
-            LOGGER.debug(sqlInstance.toString().toUpperCase() + " '" + errorTableName + "' is cached, thus it is not created");
-            return;
-        } // if
+        // if (cache.isCachedTable(dataBase, errorTableName)) {
+        //     LOGGER.debug(sqlInstance.toString().toUpperCase() + " '" + errorTableName + "' is cached, thus it is not created");
+        //     return;
+        // } // if
         String typedFieldNames = "(" +
                 "timestamp TIMESTAMP" +
                 ", error text" +
@@ -596,8 +596,10 @@ public class SQLBackendImpl implements SQLBackend{
 
         closeSQLObjects(con, stmt);
 
-        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + errorTableName + "' to the cache after table creation");
-        cache.addTable(dataBase, errorTableName);
+        // // TBD: Do not cache error table since always we are trying to insert and if fails then create it
+        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + errorTableName + "' to the cache after table creation");
+
+        // cache.addTable(dataBase, errorTableName); 
     } // createErrorTable
 
     /**
@@ -875,9 +877,9 @@ public class SQLBackendImpl implements SQLBackend{
             closeSQLObjects(con, preparedStatement);
         } // try catch
 
-        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + errorTableName + "' to the cache after insertion");
-        cache.addDataBase(dataBase);
-        cache.addTable(dataBase, errorTableName);
+        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + errorTableName + "' to the cache after insertion");
+        // cache.addDataBase(dataBase);
+        // cache.addTable(dataBase, errorTableName); 
     } // insertErrorLog
 
     private void persistError(String destination, String schema, String query, Exception exception) throws CygnusPersistenceError, CygnusRuntimeError {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -332,6 +332,7 @@ public class SQLBackendImpl implements SQLBackend{
 
             crs.populate(rs); // FIXME: close Resultset Objects??
             closeSQLObjects(con, stmt);
+            LOGGER.debug(sqlInstance.toString().toUpperCase() + " returning crs");
             return crs;
         } catch (SQLTimeoutException e) {
             throw new CygnusPersistenceError(sqlInstance.toString().toUpperCase() + " Data select error. Query " + query, "SQLTimeoutException", e.getMessage());
@@ -811,6 +812,9 @@ public class SQLBackendImpl implements SQLBackend{
 
         LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + tableName + "' to the cache after insertion");
         cache.addDataBase(dataBase);
+        if (sqlInstance == SQLInstance.POSTGRESQL) {
+            tableName = schema + "." + tableName;
+        }
         cache.addTable(dataBase, tableName);
     }
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -440,7 +440,7 @@ public class SQLBackendImpl implements SQLBackend{
         if (filters.isEmpty()) {
             LOGGER.debug(sqlInstance.toString().toUpperCase() + " No records to be deleted");
         } else {
-            LOGGER.debug(sqlInstance.toString().toUpperCase() + " Records must be deleted (destination=" + dataBase + ",tableName=" + tableName + ", filters="
+            LOGGER.debug(sqlInstance.toString().toUpperCase() + " Records must be deleted (destination=" + dataBase + ",schemaName=" + schemaName + ",tableName=" + tableName + ", filters="
                     + filters + ")");
             delete(dataBase, schemaName, tableName, filters);
         } // if else
@@ -501,17 +501,9 @@ public class SQLBackendImpl implements SQLBackend{
 
                         if (recordTime < (currentTime - (expirationTime * 1000))) {
                             if (filters.isEmpty()) {
-                                if (sqlInstance == SQLInstance.MYSQL) {
-                                    filters += "recvTime='" + recvTime + "'";
-                                } else {
-                                    filters += "recvTime=" + recvTime;
-                                }
+                                filters += "recvTime='" + recvTime + "'";
                             } else {
-                                if (sqlInstance == SQLInstance.MYSQL) {
-                                    filters += " or recvTime='" + recvTime + "'";
-                                } else {
-                                    filters += " or recvTime=" + recvTime;
-                                }
+                                filters += " or recvTime='" + recvTime + "'";
                             } // if else
                         } else {
                             break;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -334,7 +334,7 @@ public class SQLBackendImpl implements SQLBackend{
             // used once the statement is closed
             @SuppressWarnings("restriction")
             CachedRowSet crs = new CachedRowSetImpl();
-
+            LOGGER.debug(sqlInstance.toString().toUpperCase() + " populating crs");
             crs.populate(rs); // FIXME: close Resultset Objects??
             closeSQLObjects(con, stmt);
             LOGGER.debug(sqlInstance.toString().toUpperCase() + " returning crs");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -505,6 +505,8 @@ public class SQLBackendImpl implements SQLBackend{
                     throw new CygnusRuntimeError(sqlInstance.toString().toUpperCase() + " Data expiration error", "SQLException", e.getMessage());
                 } catch (ParseException e) {
                     throw new CygnusRuntimeError(sqlInstance.toString().toUpperCase() + " Data expiration error", "ParseException", e.getMessage());
+                } catch (Exception e) {
+                    throw new CygnusRuntimeError(sqlInstance.toString().toUpperCase() + " Data expiration error", "Exception", e.getMessage());
                 } // try catch
 
                 if (filters.isEmpty()) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -448,7 +448,7 @@ public class SQLBackendImpl implements SQLBackend{
             while (cache.hasNextTable(dataBase)) {
                 String tableName = cache.nextTable(dataBase);
 
-                // Get schema frmo tableName if PSQL, just for persistError before
+                // Get schema frmo tableName if PSQL, just for persistError after
                 String schema = null;
                 if (sqlInstance == SQLInstance.POSTGRESQL) {
                     String[] parts = tableName.split(".");
@@ -571,15 +571,11 @@ public class SQLBackendImpl implements SQLBackend{
 
     public void createErrorTable(String dataBase, String schema)
             throws CygnusRuntimeError, CygnusPersistenceError {
-        // the defaul table for error log will be called the same as the destination name
+        // the default table for error log will be called the same as the destination name
         String errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
-        // if (cache.isCachedTable(dataBase, errorTableName)) {
-        //     LOGGER.debug(sqlInstance.toString().toUpperCase() + " '" + errorTableName + "' is cached, thus it is not created");
-        //     return;
-        // } // if
         String typedFieldNames = "(" +
                 "timestamp TIMESTAMP" +
                 ", error text" +
@@ -619,11 +615,6 @@ public class SQLBackendImpl implements SQLBackend{
         } // try catch
 
         closeSQLObjects(con, stmt);
-
-        // // TBD: Do not cache error table since always we are trying to insert and if fails then create it
-        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + errorTableName + "' to the cache after table creation");
-
-        // cache.addTable(dataBase, errorTableName); 
     } // createErrorTable
 
     /**
@@ -903,9 +894,6 @@ public class SQLBackendImpl implements SQLBackend{
             closeSQLObjects(con, preparedStatement);
         } // try catch
 
-        // LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + errorTableName + "' to the cache after insertion");
-        // cache.addDataBase(dataBase);
-        // cache.addTable(dataBase, errorTableName); 
     } // insertErrorLog
 
     private void persistError(String destination, String schema, String query, Exception exception) throws CygnusPersistenceError, CygnusRuntimeError {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -334,10 +334,8 @@ public class SQLBackendImpl implements SQLBackend{
             // used once the statement is closed
             @SuppressWarnings("restriction")
             CachedRowSet crs = new CachedRowSetImpl();
-            LOGGER.debug(sqlInstance.toString().toUpperCase() + " populating crs");
             crs.populate(rs); // FIXME: close Resultset Objects??
             closeSQLObjects(con, stmt);
-            LOGGER.debug(sqlInstance.toString().toUpperCase() + " returning crs");
             return crs;
         } catch (SQLTimeoutException e) {
             throw new CygnusPersistenceError(sqlInstance.toString().toUpperCase() + " Data select error. Query " + query, "SQLTimeoutException", e.getMessage());

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -417,17 +417,9 @@ public class SQLBackendImpl implements SQLBackend{
                     String recvTime = records.getString("recvTime");
 
                     if (filters.isEmpty()) {
-                        if (sqlInstance == SQLInstance.MYSQL) {
-                            filters += "recvTime='" + recvTime + "'";
-                        } else {
-                            filters += "recvTime=" + recvTime;
-                        }
+                        filters += "recvTime='" + recvTime + "'";
                     } else {
-                        if (sqlInstance == SQLInstance.MYSQL) {
-                            filters += " or recvTime='" + recvTime + "'";
-                        } else {
-                            filters += " or recvTime=" + recvTime;
-                        }
+                        filters += " or recvTime='" + recvTime + "'";
                     } // if else
                 } // for
             } // if

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -309,6 +309,11 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "select " + selection + " from `" + tableName + "` order by recvTime";
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
+            if (schema != null) {
+                tableName = schema + '.' + tableName;
+            }
+            query = "select " + selection + " from " + tableName + " order by recvTime";
         } else {
             query = "select " + selection + " from " + tableName + " order by recvTime";
         }
@@ -352,6 +357,11 @@ public class SQLBackendImpl implements SQLBackend{
         String query = "";
         if (sqlInstance == SQLInstance.MYSQL) {
             query = "delete from `" + tableName + "` where " + filters;
+        } else if (sqlInstance == SQLInstance.POSTGRESQL) {
+            if (schema != null) {
+                tableName = schema + '.' + tableName;
+            }
+            query = "delete from " + tableName + " where " + filters;
         } else {
             query = "delete from " + tableName + " where " + filters;
         }
@@ -809,12 +819,11 @@ public class SQLBackendImpl implements SQLBackend{
         } finally {
             closeConnection(connection);
         } // try catch
-
-        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + tableName + "' to the cache after insertion");
-        cache.addDataBase(dataBase);
         if (sqlInstance == SQLInstance.POSTGRESQL) {
             tableName = schema + "." + tableName;
         }
+        LOGGER.debug(sqlInstance.toString().toUpperCase() + " Trying to add '" + dataBase + "' and '" + tableName + "' to the cache after insertion");
+        cache.addDataBase(dataBase);
         cache.addTable(dataBase, tableName);
     }
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -510,7 +510,7 @@ public class SQLBackendImpl implements SQLBackend{
                 if (filters.isEmpty()) {
                     LOGGER.debug(sqlInstance.toString().toUpperCase() + " No records to be deleted");
                 } else {
-                    LOGGER.debug(sqlInstance.toString().toUpperCase() + " Records must be deleted (destination=" + dataBase + ",tableName=" + tableName + ", filters="
+                    LOGGER.debug(sqlInstance.toString().toUpperCase() + " Records must be deleted (destination=" + dataBase + ",schemaName=" + schema + ",tableName=" + tableName + ", filters="
                             + filters + ")");
                     delete(dataBase, schema, tableName, filters);
                 } // if else
@@ -817,8 +817,6 @@ public class SQLBackendImpl implements SQLBackend{
         String errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         if (sqlInstance == SQLInstance.POSTGRESQL) {
             errorTableName = schema + "." + dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
-        } else if (sqlInstance == SQLInstance.ORACLE) {
-            errorTableName = dataBase + DEFAULT_ERROR_TABLE_SUFFIX;
         }
         String limit = String.valueOf(maxLatestErrors);
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -179,7 +179,7 @@ public final class CommonUtils {
             return DatatypeConverter.parseDateTime(timestamp).getTime().getTime();
         } catch (Exception e) {
             try { // try get timestamp without timezone
-                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:S");
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
                 Date date = sdf.parse(timestamp);
                 return date.getTime();
             } catch (Exception e2) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -179,11 +179,11 @@ public final class CommonUtils {
             return DatatypeConverter.parseDateTime(timestamp).getTime().getTime();
         } catch (Exception e) {
             try { // try get timestamp without timezone
-                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss:SSS");
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS");
                 Date date = sdf.parse(timestamp);
                 return date.getTime();
             } catch (Exception e2) {
-                throw new java.text.ParseException("Invalid timestamp format for value: " + timestamp, 0);
+                throw new java.text.ParseException("Invalid timestamp format for value: " + timestamp + " due to " + e2.getMessage(), 0);
             }
         }
     } // getMilliseconds

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -179,7 +179,7 @@ public final class CommonUtils {
             return DatatypeConverter.parseDateTime(timestamp).getTime().getTime();
         } catch (Exception e) {
             try { // try get timestamp without timezone
-                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS");
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:S");
                 Date date = sdf.parse(timestamp);
                 return date.getTime();
             } catch (Exception e2) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/utils/CommonUtils.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -56,7 +57,6 @@ import org.joda.time.format.DateTimeFormatter;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.json.simple.parser.Yytoken;
 import org.postgresql.largeobject.BlobOutputStream;
 import org.apache.thrift.meta_data.ListMetaData;
@@ -174,7 +174,18 @@ public final class CommonUtils {
      * @throws java.text.ParseException
      */
     public static long getMilliseconds(String timestamp) throws java.text.ParseException {
-        return DatatypeConverter.parseDateTime(timestamp).getTime().getTime();
+        try {
+            // timestamp is expected with timezone
+            return DatatypeConverter.parseDateTime(timestamp).getTime().getTime();
+        } catch (Exception e) {
+            try { // try get timestamp without timezone
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss:SSS");
+                Date date = sdf.parse(timestamp);
+                return date.getTime();
+            } catch (Exception e2) {
+                throw new java.text.ParseException("Invalid timestamp format for value: " + timestamp, 0);
+            }
+        }
     } // getMilliseconds
     
     /**
@@ -239,7 +250,7 @@ public final class CommonUtils {
         
         try {
             mds = (JSONArray) parser.parse(metadata);
-        } catch (ParseException e) {
+        } catch (org.json.simple.parser.ParseException e) {
             LOGGER.error("Error while parsing the metadaga. Details: " + e.getMessage());
             return null;
         } // try catch

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/utils/CommonUtilsTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/utils/CommonUtilsTest.java
@@ -319,6 +319,30 @@ public class CommonUtilsTest {
                     + "- FAIL - Milliseconds were not obtained");
             throw e;
         } // try catch
+
+
+        System.out.println(getTestTraceHead("[CommonUtils.getMilliseconds]")
+                + "-------- Milliseconds are obtained when passing a valid timestamp");
+        timestamp = "2017-01-10 17:08:00.000";
+        try {
+            milliseconds = CommonUtils.getMilliseconds(timestamp);
+        } catch (ParseException e) {
+            System.out.println(getTestTraceHead("[CommonUtils.getMilliseconds]")
+                    + "- FAIL - There was some problem while getting the milliseconds");
+            throw new AssertionError(e.getMessage());
+        } // try catch
+
+        try {
+            assertEquals(timestamp, CommonUtils.getHumanReadable(milliseconds, true));
+            System.out.println(getTestTraceHead("[CommonUtils.getMilliseconds]")
+                    + "-  OK  - Milliseconds obtained");
+        } catch (AssertionError e) {
+            System.out.println(getTestTraceHead("[CommonUtils.getMilliseconds]")
+                    + "- FAIL - Milliseconds were not obtained");
+            throw e;
+        } // try catch
+
+        
     } // testGetMilliseconds
 
     /**

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -383,7 +383,7 @@ public class NGSIMySQLSink extends NGSISink {
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");
-                mySQLPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+                mySQLPersistenceBackend.capRecords(dbName, null, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
             } catch (CygnusRuntimeError e) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -437,7 +437,7 @@ public class NGSIOracleSQLSink extends NGSISink {
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");
-                oracleSQLPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+                oracleSQLPersistenceBackend.capRecords(dbName, null, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
             } catch (CygnusRuntimeError e) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -427,7 +427,7 @@ public class NGSIPostgisSink extends NGSISink {
                 String schemaName = buildSchemaName(service, servicePathForNaming);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
-                        + dbName + ", tableName=" + tableName + ")");
+                        + dbName + ", schemaName=" + schemaName + ", tableName=" + tableName + ")");
                 postgisPersistenceBackend.capRecords(dbName, schemaName, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -400,6 +400,42 @@ public class NGSIPostgisSink extends NGSISink {
     
     @Override
     public void capRecords(NGSIBatch batch, long maxRecords) throws CygnusCappingError {
+        if (batch == null) {
+            LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
+            return;
+        } // if
+
+        // Iterate on the destinations
+        batch.startIterator();
+        
+        while (batch.hasNext()) {
+            // Get the events within the current sub-batch
+            ArrayList<NGSIEvent> events = batch.getNextEvents();
+
+            // Get a representative from the current destination sub-batch
+            NGSIEvent event = events.get(0);
+            
+            // Do the capping
+            String service = event.getServiceForNaming(enableNameMappings);
+            String servicePathForNaming = event.getServicePathForNaming(enableNameMappings);
+            String entity = event.getEntityForNaming(enableNameMappings, enableEncoding);
+            String entityType = event.getEntityTypeForNaming(enableNameMappings);
+            String attribute = event.getAttributeForNaming(enableNameMappings);
+            
+            try {
+                String dbName = buildDbName(service);
+                String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
+                LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
+                        + dbName + ", tableName=" + tableName + ")");
+                postgisPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+            } catch (CygnusBadConfiguration e) {
+                throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
+            } catch (CygnusRuntimeError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusRuntimeError", e.getMessage());
+            } catch (CygnusPersistenceError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusPersistenceError", e.getMessage());
+            } // try catch
+        } // while
     } // capRecords
 
     @Override

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -407,23 +407,23 @@ public class NGSIPostgisSink extends NGSISink {
 
         // Iterate on the destinations
         batch.startIterator();
-        
+
         while (batch.hasNext()) {
             // Get the events within the current sub-batch
             ArrayList<NGSIEvent> events = batch.getNextEvents();
 
             // Get a representative from the current destination sub-batch
             NGSIEvent event = events.get(0);
-            
+
             // Do the capping
             String service = event.getServiceForNaming(enableNameMappings);
             String servicePathForNaming = event.getServicePathForNaming(enableNameMappings);
             String entity = event.getEntityForNaming(enableNameMappings, enableEncoding);
             String entityType = event.getEntityTypeForNaming(enableNameMappings);
             String attribute = event.getAttributeForNaming(enableNameMappings);
-            
+
             try {
-                String dbName = buildDbName(service);
+                String dbName = buildDBName(service);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -424,10 +424,11 @@ public class NGSIPostgisSink extends NGSISink {
 
             try {
                 String dbName = buildDBName(service);
+                String schemaName = buildSchemaName(service, servicePathForNaming);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");
-                postgisPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+                postgisPersistenceBackend.capRecords(dbName, schemaName, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
             } catch (CygnusRuntimeError e) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -416,7 +416,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
             String attribute = event.getAttributeForNaming(enableNameMappings);
 
             try {
-                String dbName = buildDbName(service);
+                String dbName = buildDBName(service);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -393,6 +393,42 @@ public class NGSIPostgreSQLSink extends NGSISink {
     
     @Override
     public void capRecords(NGSIBatch batch, long maxRecords) throws CygnusCappingError {
+        if (batch == null) {
+            LOGGER.debug("[" + this.getName() + "] Null batch, nothing to do");
+            return;
+        } // if
+
+        // Iterate on the destinations
+        batch.startIterator();
+
+        while (batch.hasNext()) {
+            // Get the events within the current sub-batch
+            ArrayList<NGSIEvent> events = batch.getNextEvents();
+
+            // Get a representative from the current destination sub-batch
+            NGSIEvent event = events.get(0);
+
+            // Do the capping
+            String service = event.getServiceForNaming(enableNameMappings);
+            String servicePathForNaming = event.getServicePathForNaming(enableNameMappings);
+            String entity = event.getEntityForNaming(enableNameMappings, enableEncoding);
+            String entityType = event.getEntityTypeForNaming(enableNameMappings);
+            String attribute = event.getAttributeForNaming(enableNameMappings);
+
+            try {
+                String dbName = buildDbName(service);
+                String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
+                LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
+                        + dbName + ", tableName=" + tableName + ")");
+                postgreSQLPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+            } catch (CygnusBadConfiguration e) {
+                throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
+            } catch (CygnusRuntimeError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusRuntimeError", e.getMessage());
+            } catch (CygnusPersistenceError e) {
+                throw new CygnusCappingError("Data capping error", "CygnusPersistenceError", e.getMessage());
+            } // try catch
+        } // while        
     } // capRecords
 
     @Override

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -420,7 +420,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
                 String schemaName = buildSchemaName(service, servicePathForNaming);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
-                        + dbName + ", tableName=" + tableName + ")");
+                        + dbName + ", schemaName=" + schemaName + ", tableName=" + tableName + ")");
                 postgreSQLPersistenceBackend.capRecords(dbName, schemaName, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -417,10 +417,11 @@ public class NGSIPostgreSQLSink extends NGSISink {
 
             try {
                 String dbName = buildDBName(service);
+                String schemaName = buildSchemaName(service, servicePathForNaming);
                 String tableName = buildTableName(servicePathForNaming, entity, entityType, attribute);
                 LOGGER.debug("[" + this.getName() + "] Capping resource (maxRecords=" + maxRecords + ",dbName="
                         + dbName + ", tableName=" + tableName + ")");
-                postgreSQLPersistenceBackend.capRecords(dbName, tableName, maxRecords);
+                postgreSQLPersistenceBackend.capRecords(dbName, schemaName, tableName, maxRecords);
             } catch (CygnusBadConfiguration e) {
                 throw new CygnusCappingError("Data capping error", "CygnusBadConfiguration", e.getMessage());
             } catch (CygnusRuntimeError e) {

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSISink.java
@@ -1010,7 +1010,7 @@ public abstract class NGSISink extends CygnusSink implements Configurable {
                     try {
                         LOGGER.debug("[" + sinkName + "] Expirating records");
                         expirateRecords(persistencePolicyExpirationTime);
-                    } catch (Exception e) {
+                    } catch (CygnusExpiratingError e) {
                         LOGGER.error("[" + sinkName + "] Error while expirating records. Details: "
                                 + e.getMessage());
                     } // try catch


### PR DESCRIPTION
fix for https://github.com/telefonicaid/fiware-cygnus/issues/2242

Fix sql syntax for expiration records (select, delete, filters) in non mysql instances
Exclude error table from persist policy (cap records is based on recvtime which is non used by persistError)
Add missed capRecords implementation for PSQL backends