### PR TITLE
Fix/check key before remove from lastdatadelete

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cygnus-ngsi][ColumnAggregator][LastData] Fix error when remove old values in lastData which does not exist

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLQueryUtils.java
@@ -182,14 +182,19 @@ public class SQLQueryUtils {
             query.append("DELETE FROM ").append(postgisDestination).append(" WHERE ");
             Boolean addAnd = false;
             for (int j = 0 ; j < keys.size() ; j++) {
+
                 if (Arrays.asList(uniqueKey.toLowerCase().split("\\s*,\\s*")).contains(keys.get(j).toLowerCase())) {
-                    JsonElement value = lastDataDelete.get(keys.get(j)).get(i);
-                    String valueToAppend = value == null ? "null" : getStringValueFromJsonElement(value, "'", attrNativeTypes);
-                    if (addAnd) {
-                        query.append(" AND ");
+
+                    if (lastDataDelete.containsKey(keys.get(j))) {
+                        JsonElement value = lastDataDelete.get(keys.get(j)).get(i);
+
+                        String valueToAppend = value == null ? "null" : getStringValueFromJsonElement(value, "'", attrNativeTypes);
+                        if (addAnd) {
+                            query.append(" AND ");
+                        }
+                        query.append(keys.get(j)).append("=").append(valueToAppend);
+                        addAnd = true;
                     }
-                    query.append(keys.get(j)).append("=").append(valueToAppend);
-                    addAnd = true;
                 }
             }
             if (addAnd) { // this means delete was finished with at least one element after where
@@ -293,7 +298,7 @@ public class SQLQueryUtils {
             if (addAnd) { // this means delete was finished with at least one element after where
                 upsertList.add(query);
             } else {
-                LOGGER.warn("[SQLQueryUtils.postgreSqlUpsertQuery] incomplete delete for lastdata: " + query.toString() + " with this uniqueKey " + uniqueKey.toString() + " and keys " + keys.toString());
+                LOGGER.warn("[SQLQueryUtils.mySqlUpsertQuery] incomplete delete for lastdata: " + query.toString() + " with this uniqueKey " + uniqueKey.toString() + " and keys " + keys.toString());
             }
         }
         LOGGER.debug("[SQLQueryUtils.mySqlUpsertQuery] Preparing Upsert querys: " + upsertList.toString());

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -245,7 +245,7 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
                                 ArrayList<String> keys = new ArrayList<>(aggregation.keySet());
                                 for (int j = 0 ; j < keys.size() ; j++) {
                                     ArrayList<JsonElement> lst = lastData.get(keys.get(j));
-                                    if (lst) {
+                                    if (lst != null) {
                                         lst.remove(i);
                                     }
                                 }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/aggregation/NGSIGenericColumnAggregator.java
@@ -244,7 +244,10 @@ public class NGSIGenericColumnAggregator extends NGSIGenericAggregator {
                             if (storedTS < currentTS) {
                                 ArrayList<String> keys = new ArrayList<>(aggregation.keySet());
                                 for (int j = 0 ; j < keys.size() ; j++) {
-                                    lastData.get(keys.get(j)).remove(i);
+                                    ArrayList<JsonElement> lst = lastData.get(keys.get(j));
+                                    if (lst) {
+                                        lst.remove(i);
+                                    }
                                 }
                                 updateLastData = true;
                                 break;


### PR DESCRIPTION
When a batch contains multiple entities to delete, some of then are not deleted: 

time=2024-03-07T12:55:15.590Z | lvl=DEBUG | corr=06e31976-cb18-4082-8831-e5fe034
d43a7; cbnotif=1 | trans=e6e741da-c3af-4526-8466-9be8f6d40ebb | srv=N/A | subsrv
=N/A | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.
NGSIPostgisSink[392] : [postgis-sink] adding event to aggregator object  (name=(
entityId,entityType,fiwareServicePath,recvTimeTsC,recvTime,country,country_md,co
untry_attr_internal_type,kpiValue,kpiValue_md,kpiValue_attr_internal_type,totalA
ctivePower,totalActivePower_md,totalActivePower_attr_internal_type,municipality,
municipality_md,municipality_attr_internal_type,description,description_md,descr
iption_attr_internal_type,vertical,vertical_md,vertical_attr_internal_type,probF
emale,probFemale_md,probFemale_attr_internal_type,province,province_md,province_
attr_internal_type,zone,zone_md,zone_attr_internal_type,temperature,temperature_
md,temperature_attr_internal_type,state,state_md,state_attr_internal_type,addres
sLocality,addressLocality_md,addressLocality_attr_internal_type,addressRegion,ad
dressRegion_md,addressRegion_attr_internal_type,fillingLevel,fillingLevel_md,fil
lingLevel_attr_internal_type,storedWasteKind,storedWasteKind_md,storedWasteKind_
attr_internal_type,zip,zip_md,zip_attr_internal_type,addressCountry,addressCount
ry_md,addressCountry_attr_internal_type,address,address_md,address_attr_internal
_type,serialNumber,serialNumber_md,serialNumber_attr_internal_type,addressCommun
ity,addressCommunity_md,addressCommunity_attr_internal_type,groundHumidity,groun
dHumidity_md,groundHumidity_attr_internal_type,totalReactivePower,totalReactiveP
ower_md,totalReactivePower_attr_internal_type,district,district_md,district_attr
_internal_type,location,location_md,location_attr_internal_type,shortName,shortN
ame_md,shortName_attr_internal_type,region,region_md,region_attr_internal_type,T
imeInstant,TimeInstant_md,TimeInstant_attr_internal_type,status,status_md,status
_attr_internal_type,probMale,probMale_md,probMale_attr_internal_type), values=('
VA-MDH-04','ValidationAsset','/','1709816111498','2024-03-07 12:55:11.498','NA',
'[]','Text',941,'[]','Number',837.48,'[]','Number','NA','[]','Text','workingPart
ially','[]','Text','WidgetValidation','[]','Text',61,'[]','Number','NA','[]','Te
xt','NA','[]','Text',20.81,'[]','Number',0,'[]','Number','NA','[]','Text','NA','
[]','Text',194,'[]','Number','plastic','[]','Text','NA','[]','Text','NA','[]','Text','0 Kensington Plaza','[]','Text','NA','[]','Text','NA','[]','Text',24.223,'[]','Number',145.47,'[]','Number','NA','[]','Text',ST_GeomFromGeoJSON('{"type":"Point","coordinates":[-3.633286647,37.951694708]}'),'[]','geo:json','Contenedor 
68','[]','Text','NA','[]','Text','2023-12-01T18:00:00.122Z','[]','DateTime','full','[]','Text',77,'[]','Number'),('VA-MDH-03','ValidationAsset','/','1709816111498','2024-03-07 12:55:11.498','NA','[]','Text',7,'[]','Number',72.55,'[]','Number','NA','[]','Text',NULL,NULL,NULL,'WidgetValidation','[]','Text',19,'[]','Number','NA','[]','Text','NA','[]','Text',19.89,'[]','Number',1,'[]','Number','NA','[]','Text','NA','[]','Text',188,'[]','Number','glass','[]','Text','NA','[]','Text','NA','[]','Text','011 Vernon Center','[]','Text','NA','[]','Text','NA','[]','Text',41.871,'[]','Number',143.03,'[]','Number','NA','[]','Text',ST_GeomFromGeoJSON('{"type":"Point","coordinates":[-2.664585454,38.575501034]}'),'[]','geo:json','Contenedor 30','[]','Text','NA','[]','Text','2023-10-01T16:00:00.122Z','[]','DateTime','on','[]','Text',51,'[]','Number'),('VA-MDD-04','ValidationAsset','/','1709816111498','2024-03-07 12:55:11.498','NA','[]','Text',645,'[]','Number',281.55,'[]','Number','NA','[]','Text',NULL,NULL,NULL,'WidgetValidation','[]','Text',14,'[]','Number','NA','[]','Text','NA','[]','Text',-1.85,'[]','Number',0,'[]','Number','NA','[]','Text','NA','[]','Text',289,'[]','Number','organic','[]','Text','NA','[]','Text','NA','[]','Text','918 International Street','[]','Text','NA','[]','Text','NA','[]','Text',34.324,'[]','Number',131.83,'[]','Number','NA','[]','Text',ST_GeomFromGeoJSON('{"type":"Point","coordinates":[-2.555354985,38.729285378]}'),'[]','geo:json','Contenedor 19','[]','Text','NA','[]','Text','2023-12-12T12:00:00.122Z','[]','DateTime','ok','[]','Text',12,'[]','Number'),('VA-MDH-02','ValidationAsset','/','1709816111498','2024-03-07 12:55:11.498','NA','[]','Text',122,'[]','Number',598.23,'[]','Number','NA','[]','Text',NULL,NULL,NULL,'WidgetValidation','[]','Text',59,'[]','Number','NA','[]','Text','NA','[]','Text',20.69,'[]','Number',1,'[]','Number','NA','[]','Text','NA','[]','Text',87,'[]','Number','inorganic','[]','Text','NA','[]','Text','NA','[]','Text','91 Nevada Hill','[]','Text','NA','[]','Text','NA','[]','Text',92.517,'[]','Number',139.37,'[]','Number','NA','[]','Text',ST_GeomFromGeoJSON('{"type":"Point","coordinates":[-2.249169228,37.702170651]}'),'[]','geo:json','Contenedor 05','[]','Text','NA','[]','Text','2023-07-01T13:00:00.122Z','[]','DateTime','off','[]','Text',90,'[]','Number'))

time=2024-03-07T12:55:15.591Z | lvl=DEBUG | corr=06e31976-cb18-4082-8831-e5fe034d43a7; cbnotif=1 | trans=e6e741da-c3af-4526-8466-9be8f6d40ebb | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=postgreSqlUpsertQuery | msg=com.telefonica.iot.cygnus.backends.sql.SQLQueryUtils[201] : [SQLQueryUtils.postgreSqlUpsertQuery] Preparing Upsert querys: [DELETE FROM smartcity.validationasset_lastdata WHERE entityId=null, DELETE FROM smartcity.validationasset_lastdata WHERE entityId=null, DELETE FROM smartcity.validationasset_lastdata WHERE entityId=null, DELETE FROM smartcity.validationasset_lastdata WHERE entityId='VA-MDH-02']