### PR TITLE
Fix/check get lastdata before remove

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist
+- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist (i.e. creating and updating entiies)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist (i.e. creating and updating entiies)
+- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist (i.e. creating and updating entities)

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -245,7 +245,7 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
                                 ArrayList<String> keys = new ArrayList<>(aggregation.keySet());
                                 for (int j = 0 ; j < keys.size() ; j++) {
                                     ArrayList<JsonElement> lst = lastData.get(keys.get(j));
-                                    if (lst) {
+                                    if (lst != null) {
                                         lst.remove(i);
                                     }
                                 }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -244,7 +244,10 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
                             if (storedTS < currentTS) {
                                 ArrayList<String> keys = new ArrayList<>(aggregation.keySet());
                                 for (int j = 0 ; j < keys.size() ; j++) {
-                                    lastData.get(keys.get(j)).remove(i);
+                                    ArrayList<JsonElement> lst = lastData.get(keys.get(j));
+                                    if (lst) {
+                                        lst.remove(i);
+                                    }
                                 }
                                 updateLastData = true;
                                 break;


### PR DESCRIPTION
time=2024-03-07T10:32:00.371Z | lvl=ERROR | corr=776e343e-8e3e-4e55-99ca-67939e592c99; cbnotif=15 | trans=5bd491ef-ffc2-4d47-8141-368c227d7138 | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=processNewBatches | msg=com.telefonica.iot.cygnus.sinks.NGSISink[619] : Cannot invoke "java.util.ArrayList.remove(int)" because the return value of "java.util.LinkedHashMap.get(Object)" is null Sink: postgis-sink Destination: smartcity_/_ValidationAsset Stack trace: [com.telefonica.iot.cygnus.aggregation.NGSIGenericColumnAggregator.aggregate(NGSIGenericColumnAggregator.java:247), com.telefonica.iot.cygnus.sinks.NGSIPostgisSink.persistBatch(NGSIPostgisSink.java:390), com.telefonica.iot.cygnus.sinks.NGSISink.processNewBatches(NGSISink.java:597), com.telefonica.iot.cygnus.sinks.NGSISink.process(NGSISink.java:372), org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:39), org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:145), java.base/java.lang.Thread.run(Thread.java:840)]


Maybe related with recent jdk update (from 11 to 17)