### PR TITLE
add max and min pool idle config for sql sinks

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- [cygnus-common] [SQL-sinks] Define default values and allow to set Pool config for maxPoolSize(3), maxPoolIddle(2), minPoolIdle(0) and maxPoolWait(12000) (#2366)
+- [cygnus-common] [SQL-sinks] Define default values and allow to set connection pool config for maxPoolSize(3), maxPoolIddle(2), minPoolIdle(0) and minPoolIdleTimeMillis(10000) (#2366)
 - [cygnus-ngsi] Upgrade Debian version from 12.4 to 12.5 in Dockerfile

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- [cygnus-common] [SQL-sinks] Define default values and allow to set Pool config for maxPoolSize(3), maxPoolIddle(2), minPoolIdle(0) and maxPoolWait(12000) (#2366)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -1113,10 +1113,14 @@ public class SQLBackendImpl implements SQLBackend{
 
                 // Creates an Instance of GenericObjectPool That Holds Our Pool of Connections Object!
                 gPool = new GenericObjectPool();
+                // Tune from https://javadoc.io/static/commons-pool/commons-pool/1.6/org/apache/commons/pool/impl/GenericObjectPool.html
+                // Sets the cap on the number of objects that can be allocated by the pool (checked out to clients, or idle awaiting checkout) at a given time.
                 gPool.setMaxActive(this.maxPoolSize);
+                // Sets the cap on the number of "idle" instances in the pool.
                 gPool.setMaxIdle(this.maxPoolIdle);
+                // Sets the minimum number of objects allowed in the pool before the evictor thread (if active) spawns new objects.
                 gPool.setMinIdle(this.minPoolIdle);
-                //gPool.setMaxWait(this.maxPoolWait);
+                // Sets the minimum amount of time an object may sit idle in the pool before it is eligible for eviction by the idle object evictor (if any), with the extra condition that at least "minIdle" object instances remain in the pool.
                 gPool.setSoftMinEvictableIdleTimeMillis(this.maxPoolWait);
                 pools.put(destination, gPool);
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -1117,7 +1117,7 @@ public class SQLBackendImpl implements SQLBackend{
                 gPool.setMaxIdle(this.maxPoolIdle);
                 gPool.setMinIdle(this.minPoolIdle);
                 //gPool.setMaxWait(this.maxPoolWait);
-                gPool.setMinEvictableIdleTimeMillis(this.maxPoolWait);
+                gPool.setSoftMinEvictableIdleTimeMillis(this.maxPoolWait);
                 pools.put(destination, gPool);
 
                 // Creates a ConnectionFactory Object Which Will Be Used by the Pool to Create the Connection Object!

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -1116,7 +1116,8 @@ public class SQLBackendImpl implements SQLBackend{
                 gPool.setMaxActive(this.maxPoolSize);
                 gPool.setMaxIdle(this.maxPoolIdle);
                 gPool.setMinIdle(this.minPoolIdle);
-                gPool.setMaxWait(this.maxPoolWait);
+                //gPool.setMaxWait(this.maxPoolWait);
+                gPool.setMinEvictableIdleTimeMillis(this.maxPoolWait);
                 pools.put(destination, gPool);
 
                 // Creates a ConnectionFactory Object Which Will Be Used by the Pool to Create the Connection Object!

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -67,13 +67,14 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
+     * @param maxPoolWait
      * @param sqlInstance
      * @param sqlDriverName
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
     } // SQLBackendImpl
 
     /**
@@ -86,12 +87,13 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
+     * @param maxPoolWait
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
     } // SQLBackendImpl
 
     /**
@@ -104,14 +106,15 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
+     * @param maxPoolWait
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
-        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions);
         cache = new SQLCache();
         this.sqlInstance = sqlInstance;
         this.persistErrors = persistErrors;
@@ -943,6 +946,7 @@ public class SQLBackendImpl implements SQLBackend{
         private final int maxPoolSize;
         private final int maxPoolIdle;
         private final int minPoolIdle;
+        private final int maxPoolWait;
         private final String sqlOptions;
 
         /**
@@ -953,11 +957,14 @@ public class SQLBackendImpl implements SQLBackend{
          * @param sqlUsername
          * @param sqlPassword
          * @param maxPoolSize
+         * @param maxPoolIdle
+         * @param minPoolIdle
+         * @param maxPoolWait
          * @param sqlInstance
          * @param sqlDriverName
          * @param sqlOptions
          */
-        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
             datasources = new HashMap<>();
             pools = new HashMap<>();
             this.sqlHost = sqlHost;
@@ -967,6 +974,7 @@ public class SQLBackendImpl implements SQLBackend{
             this.maxPoolSize = maxPoolSize;
             this.maxPoolIdle = maxPoolIdle;
             this.minPoolIdle = minPoolIdle;
+            this.maxPoolWait = maxPoolWait;
             this.sqlInstance = sqlInstance;
             this.sqlDriverName = sqlDriverName;
             this.sqlOptions = sqlOptions;
@@ -1108,6 +1116,7 @@ public class SQLBackendImpl implements SQLBackend{
                 gPool.setMaxActive(this.maxPoolSize);
                 gPool.setMaxIdle(this.maxPoolIdle);
                 gPool.setMinIdle(this.minPoolIdle);
+                gPool.setMaxWait(this.maxPoolWait);
                 pools.put(destination, gPool);
 
                 // Creates a ConnectionFactory Object Which Will Be Used by the Pool to Create the Connection Object!

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -65,13 +65,15 @@ public class SQLBackendImpl implements SQLBackend{
      * @param sqlUsername
      * @param sqlPassword
      * @param maxPoolSize
+     * @param maxPoolIdle
+     * @param minPoolIdle
      * @param sqlInstance
      * @param sqlDriverName
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
     } // SQLBackendImpl
 
     /**
@@ -82,12 +84,14 @@ public class SQLBackendImpl implements SQLBackend{
      * @param sqlUsername
      * @param sqlPassword
      * @param maxPoolSize
+     * @param maxPoolIdle
+     * @param minPoolIdle
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
     } // SQLBackendImpl
 
     /**
@@ -98,14 +102,16 @@ public class SQLBackendImpl implements SQLBackend{
      * @param sqlUsername
      * @param sqlPassword
      * @param maxPoolSize
+     * @param maxPoolIdle
+     * @param minPoolIdle
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
-        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions);
         cache = new SQLCache();
         this.sqlInstance = sqlInstance;
         this.persistErrors = persistErrors;
@@ -935,6 +941,8 @@ public class SQLBackendImpl implements SQLBackend{
         private final SQLInstance sqlInstance;
         private final String sqlDriverName;
         private final int maxPoolSize;
+        private final int maxPoolIdle;
+        private final int minPoolIdle;
         private final String sqlOptions;
 
         /**
@@ -949,7 +957,7 @@ public class SQLBackendImpl implements SQLBackend{
          * @param sqlDriverName
          * @param sqlOptions
          */
-        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
             datasources = new HashMap<>();
             pools = new HashMap<>();
             this.sqlHost = sqlHost;
@@ -957,6 +965,8 @@ public class SQLBackendImpl implements SQLBackend{
             this.sqlUsername = sqlUsername;
             this.sqlPassword = sqlPassword;
             this.maxPoolSize = maxPoolSize;
+            this.maxPoolIdle = maxPoolIdle;
+            this.minPoolIdle = minPoolIdle;
             this.sqlInstance = sqlInstance;
             this.sqlDriverName = sqlDriverName;
             this.sqlOptions = sqlOptions;
@@ -1096,6 +1106,8 @@ public class SQLBackendImpl implements SQLBackend{
                 // Creates an Instance of GenericObjectPool That Holds Our Pool of Connections Object!
                 gPool = new GenericObjectPool();
                 gPool.setMaxActive(this.maxPoolSize);
+                gPool.setMaxIdle(this.maxPoolIdle);
+                gPool.setMinIdle(this.minPoolIdle);
                 pools.put(destination, gPool);
 
                 // Creates a ConnectionFactory Object Which Will Be Used by the Pool to Create the Connection Object!

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImpl.java
@@ -67,14 +67,14 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
-     * @param maxPoolWait
+     * @param minPoolIdleTimeMillis
      * @param sqlInstance
      * @param sqlDriverName
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, SQLInstance sqlInstance, String sqlDriverName, boolean persistErrors, int maxLatestErrors) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
     } // SQLBackendImpl
 
     /**
@@ -87,13 +87,13 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
-     * @param maxPoolWait
+     * @param minPoolIdleTimeMillis
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
-        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        this(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, true, DEFAULT_MAX_LATEST_ERRORS);
     } // SQLBackendImpl
 
     /**
@@ -106,15 +106,15 @@ public class SQLBackendImpl implements SQLBackend{
      * @param maxPoolSize
      * @param maxPoolIdle
      * @param minPoolIdle
-     * @param maxPoolWait
+     * @param minPoolIdleTimeMillis
      * @param sqlInstance
      * @param sqlDriverName
      * @param sqlOptions
      * @param persistErrors
      * @param maxLatestErrors
      */
-    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
-        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions);
+    public SQLBackendImpl(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+        driver = new SQLBackendImpl.SQLDriver(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions);
         cache = new SQLCache();
         this.sqlInstance = sqlInstance;
         this.persistErrors = persistErrors;
@@ -946,7 +946,7 @@ public class SQLBackendImpl implements SQLBackend{
         private final int maxPoolSize;
         private final int maxPoolIdle;
         private final int minPoolIdle;
-        private final int maxPoolWait;
+        private final int minPoolIdleTimeMillis;
         private final String sqlOptions;
 
         /**
@@ -959,12 +959,12 @@ public class SQLBackendImpl implements SQLBackend{
          * @param maxPoolSize
          * @param maxPoolIdle
          * @param minPoolIdle
-         * @param maxPoolWait
+         * @param minPoolIdleTimeMillis
          * @param sqlInstance
          * @param sqlDriverName
          * @param sqlOptions
          */
-        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
+        public SQLDriver(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, SQLInstance sqlInstance, String sqlDriverName, String sqlOptions) {
             datasources = new HashMap<>();
             pools = new HashMap<>();
             this.sqlHost = sqlHost;
@@ -974,7 +974,7 @@ public class SQLBackendImpl implements SQLBackend{
             this.maxPoolSize = maxPoolSize;
             this.maxPoolIdle = maxPoolIdle;
             this.minPoolIdle = minPoolIdle;
-            this.maxPoolWait = maxPoolWait;
+            this.minPoolIdleTimeMillis = minPoolIdleTimeMillis;
             this.sqlInstance = sqlInstance;
             this.sqlDriverName = sqlDriverName;
             this.sqlOptions = sqlOptions;
@@ -1120,8 +1120,10 @@ public class SQLBackendImpl implements SQLBackend{
                 gPool.setMaxIdle(this.maxPoolIdle);
                 // Sets the minimum number of objects allowed in the pool before the evictor thread (if active) spawns new objects.
                 gPool.setMinIdle(this.minPoolIdle);
-                // Sets the minimum amount of time an object may sit idle in the pool before it is eligible for eviction by the idle object evictor (if any), with the extra condition that at least "minIdle" object instances remain in the pool.
-                gPool.setSoftMinEvictableIdleTimeMillis(this.maxPoolWait);
+                // Sets the minimum amount of time an object may sit idle in the pool before it is eligible for eviction by the idle object evictor (if any)
+                gPool.setMinEvictableIdleTimeMillis(this.minPoolIdleTimeMillis);
+                // Sets the number of milliseconds to sleep between runs of the idle object evictor thread
+                gPool.setTimeBetweenEvictionRunsMillis(this.minPoolIdleTimeMillis*3);
                 pools.put(destination, gPool);
 
                 // Creates a ConnectionFactory Object Which Will Be Used by the Pool to Create the Connection Object!

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
@@ -53,6 +53,8 @@ public class SQLBackendImplTest {
 
     // constants
     private final int maxPoolSize = 2;
+    private final int maxPoolIdle = 2;
+    private final int minPoolIdle = 0;
     private final String host = "localhost";
     private final String port = "3306";
     private final String user = "root";
@@ -83,7 +85,7 @@ public class SQLBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
 
         // set up the behaviour of the mocked classes
         when(mockDriverDbCreate.getConnection(Mockito.anyString())).thenReturn(mockConnection);
@@ -169,7 +171,7 @@ public class SQLBackendImplTest {
         String sqlDriverName = "com.mysql.jdbc.Driver";
         String destination = "dest";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -185,7 +187,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -201,7 +203,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:oracle:oci://localhost:1521/default");
@@ -217,7 +219,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String sqlOptions = "useSSL=true&requireSSL=false";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest?useSSL=true&requireSSL=false");
@@ -225,7 +227,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<white spaces>)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -233,7 +235,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -241,7 +243,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -258,7 +260,7 @@ public class SQLBackendImplTest {
         String defaultDataBase = "default";
         String sqlOptions = "sslmode=require";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default?sslmode=require");
@@ -266,7 +268,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<white spaces)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -274,7 +276,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -282,7 +284,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
@@ -55,7 +55,7 @@ public class SQLBackendImplTest {
     private final int maxPoolSize = 2;
     private final int maxPoolIdle = 1;
     private final int minPoolIdle = 0;
-    private final int maxPoolWait = 10000;
+    private final int minPoolIdleTimeMillis = 10000;
     private final String host = "localhost";
     private final String port = "3306";
     private final String user = "root";
@@ -86,7 +86,7 @@ public class SQLBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
 
         // set up the behaviour of the mocked classes
         when(mockDriverDbCreate.getConnection(Mockito.anyString())).thenReturn(mockConnection);
@@ -172,7 +172,7 @@ public class SQLBackendImplTest {
         String sqlDriverName = "com.mysql.jdbc.Driver";
         String destination = "dest";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -188,7 +188,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -204,7 +204,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:oracle:oci://localhost:1521/default");
@@ -220,7 +220,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String sqlOptions = "useSSL=true&requireSSL=false";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest?useSSL=true&requireSSL=false");
@@ -228,7 +228,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<white spaces>)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -236,7 +236,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -244,7 +244,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -261,7 +261,7 @@ public class SQLBackendImplTest {
         String defaultDataBase = "default";
         String sqlOptions = "sslmode=require";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default?sslmode=require");
@@ -269,7 +269,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<white spaces)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -277,7 +277,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -285,7 +285,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/sql/SQLBackendImplTest.java
@@ -53,8 +53,9 @@ public class SQLBackendImplTest {
 
     // constants
     private final int maxPoolSize = 2;
-    private final int maxPoolIdle = 2;
+    private final int maxPoolIdle = 1;
     private final int minPoolIdle = 0;
+    private final int maxPoolWait = 10000;
     private final String host = "localhost";
     private final String port = "3306";
     private final String user = "root";
@@ -85,7 +86,7 @@ public class SQLBackendImplTest {
     @Before
     public void setUp() throws Exception {
         // set up the instance of the tested class
-        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(host, port, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, null, persistErrors, maxLatestErrors);
 
         // set up the behaviour of the mocked classes
         when(mockDriverDbCreate.getConnection(Mockito.anyString())).thenReturn(mockConnection);
@@ -171,7 +172,7 @@ public class SQLBackendImplTest {
         String sqlDriverName = "com.mysql.jdbc.Driver";
         String destination = "dest";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, null, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -187,7 +188,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -203,7 +204,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String defaultDataBase = "default";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, defaultDataBase, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:oracle:oci://localhost:1521/default");
@@ -219,7 +220,7 @@ public class SQLBackendImplTest {
         String destination = "dest";
         String sqlOptions = "useSSL=true&requireSSL=false";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest?useSSL=true&requireSSL=false");
@@ -227,7 +228,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<white spaces>)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -235,7 +236,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -243,7 +244,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:mysql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:mysql://localhost:3306/dest");
@@ -260,7 +261,7 @@ public class SQLBackendImplTest {
         String defaultDataBase = "default";
         String sqlOptions = "sslmode=require";
 
-        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        SQLBackendImpl backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         SQLBackendImpl.SQLDriver driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default?sslmode=require");
@@ -268,7 +269,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<white spaces)");
         sqlOptions = " \t";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -276,7 +277,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<empty>)");
         sqlOptions = "";
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");
@@ -284,7 +285,7 @@ public class SQLBackendImplTest {
         System.out.println("Testing SQLBackendImpl.SQLDriver.generateJDBCUrl (sqlInstance:postgresql, options:<null>)");
         sqlOptions = null;
 
-        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
+        backend = new SQLBackendImpl(sqlHost, sqlPort, user, password, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, sqlInstance, sqlDriverName, sqlOptions, persistErrors, maxLatestErrors);
         driver = backend.getDriver();
 
         assertEquals(driver.generateJDBCUrl(destination), "jdbc:postgresql://localhost:5432/default");

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -57,6 +57,8 @@ public class NGSIPostgisSink extends NGSILDSink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -70,6 +72,8 @@ public class NGSIPostgisSink extends NGSILDSink {
     private String postgisPassword;
     private boolean rowAttrPersistence;
     private int maxPoolSize;
+    private int maxPoolIdle;
+    private int minPoolIdle;
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -206,6 +210,12 @@ public class NGSIPostgisSink extends NGSILDSink {
         maxPoolSize = context.getInteger("postgis_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolSize=" + maxPoolSize + ")");
 
+        maxPoolIdle = context.getInteger("postgis_maxPoolIdle", DEFAULT_MAX_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolIdle=" + maxPoolIdle + ")");
+
+        minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -269,7 +279,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, postgisOptions);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgisOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the Postgis persistence backend. Details="
                     + e.getMessage());
@@ -282,9 +292,9 @@ public class NGSIPostgisSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -59,6 +59,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;    
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -74,6 +75,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
+    private int maxPoolWait;
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -216,6 +218,9 @@ public class NGSIPostgisSink extends NGSILDSink {
         minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
 
+        maxPoolWait = context.getInteger("postgis_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolWait=" + maxPoolWait + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -279,7 +284,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgisOptions);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgisOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the Postgis persistence backend. Details="
                     + e.getMessage());
@@ -292,9 +297,9 @@ public class NGSIPostgisSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -59,7 +59,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;    
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;    
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -75,7 +75,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;    
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -218,8 +218,8 @@ public class NGSIPostgisSink extends NGSILDSink {
         minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("postgis_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolWait=" + maxPoolWait + ")");
+        minPoolIdleTimeMillis = context.getInteger("postgis_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -284,7 +284,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgisOptions);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, postgisOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the Postgis persistence backend. Details="
                     + e.getMessage());
@@ -297,9 +297,9 @@ public class NGSIPostgisSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -57,7 +57,7 @@ public class NGSIPostgisSink extends NGSILDSink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -50,6 +50,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
 
@@ -61,7 +62,8 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private String postgresqlPassword;
     private int maxPoolSize;
     private int maxPoolIdle;
-    private int minPoolIdle;    
+    private int minPoolIdle;
+    private int maxPoolWait;
     private boolean rowAttrPersistence;
     private SQLBackendImpl postgreSQLPersistenceBackend;
     private boolean enableCache;
@@ -194,6 +196,9 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
         minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
 
+        maxPoolWait = context.getInteger("postgresql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolWait=" + maxPoolWait + ")");        
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -223,7 +228,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgresqlOptions);
+            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgresqlOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the PostgreSQL persistence backend. Details="
                     + e.getMessage());
@@ -236,9 +241,9 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions) {
         if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
+            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -196,7 +196,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
         minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
 
-        minPoolIdleTimeMillis = context.getInteger("postgresql_minPoolIdleTimeMillis", DEFAULT_MAX_POOL_WAIT);
+        minPoolIdleTimeMillis = context.getInteger("postgresql_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");        
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -48,6 +48,8 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
 
@@ -58,6 +60,8 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private String postgresqlUsername;
     private String postgresqlPassword;
     private int maxPoolSize;
+    private int maxPoolIdle;
+    private int minPoolIdle;    
     private boolean rowAttrPersistence;
     private SQLBackendImpl postgreSQLPersistenceBackend;
     private boolean enableCache;
@@ -184,6 +188,12 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
         maxPoolSize = context.getInteger("postgresql_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolSize=" + maxPoolSize + ")");
 
+        maxPoolIdle = context.getInteger("postgresql_maxPoolIdle", DEFAULT_MAX_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolIdle=" + maxPoolIdle + ")");
+
+        minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -213,7 +223,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, postgresqlOptions);
+            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgresqlOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the PostgreSQL persistence backend. Details="
                     + e.getMessage());
@@ -226,9 +236,9 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions) {
         if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
+            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -48,7 +48,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;

--- a/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi-ld/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -50,7 +50,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;    
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
 
@@ -63,7 +63,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;
     private boolean rowAttrPersistence;
     private SQLBackendImpl postgreSQLPersistenceBackend;
     private boolean enableCache;
@@ -196,8 +196,8 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
         minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("postgresql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolWait=" + maxPoolWait + ")");        
+        minPoolIdleTimeMillis = context.getInteger("postgresql_minPoolIdleTimeMillis", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");        
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -228,7 +228,7 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgresqlOptions);
+            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, postgresqlOptions);
         } catch (Exception e) {
             LOGGER.error("Error while creating the PostgreSQL persistence backend. Details="
                     + e.getMessage());
@@ -241,9 +241,9 @@ public class NGSIPostgreSQLSink extends NGSILDSink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions) {
         if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
+            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -60,6 +60,7 @@ public class NGSIMySQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String MYSQL_DRIVER_NAME = "com.mysql.jdbc.Driver";
     private static final SQLInstance MYSQL_INSTANCE_NAME = SQLInstance.MYSQL;
@@ -78,6 +79,7 @@ public class NGSIMySQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
+    private int maxPoolWait;
     private boolean rowAttrPersistence;
     private SQLBackendImpl mySQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -203,6 +205,9 @@ public class NGSIMySQLSink extends NGSISink {
         minPoolIdle = context.getInteger("mysql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_minPoolIdle=" + minPoolIdle + ")");
 
+        maxPoolWait = context.getInteger("mysql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_maxPoolWait=" + maxPoolWait + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -291,7 +296,7 @@ public class NGSIMySQLSink extends NGSISink {
             createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle,  mysqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] MySQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " maxPoolWait " + maxPoolWait + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the MySQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -310,9 +315,9 @@ public class NGSIMySQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (mySQLPersistenceBackend == null) {
-            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -60,7 +60,7 @@ public class NGSIMySQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String MYSQL_DRIVER_NAME = "com.mysql.jdbc.Driver";
     private static final SQLInstance MYSQL_INSTANCE_NAME = SQLInstance.MYSQL;
@@ -79,7 +79,7 @@ public class NGSIMySQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;
     private boolean rowAttrPersistence;
     private SQLBackendImpl mySQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -205,8 +205,8 @@ public class NGSIMySQLSink extends NGSISink {
         minPoolIdle = context.getInteger("mysql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("mysql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_maxPoolWait=" + maxPoolWait + ")");
+        minPoolIdleTimeMillis = context.getInteger("mysql_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -293,10 +293,10 @@ public class NGSIMySQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, mysqlOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, mysqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] MySQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " maxPoolWait " + maxPoolWait + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " minPoolIdleTimeMillis " + minPoolIdleTimeMillis + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the MySQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -315,9 +315,9 @@ public class NGSIMySQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (mySQLPersistenceBackend == null) {
-            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -58,7 +58,7 @@ public class NGSIMySQLSink extends NGSISink {
     private static final String DEFAULT_HOST = "localhost";
     private static final String DEFAULT_USER_NAME = "root";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String MYSQL_DRIVER_NAME = "com.mysql.jdbc.Driver";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -58,6 +58,8 @@ public class NGSIMySQLSink extends NGSISink {
     private static final String DEFAULT_HOST = "localhost";
     private static final String DEFAULT_USER_NAME = "root";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String MYSQL_DRIVER_NAME = "com.mysql.jdbc.Driver";
     private static final SQLInstance MYSQL_INSTANCE_NAME = SQLInstance.MYSQL;
@@ -74,6 +76,8 @@ public class NGSIMySQLSink extends NGSISink {
     private String mysqlUsername;
     private String mysqlPassword;
     private int maxPoolSize;
+    private int maxPoolIdle;
+    private int minPoolIdle;
     private boolean rowAttrPersistence;
     private SQLBackendImpl mySQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -193,6 +197,12 @@ public class NGSIMySQLSink extends NGSISink {
         maxPoolSize = context.getInteger("mysql_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_maxPoolSize=" + maxPoolSize + ")");
 
+        maxPoolIdle = context.getInteger("mysql_maxPoolIdle", DEFAULT_MAX_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_maxPoolIdle=" + maxPoolIdle + ")");
+
+        minPoolIdle = context.getInteger("mysql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (mysql_minPoolIdle=" + minPoolIdle + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -278,10 +288,10 @@ public class NGSIMySQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, mysqlOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle,  mysqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] MySQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the MySQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -300,9 +310,9 @@ public class NGSIMySQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (mySQLPersistenceBackend == null) {
-            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            mySQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, MYSQL_INSTANCE_NAME, MYSQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIMySQLSink.java
@@ -293,7 +293,7 @@ public class NGSIMySQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle,  mysqlOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(mysqlHost, mysqlPort, mysqlUsername, mysqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, mysqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] MySQL persistence backend created");
         } catch (Exception e) {
             String configParams = " mysqlHost " + mysqlHost + " mysqlPort " + mysqlPort + " mysqlUsername " + mysqlUsername + " mysqlPassword " + mysqlPassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " maxPoolWait " + maxPoolWait + " mysqlOptions " + mysqlOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -60,7 +60,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     //private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.OracleDriver";
     private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.driver.OracleDriver";    
@@ -87,7 +87,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;
     private boolean rowAttrPersistence;
     private SQLBackendImpl oracleSQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -228,8 +228,8 @@ public class NGSIOracleSQLSink extends NGSISink {
         minPoolIdle = context.getInteger("oracle_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("oracle_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_maxPoolWait=" + maxPoolWait + ")");
+        minPoolIdleTimeMillis = context.getInteger("oracle_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -342,10 +342,10 @@ public class NGSIOracleSQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, oracleOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, oracleOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] OracleSQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " maxPoolWait " + maxPoolWait + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " minPoolIdleTimeMillis " + minPoolIdleTimeMillis + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the OracleSQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -364,9 +364,9 @@ public class NGSIOracleSQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (oracleSQLPersistenceBackend == null) {
-            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
             oracleSQLPersistenceBackend.setNlsTimestampFormat(nlsTimestampFormat);
             oracleSQLPersistenceBackend.setNlsTimestampTzFormat(nlsTimestampTzFormat);
         }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -58,6 +58,8 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final String DEFAULT_USER_NAME = "system";
     private static final String DEFAULT_DATABASE = "xe";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     //private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.OracleDriver";
     private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.driver.OracleDriver";    
@@ -82,6 +84,8 @@ public class NGSIOracleSQLSink extends NGSISink {
     private String oraclePassword;
     private String oracleDatabase;    
     private int maxPoolSize;
+    private int maxPoolIdle;
+    private int minPoolIdle;
     private boolean rowAttrPersistence;
     private SQLBackendImpl oracleSQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -216,6 +220,12 @@ public class NGSIOracleSQLSink extends NGSISink {
         maxPoolSize = context.getInteger("oracle_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_maxPoolSize=" + maxPoolSize + ")");
 
+        maxPoolIdle = context.getInteger("oracle_maxPoolIdle", DEFAULT_MAX_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_maxPoolIdle=" + maxPoolIdle + ")");
+
+        minPoolIdle = context.getInteger("oracle_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_minPoolIdle=" + minPoolIdle + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -327,10 +337,10 @@ public class NGSIOracleSQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, oracleOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, maxPoolIdle, minPoolIdle, oracleOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] OracleSQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the OracleSQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -349,9 +359,9 @@ public class NGSIOracleSQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (oracleSQLPersistenceBackend == null) {
-            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
             oracleSQLPersistenceBackend.setNlsTimestampFormat(nlsTimestampFormat);
             oracleSQLPersistenceBackend.setNlsTimestampTzFormat(nlsTimestampTzFormat);
         }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -58,7 +58,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final String DEFAULT_USER_NAME = "system";
     private static final String DEFAULT_DATABASE = "xe";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     //private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.OracleDriver";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIOracleSQLSink.java
@@ -60,6 +60,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     //private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.OracleDriver";
     private static final String ORACLE_DRIVER_NAME = "oracle.jdbc.driver.OracleDriver";    
@@ -86,6 +87,7 @@ public class NGSIOracleSQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
+    private int maxPoolWait;
     private boolean rowAttrPersistence;
     private SQLBackendImpl oracleSQLPersistenceBackend;
     private boolean attrNativeTypes;
@@ -226,6 +228,9 @@ public class NGSIOracleSQLSink extends NGSISink {
         minPoolIdle = context.getInteger("oracle_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_minPoolIdle=" + minPoolIdle + ")");
 
+        maxPoolWait = context.getInteger("oracle_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (oracle_maxPoolWait=" + maxPoolWait + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -337,10 +342,10 @@ public class NGSIOracleSQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, maxPoolIdle, minPoolIdle, oracleOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(oracleHost, oraclePort, oracleUsername, oraclePassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, oracleOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] OracleSQL persistence backend created");
         } catch (Exception e) {
-            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
+            String configParams = " oracleHost " + oracleHost + " oraclePort " + oraclePort + " oracleUsername " + oracleUsername + " oraclePassword " + oraclePassword + " maxPoolSize " + maxPoolSize + " maxPoolIdle " + maxPoolIdle + " minPoolIdle " + minPoolIdle + " maxPoolWait " + maxPoolWait + " oracleOptions " + oracleOptions + " persistErrors " + persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the OracleSQL persistence backend. " +
                          "Config params= " + configParams +
                          "Details=" + e.getMessage() +
@@ -359,9 +364,9 @@ public class NGSIOracleSQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (oracleSQLPersistenceBackend == null) {
-            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            oracleSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, ORACLE_INSTANCE_NAME, ORACLE_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
             oracleSQLPersistenceBackend.setNlsTimestampFormat(nlsTimestampFormat);
             oracleSQLPersistenceBackend.setNlsTimestampTzFormat(nlsTimestampTzFormat);
         }

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -342,7 +342,7 @@ public class NGSIPostgisSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
-                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolIWaitdle + " postgisOptions " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolIWait + " postgisOptions " +
                 postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgis persistence backend. " +
                          "Config params= " + configParams +

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -54,7 +54,7 @@ public class NGSIPostgisSink extends NGSISink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -56,6 +56,7 @@ public class NGSIPostgisSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -79,6 +80,7 @@ public class NGSIPostgisSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
+    private int maxPoolWait;
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -228,6 +230,9 @@ public class NGSIPostgisSink extends NGSISink {
         minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
 
+        maxPoolWait = context.getInteger("postgis_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolWait=" + maxPoolWait + ")");        
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -333,11 +338,11 @@ public class NGSIPostgisSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgisOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgisOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
-                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " postgisOptions " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolIWaitdle + " postgisOptions " +
                 postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgis persistence backend. " +
                          "Config params= " + configParams +
@@ -352,9 +357,9 @@ public class NGSIPostgisSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -54,6 +54,8 @@ public class NGSIPostgisSink extends NGSISink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -75,6 +77,8 @@ public class NGSIPostgisSink extends NGSISink {
     private String postgisPassword;
     private boolean rowAttrPersistence;
     private int maxPoolSize;
+    private int maxPoolIdle;
+    private int minPoolIdle;
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -218,6 +222,12 @@ public class NGSIPostgisSink extends NGSISink {
         maxPoolSize = context.getInteger("postgis_maxPoolSize", DEFAULT_MAX_POOL_SIZE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolSize=" + maxPoolSize + ")");
 
+        maxPoolIdle = context.getInteger("postgis_maxPoolIdle", DEFAULT_MAX_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolIdle=" + maxPoolIdle + ")");
+
+        minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -323,11 +333,11 @@ public class NGSIPostgisSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, postgisOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgisOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
-                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " postgisOptions " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " postgisOptions " +
                 postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgis persistence backend. " +
                          "Config params= " + configParams +
@@ -342,9 +352,9 @@ public class NGSIPostgisSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -56,7 +56,7 @@ public class NGSIPostgisSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;
     private static final String DEFAULT_POSTGIS_TYPE = "geometry";
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGIS_DRIVER_NAME = "org.postgresql.Driver";
@@ -80,7 +80,7 @@ public class NGSIPostgisSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;
     private SQLBackendImpl postgisPersistenceBackend;
     private boolean enableCache;
     private boolean swapCoordinates;
@@ -230,8 +230,8 @@ public class NGSIPostgisSink extends NGSISink {
         minPoolIdle = context.getInteger("postgis_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("postgis_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_maxPoolWait=" + maxPoolWait + ")");        
+        minPoolIdleTimeMillis = context.getInteger("postgis_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgis_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -338,11 +338,11 @@ public class NGSIPostgisSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgisOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(postgisHost, postgisPort, postgisUsername, postgisPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, postgisOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
-                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolWait + " postgisOptions " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " minPoolIdleTimeMillis " +  minPoolIdleTimeMillis + " postgisOptions " +
                 postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgis persistence backend. " +
                          "Config params= " + configParams +
@@ -357,9 +357,9 @@ public class NGSIPostgisSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (postgisPersistenceBackend == null) {
-            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            postgisPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, POSTGIS_INSTANCE_NAME, POSTGIS_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgisSink.java
@@ -342,7 +342,7 @@ public class NGSIPostgisSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] POSTGIS persistence backend created");
         } catch (Exception e) {
             String configParams = " postgisHost " + postgisHost + " postgisPort " + postgisPort + "  postgisUsername " +
-                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolIWait + " postgisOptions " +
+                postgisUsername + " postgisPassword " + postgisPassword + " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " +  maxPoolWait + " postgisOptions " +
                 postgisOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgis persistence backend. " +
                          "Config params= " + configParams +

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -56,7 +56,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private static final String DEFAULT_DATABASE = "postgres";
     private static final String DEFAULT_ENABLE_CACHE = "false";
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
-    private static final int DEFAULT_MAX_POOL_IDLE = 3;
+    private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -58,7 +58,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
-    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
+    private static final int DEFAULT_MIN_POOL_IDLE_TIME_MILLIS = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
@@ -80,7 +80,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
-    private int maxPoolWait;
+    private int minPoolIdleTimeMillis;
     private boolean rowAttrPersistence;
     private SQLBackendImpl postgreSQLPersistenceBackend;
     private boolean enableCache;
@@ -230,8 +230,8 @@ public class NGSIPostgreSQLSink extends NGSISink {
         minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
 
-        maxPoolWait = context.getInteger("postgresql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
-        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolWait=" + maxPoolWait + ")");
+        minPoolIdleTimeMillis = context.getInteger("postgresql_minPoolIdleTimeMillis", DEFAULT_MIN_POOL_IDLE_TIME_MILLIS);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdleTimeMillis=" + minPoolIdleTimeMillis + ")");
 
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
@@ -330,12 +330,12 @@ public class NGSIPostgreSQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgresqlOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, postgresqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] Postgresql persistence backend created");
         } catch (Exception e) {
             String configParams = " postgresqlHost " + postgresqlHost + " postgresqlPort " + postgresqlPort +
                 "  postgresqlUsername " + postgresqlUsername + " postgresqlPassword " + postgresqlPassword +
-                " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " + maxPoolWait + " postgresqlOptions " +
+                " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " minPoolIdleTimeMillis " + minPoolIdleTimeMillis + " postgresqlOptions " +
                 postgresqlOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgresql persistence backend. " +
                          "Config params= " + configParams +
@@ -350,9 +350,9 @@ public class NGSIPostgreSQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int minPoolIdleTimeMillis, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, minPoolIdleTimeMillis, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIPostgreSQLSink.java
@@ -58,6 +58,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private static final int DEFAULT_MAX_POOL_SIZE = 3;
     private static final int DEFAULT_MAX_POOL_IDLE = 2;
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
+    private static final int DEFAULT_MAX_POOL_WAIT = 10000;
     private static final String DEFAULT_ATTR_NATIVE_TYPES = "false";
     private static final String POSTGRESQL_DRIVER_NAME = "org.postgresql.Driver";
     private static final SQLInstance POSTGRESQL_INSTANCE_NAME = SQLInstance.POSTGRESQL;
@@ -79,6 +80,7 @@ public class NGSIPostgreSQLSink extends NGSISink {
     private int maxPoolSize;
     private int maxPoolIdle;
     private int minPoolIdle;
+    private int maxPoolWait;
     private boolean rowAttrPersistence;
     private SQLBackendImpl postgreSQLPersistenceBackend;
     private boolean enableCache;
@@ -227,6 +229,10 @@ public class NGSIPostgreSQLSink extends NGSISink {
 
         minPoolIdle = context.getInteger("postgresql_minPoolIdle", DEFAULT_MIN_POOL_IDLE);
         LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_minPoolIdle=" + minPoolIdle + ")");
+
+        maxPoolWait = context.getInteger("postgresql_maxPoolWait", DEFAULT_MAX_POOL_WAIT);
+        LOGGER.debug("[" + this.getName() + "] Reading configuration (postgresql_maxPoolWait=" + maxPoolWait + ")");
+
         rowAttrPersistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE).equals("row");
         String persistence = context.getString("attr_persistence", DEFAULT_ROW_ATTR_PERSISTENCE);
 
@@ -324,12 +330,12 @@ public class NGSIPostgreSQLSink extends NGSISink {
     @Override
     public void start() {
         try {
-            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, postgresqlOptions, persistErrors, maxLatestErrors);
+            createPersistenceBackend(postgresqlHost, postgresqlPort, postgresqlUsername, postgresqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, postgresqlOptions, persistErrors, maxLatestErrors);
             LOGGER.debug("[" + this.getName() + "] Postgresql persistence backend created");
         } catch (Exception e) {
             String configParams = " postgresqlHost " + postgresqlHost + " postgresqlPort " + postgresqlPort +
                 "  postgresqlUsername " + postgresqlUsername + " postgresqlPassword " + postgresqlPassword +
-                " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " postgresqlOptions " +
+                " maxPoolSize " +  maxPoolSize + " maxPoolIdle " +  maxPoolIdle + " minPoolIdle " +  minPoolIdle + " maxPoolWait " + maxPoolWait + " postgresqlOptions " +
                 postgresqlOptions + " persistErrors " +  persistErrors + " maxLatestErrors " + maxLatestErrors;
             LOGGER.error("Error while creating the Postgresql persistence backend. " +
                          "Config params= " + configParams +
@@ -344,9 +350,9 @@ public class NGSIPostgreSQLSink extends NGSISink {
     /**
      * Initialices a lazy singleton to share among instances on JVM
      */
-    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
+    private void createPersistenceBackend(String sqlHost, String sqlPort, String sqlUsername, String sqlPassword, int maxPoolSize, int maxPoolIdle, int minPoolIdle, int maxPoolWait, String sqlOptions, boolean persistErrors, int maxLatestErrors) {
         if (postgreSQLPersistenceBackend == null) {
-            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
+            postgreSQLPersistenceBackend = new SQLBackendImpl(sqlHost, sqlPort, sqlUsername, sqlPassword, maxPoolSize, maxPoolIdle, minPoolIdle, maxPoolWait, POSTGRESQL_INSTANCE_NAME, POSTGRESQL_DRIVER_NAME, sqlOptions, persistErrors, maxLatestErrors);
         }
     }
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
@@ -235,8 +235,8 @@ If `attr_persistence=colum` then `NGSIMySQLSink` will persist the data within th
 | mysql\_username | no | root | `root` is the default username that is created automatically |
 | mysql\_password | no | N/A | Empty value as default (no password is created automatically) |
 | mysql\_maxPoolSize | no | 3 | Max number of connections per database pool |
-| mysql\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
-| mysql\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| mysql\_maxPoolIdle | no | 2 | Max number of idle connections per database pool |
+| mysql\_minPoolIdle | no | 0 | Min number of idle connections per database pool |
 | mysql\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | mysql\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `useSSL=true&requireSSL=false` is set to `mysql_options`, jdbc url will become like <b>jdbc:mysql://mysql.example.com:3306/fiwareservice?useSSL=true&requireSSL=false</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink.md
@@ -235,6 +235,9 @@ If `attr_persistence=colum` then `NGSIMySQLSink` will persist the data within th
 | mysql\_username | no | root | `root` is the default username that is created automatically |
 | mysql\_password | no | N/A | Empty value as default (no password is created automatically) |
 | mysql\_maxPoolSize | no | 3 | Max number of connections per database pool |
+| mysql\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
+| mysql\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| mysql\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | mysql\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `useSSL=true&requireSSL=false` is set to `mysql_options`, jdbc url will become like <b>jdbc:mysql://mysql.example.com:3306/fiwareservice?useSSL=true&requireSSL=false</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>
 | attr\_metadata\_store | no | false | <i>true</i> or <i>false</i>. |
@@ -264,6 +267,9 @@ A configuration example could be:
     cygnus-ngsi.sinks.mysql-sink.mysql_username = myuser
     cygnus-ngsi.sinks.mysql-sink.mysql_password = mypassword
     cygnus-ngsi.sinks.mysql-sink.mysql_maxPoolSize = 3
+    cygnus-ngsi.sinks.mysql-sink.mysql_maxPoolIdle = 2
+    cygnus-ngsi.sinks.mysql-sink.mysql_minPoolIdle = 0
+    cygnus-ngsi.sinks.mysql-sink.mysql_minPoolIdleTimeMillis = 10000
     cygnus-ngsi.sinks.mysql-sink.mysql_options = useSSL=true&requireSSL=false
     cygnus-ngsi.sinks.mysql-sink.attr_persistence = row
     cygnus-ngsi.sinks.mysql-sink.attr_native_types = false

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
@@ -236,6 +236,9 @@ If `attr_persistence=colum` then `NGSIOracleSQLSink` will persist the data withi
 | oracle\_password | no | oracle | `oracle` is the default for default username |
 | oracle\_database | no | xe | `xe` is the default database avaiable in oracle 11g XE (express edition) |
 | oracle\_maxPoolSize | no | 3 | Max number of connections per database pool |
+| oracle\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
+| oracle\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| oracle\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | oracle\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `useSSL=true&requireSSL=false` is set to `oracle_options`, jdbc url will become like <b>jdbc:oracle://oracle.example.com:3306/fiwareservice?useSSL=true&requireSSL=false</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>
 | attr\_metadata\_store | no | false | <i>true</i> or <i>false</i>. |
@@ -273,6 +276,9 @@ A configuration example could be:
     cygnus-ngsi.sinks.oracle-sink.nl_timestamp_format = YYYY-MM-DD HH24:MI:SS.FF6
     cygnus-ngsi.sinks.oracle-sink.nl_timestamp_tz_format = YYYY-MM-DD\"T\"HH24:MI:SS.FF6 TZR
     cygnus-ngsi.sinks.oracle-sink.oracle_maxPoolSize = 3
+    cygnus-ngsi.sinks.oracle-sink.oracle_maxPoolIdle = 2
+    cygnus-ngsi.sinks.oracle-sink.oracle_minPoolIdle = 0
+    cygnus-ngsi.sinks.oracle-sink.oracle_minPoolIdleTimeMillis = 10000
     cygnus-ngsi.sinks.oracle-sink.attr_persistence = column
     cygnus-ngsi.sinks.oracle-sink.attr_native_types = false
     cygnus-ngsi.sinks.oracle-sink.batch_size = 100

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_oracle_sink.md
@@ -236,8 +236,8 @@ If `attr_persistence=colum` then `NGSIOracleSQLSink` will persist the data withi
 | oracle\_password | no | oracle | `oracle` is the default for default username |
 | oracle\_database | no | xe | `xe` is the default database avaiable in oracle 11g XE (express edition) |
 | oracle\_maxPoolSize | no | 3 | Max number of connections per database pool |
-| oracle\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
-| oracle\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| oracle\_maxPoolIdle | no | 2 | Max number of idle connections per database pool |
+| oracle\_minPoolIdle | no | 0 | Min number of idle connections per database pool |
 | oracle\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | oracle\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `useSSL=true&requireSSL=false` is set to `oracle_options`, jdbc url will become like <b>jdbc:oracle://oracle.example.com:3306/fiwareservice?useSSL=true&requireSSL=false</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
@@ -268,6 +268,10 @@ Coming soon.
 | postgresql\_database | no | postgres | `postgres` is the default database that is created automatically when install. Note also than with datamodels <i>dm-by-entity-database</i>, <i>dm-by-entity-database-schema</i>, <i>dm-by-entity-type-database</i> and <i>dm-by-entity-type-database-schema</i> this setting is ignored (as the database is part of the mapping done by the datamodel) | |
 | postgresql\_username | no | postgres | `postgres` is the default username that is created automatically when install |
 | postgresql\_password | no | N/A | Empty value by default (No password is created when install) |
+| postgresql\_maxPoolSize | no | 3 | Max number of connections per database pool |
+| postgresql\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
+| postgresql\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| postgresql\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | postgresql\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `sslmode=require` is set to `postgresql_options`, jdbc url will become like <b>jdbc:postgresql://postgresql.example.com:5432/postgres?sslmode=require</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>. |
 | attr\_metadata\_store | no | false | <i>true</i> or <i>false</i>. |
@@ -295,6 +299,10 @@ A configuration example could be:
     cygnus-ngsi.sinks.postgresql-sink.postgresql_database = mydatabase
     cygnus-ngsi.sinks.postgresql-sink.postgresql_username = myuser
     cygnus-ngsi.sinks.postgresql-sink.postgresql_password = mypassword
+    cygnus-ngsi.sinks.postgresql-sink.postgresql_maxPoolSize = 3
+    cygnus-ngsi.sinks.postgresql-sink.postgresql_maxPoolIdle = 2
+    cygnus-ngsi.sinks.postgresql-sink.postgresql_minPoolIdle = 0
+    cygnus-ngsi.sinks.postgresql-sink.postgresql_minPoolIdleTimeMillis = 10000
     cygnus-ngsi.sinks.postgresql-sink.postgresql_options = sslmode=require
     cygnus-ngsi.sinks.postgresql-sink.attr_persistence = row
     cygnus-ngsi.sinks.postgresql-sink.attr_native_types = false

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_postgresql_sink.md
@@ -269,8 +269,8 @@ Coming soon.
 | postgresql\_username | no | postgres | `postgres` is the default username that is created automatically when install |
 | postgresql\_password | no | N/A | Empty value by default (No password is created when install) |
 | postgresql\_maxPoolSize | no | 3 | Max number of connections per database pool |
-| postgresql\_maxPoolIdle | no | 2 | Max number of connections idle per database pool |
-| postgresql\_minPoolIdle | no | 0 | Min number of connections idle per database pool |
+| postgresql\_maxPoolIdle | no | 2 | Max number of idle connections per database pool |
+| postgresql\_minPoolIdle | no | 0 | Min number of idle connections per database pool |
 | postgresql\_minPoolIdleTimeMillis | no | 10000 | minimum amount of time an idle connection before is eligible for eviction |
 | postgresql\_options | no | N/A | optional connection parameter(s) concatinated to jdbc url if necessary<br/>When `sslmode=require` is set to `postgresql_options`, jdbc url will become like <b>jdbc:postgresql://postgresql.example.com:5432/postgres?sslmode=require</b>|
 | attr\_persistence | no | row | <i>row</i> or <i>column</i>. |


### PR DESCRIPTION
Related https://github.com/telefonicaid/fiware-cygnus/issues/2366

doc about GenericObjectPool
https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPool.html

This PR allows change: 
- pool.maxSize
- pool.maxIdle
- pool.minIdle
- pool.minIdleTimeMillis

And fixes default initial values for:
- maxSize: 3
- maxIddle: 2
- minIddle: 0
- minIddleTimeMillis 10000

- [x] Upgrade doc with these new config entries