### PR TITLE
Removes "_" in schema name for DM -schema family (#2201) (reopens for Postgis)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi] Removes "_" in schema name for DM -schema family (#2201) (reopens for Postgis)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-- [cygnus-ngsi] Removes "_" in schema name for DM -schema family (#2201) (reopens for Postgis)
+- [cygnus-ngsi] Removes "_" in schema name for DM -schema family (#2270, #2201 reopens for Postgis)
+

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -592,7 +592,7 @@ public class NGSIPostgisSink extends NGSISink {
                 case DMBYENTITYDATABASESCHEMA:
                 case DMBYENTITYTYPEDATABASESCHEMA:
                 case DMBYFIXEDENTITYTYPEDATABASESCHEMA:
-                    name = NGSIUtils.encode(subService, false, true);
+                    name = NGSIUtils.encode(subService, true, false);
                     break;
                 default:
                     name = NGSIUtils.encode(service, false, true);


### PR DESCRIPTION
fix for https://github.com/telefonicaid/fiware-cygnus/issues/2270

This is the solution applied by https://github.com/telefonicaid/fiware-cygnus/pull/2210 but to PostgisSQL sink