### PR TITLE
Task/set geometry null value when invalid format

### DIFF
--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
@@ -275,7 +275,10 @@ public class Feature {
     public JsonObject toJson() {
         JsonObject resultJSON = new JsonObject();
 
-        resultJSON.add(GEOMETRY_TAG, this.getGeometry().toJSON());
+        Geometry geo = this.getGeometry();
+        if (geo) {
+            resultJSON.add(GEOMETRY_TAG, geo.toJSON());
+        }
 
         JsonObject attributes = new JsonObject();
         for (Map.Entry<String, Object> attribute : this.attributes.entrySet()) {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
@@ -276,7 +276,7 @@ public class Feature {
         JsonObject resultJSON = new JsonObject();
 
         Geometry geo = this.getGeometry();
-        if (geo) {
+        if (geo != null) {
             resultJSON.add(GEOMETRY_TAG, geo.toJSON());
         }
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/model/Feature.java
@@ -312,7 +312,7 @@ public class Feature {
                 geometry = Point.createInstanceFromJson(jsonGeometry); // TODO another 
                                                                        //geometry types?
             } else {
-                geometry = new Point(0, 0);
+                geometry = null;
             }
             Map<String, Object> attributes = attToMap(json.get(ATTRIBUTES_TAG).getAsJsonObject());
             return new Feature(geometry, attributes);

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
@@ -596,6 +596,7 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
 
                     } else {
                         LOGGER.warn("Invalid geo:json type, only points allowed: " + location.toString());
+                        feature.setGeometry(null);
                     }
                 } catch (Exception e) {
                     LOGGER.error("Invalid geo:json format, (sikipped): " + attrValue.toString() + " - Error: "

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
@@ -717,7 +717,7 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
 
             LOGGER.debug("[ArcgisAggregatorDomain] - constructor init.");
             try {
-                feature = Feature.createPointFeature(0, 0);
+                feature = new Feature();
             } catch (Throwable e) {
                 LOGGER.error(
                         "ArcgisAggregatorDomain - Unexpected error " + e.getClass().getName() + " - " + e.getMessage());


### PR DESCRIPTION
Continuation of PR  https://github.com/telefonicaid/fiware-cygnus/pull/2380


related with log: 

time=2024-06-07T12:35:39.822Z | lvl=ERROR | corr=0c8ad6ce-3867-45b7-83ad-e01fcfc61686; cbnotif=1 | trans=fa366403-1782-4545-8273-d912c007dc6b | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=persistAggregation | msg=com.telefonica.iot.cygnus.sinks.NGSIArcgisFeatureTableSink[403] : [arcgis-sink-no-nm] Error persisting batch, NullPointerException - Cannot invoke "com.telefonica.iot.cygnus.backends.arcgis.model.Geometry.toJSON()" because the return value of "com.telefonica.iot.cygnus.backends.arcgis.model.Feature.getGeometry()" is null
time=2024-06-07T12:35:39.822Z | lvl=ERROR | corr=0c8ad6ce-3867-45b7-83ad-e01fcfc61686; cbnotif=1 | trans=fa366403-1782-4545-8273-d912c007dc6b | srv=N/A | subsrv=N/A | comp=cygnus-ngsi | op=persistBatch | msg=com.telefonica.iot.cygnus.sinks.NGSIArcgisFeatureTableSink[310] : [arcgis-sink-no-nm] Error persisting batch, CygnusRuntimeError.CygnusRuntimeError. Cannot invoke "com.telefonica.iot.cygnus.backends.arcgis.model.Geometry.toJSON()" because the return value of "com.telefonica.iot.cygnus.backends.arcgis.model.Feature.getGeometry()" is null.