### PR TITLE
check null from string

### DIFF
--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/utils/NGSIUtils.java
@@ -115,7 +115,7 @@ public final class NGSIUtils {
         } // if
         
         if (attrType.equals("geo:json")) {
-            if (attrValue != null) {
+            if (attrValue != null && (!attrValue.equals("null"))) {
                 return new ImmutablePair("ST_GeomFromGeoJSON('" + attrValue + "')", true);
             } else {
                 // MySQL and PostgreSQL allows null, but without quotation marks


### PR DESCRIPTION
reopens previous PR https://github.com/telefonicaid/fiware-cygnus/pull/2259

Cygnus is reading a null from event into a string

String value = (String) raw;

then value is "null



No CNR update is needed