### PR TITLE
Add another check to connection reset when no  java.net.SocketException has no cause

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - [cygnus-ngsi][arcgis] Log feature table error
 - [cygnus-ngsi][arcgis] fix log warn to debug level in arcgis feature when no object id is found (#2430)
+- [cygnus-ngsi][arcgis] Add another check to connection reset when no java.net.SocketException has no cause (#2405)
 - [cygnus-ngsi] Upgrade Debian version from 12.6 to 12.7 in Dockerfile

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
@@ -610,6 +610,8 @@ public class ArcgisFeatureTable {
                     connected = false;
                 }
                 LOGGER.error("Error Cause: " + e.getCause().getMessage());
+            } else if (e != null && e.getMessage().contains("Connection reset")) {
+                connected = false;
             }
             LOGGER.error("Error Message: " + e.getMessage());
 


### PR DESCRIPTION
related and continuation https://github.com/telefonicaid/fiware-cygnus/pull/2421:  Set feature table to not connected after a connection error

Maybe for java.net.SocketException without cause but are "connection reset"