### PR TITLE
Allow mongodb autodiscover at connect when just one server is provided

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 [cygnus-ngsi] [mongo-sink] Add mongo_ssl, mongo_ssl_invalid_host_allowed, mongo_ssl_keystore_path_file, mongo_ssl_keystore_password, mongo_ssl_truststore_path_file and mongo_ssl_truststore_password options for mongoDB connections
 [cygnus-common] [mongo-backend] Use sslEnabled, sslInvalidHostNameAllowed, sslKeystorePathFile, sslKeystorePassword, sslTruststorePathFile and sslTruststorePassword options for mongoDB connections
+[cygnus-common] [mongo-backend] Allow mongodb autodiscover at connect when just one server is provided

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/mongo/MongoBackendImpl.java
@@ -661,9 +661,17 @@ public class MongoBackendImpl implements MongoBackend {
                         .sslContext(sslContext)
                         .build();
                 }
-                client = new MongoClient(servers, credential, options);
+                if (servers.size() == 1) { // allow auto-discover when just one endpoint is provided
+                    client = new MongoClient(servers.get(0), credential, options);
+                } else {
+                    client = new MongoClient(servers, credential, options);
+                }
             } else {
-                client = new MongoClient(servers, options);
+                if (servers.size() == 1) { // allow auto-discover when just one endpoint is provided
+                    client = new MongoClient(servers.get(0), options);
+                } else {
+                    client = new MongoClient(servers, options);
+                }
             } // if else
         } // if
 


### PR DESCRIPTION
Otherwise that one server was handled as a close cluster list

MongoClient constructors: https://javadoc.io/static/org.mongodb/mongo-java-driver/3.12.14/com/mongodb/MongoClient.html#%3Cinit%3E(java.lang.String,com.mongodb.MongoClientOptions

https://mongodb.github.io/mongo-java-driver/3.6/javadoc/?com/mongodb/MongoClient.html




[MongoClient](https://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/MongoClient.html#MongoClient-com.mongodb.ServerAddress-)([ServerAddress](https://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/ServerAddress.html) addr)
Creates a Mongo instance based on a (single) mongodb node