### PR TITLE
fix to openjdk-11 instead of openjdk-17

### DIFF
--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -256,7 +256,7 @@ ENV FLUME_HOME "/opt/apache-flume"
 ENV FLUME_TGZ "apache-flume-${FLUME_VER}-bin.tar.gz"
 ENV FLUME_URL "https://archive.apache.org/dist/flume/${FLUME_VER}/${FLUME_TGZ}"
 
-ENV JAVA_VERSION "1.17.0"
+ENV JAVA_VERSION "1.11.0"
 
 COPY / ${CYGNUS_HOME}
 
@@ -269,7 +269,13 @@ RUN \
     apt-get -y update && \
     apt-get -y upgrade && \
     # Install dependencies
-    apt-get -y install openjdk-17-jdk curl git python3 maven && \
+    apt-get -y install curl git python3 && \
+    curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jdk_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jdk_11.0.20+8-1~deb11u1_amd64.deb && \
+    curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jre_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jre_11.0.20+8-1~deb11u1_amd64.deb && \
+    curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jdk-headless_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jdk-headless_11.0.20+8-1~deb11u1_amd64.deb && \
+    curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jre-headless_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jre-headless_11.0.20+8-1~deb11u1_amd64.deb && \
+    apt-get -y install  ./openjdk-11-jre-headless_11.0.20+8-1~deb11u1_amd64.deb ./openjdk-11-jre_11.0.20+8-1~deb11u1_amd64.deb ./openjdk-11-jdk-headless_11.0.20+8-1~deb11u1_amd64.deb ./openjdk-11-jdk_11.0.20+8-1~deb11u1_amd64.deb && \
+    apt-get -y install maven && \
     # Add Cygnus user
     adduser ${CYGNUS_USER} && \
     export JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk-amd64 && \

--- a/docker/cygnus-ngsi/Dockerfile
+++ b/docker/cygnus-ngsi/Dockerfile
@@ -269,6 +269,8 @@ RUN \
     apt-get -y update && \
     apt-get -y upgrade && \
     # Install dependencies
+    # Debian 12 comes with Java 17 but we have found some problems with it (see https://github.com/telefonicaid/fiware-cygnus/issues/2297)
+    # so we "downgrade" to Java 11
     apt-get -y install curl git python3 && \
     curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jdk_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jdk_11.0.20+8-1~deb11u1_amd64.deb && \
     curl -s --insecure -L 'http://security.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jre_11.0.20+8-1~deb11u1_amd64.deb' > openjdk-11-jre_11.0.20+8-1~deb11u1_amd64.deb && \


### PR DESCRIPTION
continuation of PR https://github.com/telefonicaid/fiware-cygnus/pull/2284

No CNR update is needed (keeping using openjdk-11)

Due to https://github.com/telefonicaid/fiware-cygnus/issues/2297