### PR TITLE
Task/add timeout connection

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Add arcgis_connectionTimeout and arcgis_readTimeout sink options to allow set non infinite conection timeouts with arcgis (#2440)
+- [cygnus-ngsi][cygnus-comon] Add arcgis_connectionTimeout and arcgis_readTimeout sink options to allow set non infinite conection timeouts with arcgis (#2440)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Add arcgis_connectionTimeout and arcgis_readTimeout sink options to allow set non infinite conection timeouts with arcgis (#2440)

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/NGSIArcgisFeatureTable.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/NGSIArcgisFeatureTable.java
@@ -45,8 +45,8 @@ public class NGSIArcgisFeatureTable extends ArcgisFeatureTable {
      * @param timeoutSecs
      */
     public NGSIArcgisFeatureTable(String featureServiceUrl, String username, String password,
-            String getTokenUrl, long timeoutSecs) {
-        super(featureServiceUrl, username, password, getTokenUrl, false);
+                                  String getTokenUrl, long timeoutSecs, int connectionTimeout, int readTimeout) {
+        super(featureServiceUrl, username, password, getTokenUrl, false, connectionTimeout, readTimeout);
         this.timeoutSecs = timeoutSecs;
     }
 

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
@@ -56,6 +56,7 @@ public class ArcgisFeatureTable {
     private boolean connected;
 
     private int batchSize;
+
     private String errorDesc = "";
     private int errorCode = 0;
     private List<Feature> featureBatch = Collections.synchronizedList(new ArrayList<Feature>());
@@ -86,9 +87,8 @@ public class ArcgisFeatureTable {
      * @param readOnly
      */
     public ArcgisFeatureTable(String url, String user, String password, String tokenGenUrl,
-            boolean readOnly) {
+                              boolean readOnly, int connectionTimeout, int readTimeout) {
         this();
-        
         LOGGER.debug("Arcgis constructor.. " + url);
 
         LOGGER.debug("Arcgis url.. " + url);
@@ -97,7 +97,7 @@ public class ArcgisFeatureTable {
 
         Credential credential = new UserCredential(user, password);
         try {
-            arcGISFeatureTable = new RestFeatureTable(url, credential, tokenGenUrl);
+            arcGISFeatureTable = new RestFeatureTable(url, credential, tokenGenUrl, connectionTimeout, readTimeout);
             LOGGER.debug("Recovering attribute info from feature table. ->" + url);
             arcGISFeatureTable.getTableAttributesInfo();
             LOGGER.debug("Table successfully connected.");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/ArcgisFeatureTable.java
@@ -103,7 +103,7 @@ public class ArcgisFeatureTable {
             LOGGER.debug("Table successfully connected.");
             connected = true;
         } catch (ArcgisException e) {
-            LOGGER.error("Argis error while connecting to Feature Table: (" + e.getMessage() + ")"
+            LOGGER.error("Arcgis error while connecting to Feature Table: (" + e.getMessage() + ")"
                 + "\n\t URL: " + url
                 + "\n\t tokenGenURL: " + tokenGenUrl);
             connected = false;
@@ -570,7 +570,7 @@ public class ArcgisFeatureTable {
                                     + featureList.size());
                 }
             } else {
-                LOGGER.error("WARN - Argis.commitFeatures called with " + sizeList + " entities and hasError() " + hasError());
+                LOGGER.error("WARN - Arcgis.commitFeatures called with " + sizeList + " entities and hasError() " + hasError());
             }
 
         } else {

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/CredentialRestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/CredentialRestApi.java
@@ -37,17 +37,23 @@ public abstract class CredentialRestApi extends RestApi {
     protected Credential credential;
     protected String referer;
 
+    protected int connectionTimeout = 0;
+    protected int readTimeout = 0;
+
     /**
      * @param tokenGenUrl
      * @param credential
      * @param referer
      * @param expirationMins
      */
-    public CredentialRestApi(URL tokenGenUrl, Credential credential, String referer) {
+    public CredentialRestApi(URL tokenGenUrl, Credential credential, String referer,
+                             int connectionTimeout, int readTimeout) {
         super();
         this.tokenGenUrl = tokenGenUrl;
         this.credential = credential;
         this.referer = referer;
+        this.connectionTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
     }
 
     /**
@@ -57,12 +63,15 @@ public abstract class CredentialRestApi extends RestApi {
      * @param expirationMins
      * @throws ArcgisException
      */
-    public CredentialRestApi(String tokenGenUrl, Credential credential, String referer)
+    public CredentialRestApi(String tokenGenUrl, Credential credential, String referer,
+                             int connectionTimeout, int readTimeout)
             throws ArcgisException {
         super();
 
         this.credential = credential;
         this.referer = referer;
+        this.connectionTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
         try {
             if (tokenGenUrl != null && !"".equals(tokenGenUrl.trim())) {
                 this.tokenGenUrl = new URL(tokenGenUrl);
@@ -88,7 +97,7 @@ public abstract class CredentialRestApi extends RestApi {
                 + (credential != null ? credential.isExpired() : null));
         if (tokenGenUrl != null && (credential == null || credential.isExpired())) {
             LOGGER.debug("Creating/Refreshing token.");
-            credential = RestAuthentication.createToken(credential, tokenGenUrl, referer);
+            credential = RestAuthentication.createToken(credential, tokenGenUrl, referer, this.connectionTimeout, this.readTimeout);
         }
 
         return credential;

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestApi.java
@@ -162,7 +162,8 @@ public class RestApi  {
      * @throws Exception
      */
     public static HttpResponse requestHTTP(String urlToRead, Map<String, String> params,
-            HttpMethod httpMethod, String body) {
+                                           HttpMethod httpMethod, String body,
+                                           int connectionTimeout, int readTimeout) {
 
         HttpResponse httpResponse = new HttpResponse();
         StringBuilder result = new StringBuilder("");
@@ -209,7 +210,9 @@ public class RestApi  {
             URL url = new java.net.URL(strUrl);
             conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod(httpMethod.toString());
-
+            conn.setConnectTimeout(connectionTimeout);
+            conn.setReadTimeout(readTimeout);
+            
             // Si es necesario ponemos el body
             if (httpMethod != HttpMethod.GET) {
                 conn.setDoOutput(true);
@@ -283,8 +286,9 @@ public class RestApi  {
      * @param params
      * @return
      */
-    public static HttpResponse httpGet(String urlToRead, Map<String, String> params) {
-        return requestHTTP(urlToRead, params, HttpMethod.GET, "");
+    public static HttpResponse httpGet(String urlToRead, Map<String, String> params,
+                                       int connectionTimeout, int readTimeout) {
+        return requestHTTP(urlToRead, params, HttpMethod.GET, "", connectionTimeout, readTimeout);
     }
 
     /**
@@ -295,8 +299,9 @@ public class RestApi  {
      * @param body
      * @return
      */
-    public static HttpResponse httpPost(String urlToRead, Map<String, String> params, String body) {
-        return requestHTTP(urlToRead, params, HttpMethod.POST, body);
+    public static HttpResponse httpPost(String urlToRead, Map<String, String> params, String body,
+                                        int connectionTimeout, int readTimeout) {
+        return requestHTTP(urlToRead, params, HttpMethod.POST, body, connectionTimeout, readTimeout );
     }
 
     /**
@@ -309,9 +314,10 @@ public class RestApi  {
      * @throws UnsupportedEncodingException
      */
     public static HttpResponse httpPost(String urlToRead, Map<String, String> params,
-            Map<String, String> bodyParams) {
+                                        Map<String, String> bodyParams,
+                                        int connectionTimeout, int readTimeout) {
         bodyParams = checkParameters(bodyParams);
-        return requestHTTP(urlToRead, params, HttpMethod.POST, getPostParameters(bodyParams));
+        return requestHTTP(urlToRead, params, HttpMethod.POST, getPostParameters(bodyParams), connectionTimeout, readTimeout);
     }
 
     /**
@@ -322,8 +328,9 @@ public class RestApi  {
      * @param body
      * @return
      */
-    public static HttpResponse httpPost(String urlToRead, Map<String, String> bodyParams) {
-        return httpPost(urlToRead, null, bodyParams);
+    public static HttpResponse httpPost(String urlToRead, Map<String, String> bodyParams,
+                                        int connectionTimeout, int readTimeout) {
+        return httpPost(urlToRead, null, bodyParams, connectionTimeout, readTimeout);
     }
 
     /**

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestAuthentication.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestAuthentication.java
@@ -151,7 +151,8 @@ public class RestAuthentication extends RestApi {
      * @throws ArcGisException
      */
     public static Credential createUserToken(String user, String password, URL tokenGenUrl,
-            String referer, Integer expirationMins) throws ArcgisException {
+                                             String referer, Integer expirationMins,
+                                             int connectionTimeout, int readTimeout) throws ArcgisException {
         String tokenJSON = null;
         try {
             Map<String, String> bodyParams = new LinkedHashMap<String, String>();
@@ -163,7 +164,7 @@ public class RestAuthentication extends RestApi {
             }
             bodyParams.put(PARAM_REQUEST_FORMAT, REQUEST_FORMAT_PARAMETER);
 
-            HttpResponse response = httpPost(tokenGenUrl.toString(), bodyParams);
+            HttpResponse response = httpPost(tokenGenUrl.toString(), bodyParams, connectionTimeout, readTimeout);
 
             if (response.getResponseCode() == 200) {
                 tokenJSON = response.getBody();
@@ -194,8 +195,8 @@ public class RestAuthentication extends RestApi {
      * @throws ArcGisException
      */
     public static Credential createUserToken(String user, String password, URL tokenGenUrl,
-            String referer) throws ArcgisException {
-        return createUserToken(user, password, tokenGenUrl, referer, null);
+                                             String referer, int connectionTimeout, int readTimeout) throws ArcgisException {
+        return createUserToken(user, password, tokenGenUrl, referer, null, connectionTimeout, readTimeout);
     }
 
     /**
@@ -208,13 +209,13 @@ public class RestAuthentication extends RestApi {
      * @return
      * @throws ArcgisException
      */
-    public static Credential createToken(Credential credential, URL tokenGenUrl, String referer)
+    public static Credential createToken(Credential credential, URL tokenGenUrl, String referer, int connectionTimeout, int readTimeout)
             throws ArcgisException {
 
         if (credential instanceof UserCredential) {
             UserCredential userCredential = (UserCredential) credential;
             credential = createUserToken(userCredential.getUser(), userCredential.getPassword(),
-                    tokenGenUrl, referer);
+                                         tokenGenUrl, referer, connectionTimeout, readTimeout);
 
         } else {
             throw new ArcgisException("Invalid Credential type.");

--- a/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestFeatureTable.java
+++ b/cygnus-common/src/main/java/com/telefonica/iot/cygnus/backends/arcgis/restutils/RestFeatureTable.java
@@ -78,6 +78,9 @@ public class RestFeatureTable extends CredentialRestApi {
 
     protected URL serviceUrl;
 
+    protected int connectionTimeout = 0;
+    protected int readTimeout = 0;
+
     // Table info
     private String uniqueIdField = "";
     private Map<String, Field> tableAttributes = new HashMap<String, Field>();
@@ -90,9 +93,12 @@ public class RestFeatureTable extends CredentialRestApi {
      * @param referer
      * @param expirationMins
      */
-    private RestFeatureTable(URL serviceUrl, Credential credential) {
-        super((URL) null, credential, serviceUrl.toString());
+    private RestFeatureTable(URL serviceUrl, Credential credential,
+                             int connectionTimeout, int readTimeout) {
+        super((URL) null, credential, serviceUrl.toString(), connectionTimeout, readTimeout);
         this.serviceUrl = serviceUrl;
+        this.connectionTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
     }
 
 
@@ -103,10 +109,12 @@ public class RestFeatureTable extends CredentialRestApi {
      * @param credential
      * @throws MalformedURLException
      */
-    public RestFeatureTable(String url, Credential credential, String tokenGenUrl)
+    public RestFeatureTable(String url, Credential credential, String tokenGenUrl,
+                            int connectionTimeout, int readTimeout)
             throws ArcgisException {
-        super(tokenGenUrl, credential, url);
-
+        super(tokenGenUrl, credential, url, connectionTimeout, readTimeout);
+        this.connectionTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
         try {
             this.serviceUrl = new URL(url);
         } catch (MalformedURLException e) {
@@ -212,7 +220,7 @@ public class RestFeatureTable extends CredentialRestApi {
             fullUrl += QUERY_RELATIVE_PATH;
         }
 
-        HttpResponse response = httpGet(fullUrl, params);
+        HttpResponse response = httpGet(fullUrl, params, this.connectionTimeout, this.readTimeout);
         LOGGER.debug("Response code: " + response.getResponseCode() + "\n\t" + response.getBody());
 
         checkResponse(response);
@@ -265,7 +273,7 @@ public class RestFeatureTable extends CredentialRestApi {
             fullUrl += "/" + action;
         }
 
-        HttpResponse response = httpPost(fullUrl, params, bodyParams);
+        HttpResponse response = httpPost(fullUrl, params, bodyParams, this.connectionTimeout, this.readTimeout);
         LOGGER.debug("Response code: " + response.getResponseCode() + "\n\t" + response.getBody());
 
         checkResponse(response);
@@ -350,7 +358,7 @@ public class RestFeatureTable extends CredentialRestApi {
             fullUrl += DELETE_FEATURES_RELATIVE_PATH;
         }
 
-        HttpResponse response = httpPost(fullUrl, params, bodyParams);
+        HttpResponse response = httpPost(fullUrl, params, bodyParams, this.connectionTimeout, this.readTimeout);
         LOGGER.debug("Response code: " + response.getResponseCode() + "\n\t" + response.getBody());
 
         checkResponse(response);
@@ -397,7 +405,7 @@ public class RestFeatureTable extends CredentialRestApi {
             params.put(OUTPUT_FORMAT_PARAM, DEFAULT_OUTPUT_FORMAT);
 
             LOGGER.debug("HttpGet " + fullUrl.toString() + " number of params: " + params.size());
-            HttpResponse response = httpGet(fullUrl, params);
+            HttpResponse response = httpGet(fullUrl, params, this.connectionTimeout, this.readTimeout);
             LOGGER.debug("Response code: " + response.getResponseCode() + "\n\t" + response.getBody());
 
             checkResponse(response);

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/ArcgisFeatureTableTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/ArcgisFeatureTableTest.java
@@ -51,7 +51,7 @@ public class ArcgisFeatureTableTest implements ArcgisBaseTest {
 
     private ArcgisFeatureTable connectArcgis() {
         return new ArcgisFeatureTable(ArcgisBaseTest.getFeatureUrl(), ArcgisBaseTest.getUser(),
-                ArcgisBaseTest.getPassword(), ArcgisBaseTest.getGenerateTokenUrl(), false);
+                                      ArcgisBaseTest.getPassword(), ArcgisBaseTest.getGenerateTokenUrl(), false, 0, 0);
     }
 
     /**
@@ -154,7 +154,7 @@ public class ArcgisFeatureTableTest implements ArcgisBaseTest {
         if (!ArcgisBaseTest.connectionTestsSkipped()){
             ArcgisFeatureTable arcgis = new ArcgisFeatureTable(
                     "https://sags1/arcgis/rest/services/Urbanismo/MobiliarioUrbano_ETRS89/FeatureServer/5",
-                    "", "", "", false);
+                    "", "", "", false, 0, 0);
             List<Feature> resultList;
             try {
                 resultList = arcgis.queryFeatures(arcgis.getUniqueIdField() + ">0");
@@ -178,7 +178,7 @@ public class ArcgisFeatureTableTest implements ArcgisBaseTest {
         System.out.println("----------------  arcgisGetSecuredFeatures");
         if (!ArcgisBaseTest.connectionTestsSkipped()){
             ArcgisFeatureTable arcgis = new ArcgisFeatureTable(PORTAL_FEATURETABLE_URL, PORTAL_USER,
-                    PORTAL_PASSWORD, PORTAL_GENERATE_TOKEN_URL, false);
+                                                               PORTAL_PASSWORD, PORTAL_GENERATE_TOKEN_URL, false, 0, 0);
             List<Feature> resultList;
             try {
                 resultList = arcgis.queryFeatures(arcgis.getUniqueIdField() + ">0");

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/CredentialRestApiTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/CredentialRestApiTest.java
@@ -43,7 +43,7 @@ public class CredentialRestApiTest extends CredentialRestApi implements ArcgisBa
      * @throws ArcgisException
      */
     public CredentialRestApiTest() throws ArcgisException {
-        super(PORTAL_GENERATE_TOKEN_URL, null, PORTAL_FEATURETABLE_URL);
+        super(PORTAL_GENERATE_TOKEN_URL, null, PORTAL_FEATURETABLE_URL, 0, 0);
     }
 
     /**
@@ -55,7 +55,7 @@ public class CredentialRestApiTest extends CredentialRestApi implements ArcgisBa
         if (!ArcgisBaseTest.connectionTestsSkipped()){
             try {
                 Credential credential = RestAuthentication.createUserToken(PORTAL_USER, PORTAL_PASSWORD,
-                        new URL(PORTAL_GENERATE_TOKEN_URL), PORTAL_FEATURETABLE_URL, new Integer(1));
+                                                                           new URL(PORTAL_GENERATE_TOKEN_URL), PORTAL_FEATURETABLE_URL, new Integer(1), 0, 0);
                 System.out.println("ExpirationTime: " + credential.getExpirationTime());
                 this.setCredential(credential);
                 credential = getCredential();

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestApiTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestApiTest.java
@@ -57,7 +57,7 @@ public class RestApiTest extends RestApi{
         HashMap<String, String> params = new HashMap<String, String>();
 
         try {
-            HttpResponse response = RestApi.httpGet(urlRequest, params);
+            HttpResponse response = RestApi.httpGet(urlRequest, params, 0, 0);
             System.out.println(response.toString());
             Assert.assertTrue(response.getResponseCode() == 200);
         } catch (Exception e) {
@@ -79,7 +79,7 @@ public class RestApiTest extends RestApi{
         params.put("f", "pjson");
 
         try {
-            HttpResponse response = RestApi.httpGet(urlRequest, params);
+            HttpResponse response = RestApi.httpGet(urlRequest, params, 0, 0);
             System.out.println(response.toString());
             Assert.assertTrue(response.getResponseCode() == 200);
         } catch (Exception e) {

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestAuthenticationTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestAuthenticationTest.java
@@ -59,7 +59,7 @@ public class RestAuthenticationTest implements ArcgisBaseTest {
                 System.out.println("------- TEST getPortalTokenTest()");
                 credential = RestAuthentication.createUserToken(PORTAL_USER, PORTAL_PASSWORD,
                         new URL(PORTAL_GENERATE_TOKEN_URL),
-                        "https://sags1.int.ayto-santander.es/arcgis/rest/services/Policia");
+                                                                "https://sags1.int.ayto-santander.es/arcgis/rest/services/Policia", 0, 0);
                 System.out.println("Recovered credential: " + credential);
                 assertTrue(!"".equals(credential.getToken()));
             } catch (MalformedURLException e) {
@@ -88,7 +88,7 @@ public class RestAuthenticationTest implements ArcgisBaseTest {
                 System.out.println("------- TEST getOnlineTokenTest()");
     
                 credential = RestAuthentication.createUserToken(ONLINE_USER, ONLINE_PASSWORD,
-                        new URL(ONLINE_GENERATE_TOKEN_URL), "*");
+                                                                new URL(ONLINE_GENERATE_TOKEN_URL), "*", 0, 0);
                 System.out.println("Recovered Token: " + credential);
                 assertTrue(!"".equals(credential.getToken()));
             } catch (MalformedURLException e) {

--- a/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestFeatureTableTest.java
+++ b/cygnus-common/src/test/java/com/telefonica/iot/cygnus/backends/arcgis/RestFeatureTableTest.java
@@ -70,7 +70,7 @@ public class RestFeatureTableTest implements ArcgisBaseTest {
             try {
                 Credential credential = new UserCredential(ArcgisBaseTest.getUser(),
                         ArcgisBaseTest.getPassword());
-                RestFeatureTable featureTable = new RestFeatureTable(serviceUrl, credential, tokenUrl);
+                RestFeatureTable featureTable = new RestFeatureTable(serviceUrl, credential, tokenUrl, 0, 0);
     
                 System.out.println("Connecting....");
     
@@ -105,7 +105,7 @@ public class RestFeatureTableTest implements ArcgisBaseTest {
         System.out.println("----------------  createFeatureTable");
         Credential credential = new UserCredential(ArcgisBaseTest.getUser(),
                 ArcgisBaseTest.getPassword());
-        return new RestFeatureTable(serviceUrl, credential, tokenUrl);
+        return new RestFeatureTable(serviceUrl, credential, tokenUrl, 0, 0);
     }
 
     /**
@@ -243,7 +243,7 @@ public class RestFeatureTableTest implements ArcgisBaseTest {
                 String tokenUrl = ArcgisBaseTest.getGenerateTokenUrl();
                 Credential credential = new UserCredential(ArcgisBaseTest.getUser(),
                         ArcgisBaseTest.getPassword());
-                RestFeatureTable featureTable = new RestFeatureTable(serviceUrl, credential, tokenUrl);
+                RestFeatureTable featureTable = new RestFeatureTable(serviceUrl, credential, tokenUrl, 0, 0);
     
                 String whereClause = "OBJECTID>0";
     
@@ -304,7 +304,7 @@ public class RestFeatureTableTest implements ArcgisBaseTest {
                         ArcgisBaseTest.getPassword());
     
                 RestFeatureTable featureTable = new RestFeatureTable(serviceUrl, credential,
-                        ArcgisBaseTest.getGenerateTokenUrl());
+                                                                     ArcgisBaseTest.getGenerateTokenUrl(), 0, 0);
     
                 featureTable.getTableAttributesInfo();
                 System.out.println(

--- a/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
+++ b/cygnus-ngsi/src/main/java/com/telefonica/iot/cygnus/sinks/NGSIArcgisFeatureTableSink.java
@@ -76,6 +76,7 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
     private static final String DEFAULT_PASSWORD = "";
     private static final int DEFAULT_MAX_BATCH_SIZE = 10;
     private static final int DEFAULT_BATCH_TIMEOUT_SECS = 60;
+    private static final int DEFAULT_TIMEOUT = 0;
     private static final String ARCGIS_INSTANCE_NAME = "arcgis";
     
     private static final String GEO_JSON_COORDINATES_TAG = "coordinates";
@@ -89,6 +90,8 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
     private String password;
     private int maxBatchSize;
     private long timeoutSecs;
+    private int connectionTimeout;
+    private int readTimeout;
     private static volatile Map<String, NGSIArcgisFeatureTable> arcgisPersistenceBackend;
 
     /**
@@ -177,7 +180,8 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
             LOGGER.debug("Token url: " + getGetTokenUrl());
             try {
                 NGSIArcgisFeatureTable newTable = new NGSIArcgisFeatureTable(featureServiceUrl, getUsername(),
-                        getPassword(), getGetTokenUrl(), timeoutSecs);
+                                                                             getPassword(), getGetTokenUrl(), timeoutSecs,
+                                                                             connectionTimeout, readTimeout);
                 newTable.setBatchAction(ArcgisFeatureTable.ADD_UPDATE_ACTION);
                 newTable.setBatchSize(maxBatchSize);
 
@@ -243,6 +247,22 @@ public class NGSIArcgisFeatureTableSink extends NGSISink {
             LOGGER.debug("[" + this.getName() + "] Reading configuration (arcgis_timeoutSecs=" + maxBatchSize + ")");
         }
 
+        connectionTimeout = context.getInteger("arcgis_connectionTimeout", DEFAULT_TIMEOUT);
+        if (connectionTimeout < 0 || connectionTimeout > Integer.MAX_VALUE) {
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (arcgis_connectionTimeout=" + connectionTimeout + ") "
+                    + "must be an integer between 0 and Integer.MAX_VALUE");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (arcgis_connectionTimeout=" + connectionTimeout + ")");
+        }
+        readTimeout = context.getInteger("arcgis_readTimeout", DEFAULT_TIMEOUT);
+        if (readTimeout < 0 || readTimeout > Integer.MAX_VALUE) {
+            invalidConfiguration = true;
+            LOGGER.error("[" + this.getName() + "] Invalid configuration (arcgis_readTimeout=" + readTimeout + ") "
+                    + "must be an integer between 0 and Integer.MAX_VALUE");
+        } else {
+            LOGGER.debug("[" + this.getName() + "] Reading configuration (arcgis_connectionTimeout=" + connectionTimeout + ")");
+        }
         super.configure(context);
     } // configure
 

--- a/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_arcgis_featuretable_sink.md
+++ b/doc/cygnus-ngsi/flume_extensions_catalogue/ngsi_arcgis_featuretable_sink.md
@@ -177,6 +177,8 @@ The name mappings configuration would be:
 | arcgis\_gettoken\_url | yes | N/A |https://{url\_host}/sharing/generateToken|
 | arcgis\_maxBatchSize | no | 10 | Number of feature updates accumulated in feature table before persist it. |
 | arcgis_timeoutSec | no | 60 | feature table timeout |
+| arcgis\_connectionTimeout | no | 0 | Sets a specified timeout value, in milliseconds, to be used when opening a communications link to the arcgis. A timeout of zero is interpreted as an infinite timeout |
+| arcgis\_readTimeout | no | 0 | Sets the read timeout to a specified timeout, in milliseconds. A timeout of zero is interpreted as an infinite timeout |
 | batch\_timeout | no | 30 | Number of seconds the batch will be building before it is persisted as it is. |
 | batch\_ttl | no | 10 | Number of retries when a batch cannot be persisted. Use `0` for no retries, `-1` for infinite retries. Please, consider an infinite TTL (even a very large one) may consume all the sink's channel capacity very quickly. |
 | batch\_size | no | 1 | Number of events accumulated before persistence. |


### PR DESCRIPTION
https://github.com/telefonicaid/fiware-cygnus/issues/2440

This PR adds two new options to arcgis sink with the following means:


| Parameter | Mandatory | Default value | Comments |
|---|---|---|---|
| arcgis\_connectionTimeout | no | 0 | Sets a specified timeout value, in milliseconds, to be used when opening a communications link to the arcgis. A timeout of zero is interpreted as an infinite timeout |
| arcgis\_readTimeout | no | 0 | Sets the read timeout to a specified timeout, in milliseconds. A timeout of zero is interpreted as an infinite timeout |


An example of use In cygnus agent.conf would be (fix to 30 seconds):
```
cygnus-ngsi.sinks.arcgis-sink.arcgis_connectionTimeout = 30000
cygnus-ngsi.sinks.arcgis-sink.arcgis_readTimeout = 30000
```
