### PR TITLE
Added missing quote mentioned in issue #2332

### DIFF
--- a/docker/cygnus-ngsi/README.md
+++ b/docker/cygnus-ngsi/README.md
@@ -71,7 +71,7 @@ services:
     hostname: postgres-db
     container_name: db-postgres
     ports:
-      - "5432:5432
+      - "5432:5432"
     environment:
       - "POSTGRES_PASSWORD=password"
       - "POSTGRES_USER=postgres"


### PR DESCRIPTION
Fixed missing quote in the provided sample docker-compose file in the README.md [file](https://github.com/telefonicaid/fiware-cygnus/blob/master/docker/cygnus-ngsi/README.md).